### PR TITLE
Disable benchmark tests by default and remove multi-lds support for fp64

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -27,7 +27,7 @@
 include( CMakeDependentOption )
 
 cmake_dependent_option( ROCWMMA_BUILD_VALIDATION_TESTS "Build validation tests" ON "ROCWMMA_BUILD_TESTS" OFF )
-cmake_dependent_option( ROCWMMA_BUILD_BENCHMARK_TESTS "Build benchmarking tests" ON "ROCWMMA_BUILD_TESTS" OFF )
+cmake_dependent_option( ROCWMMA_BUILD_BENCHMARK_TESTS "Build benchmarking tests" OFF "ROCWMMA_BUILD_TESTS" OFF )
 cmake_dependent_option( ROCWMMA_BUILD_EXTENDED_TESTS "Build extended test parameter coverage" OFF "ROCWMMA_BUILD_TESTS" OFF )
 
 # Test/benchmark requires additional dependencies

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_1x1.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_1x1.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NN
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNN;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_1x2.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_1x2.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NN
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNN;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_2x1.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_2x1.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NN
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNN;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_2x2.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_2x2.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NN
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNN;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_4x4.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_4x4.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NN
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNN;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_8x8.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nn_8x8.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NN
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNN;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_1x1.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_1x1.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NT
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNT;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_1x2.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_1x2.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NT
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNT;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_2x1.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_2x1.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NT
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNT;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_2x2.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_2x2.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NT
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNT;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_4x4.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_4x4.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NT
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNT;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_8x8.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_nt_8x8.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: NT
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsNT;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_1x1.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_1x1.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TN
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTN;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_1x2.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_1x2.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TN
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTN;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_2x1.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_2x1.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TN
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTN;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_2x2.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_2x2.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TN
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTN;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_4x4.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_4x4.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TN
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTN;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_8x8.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tn_8x8.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TN
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTN;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_1x1.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_1x1.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TT
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTT;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_1x2.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_1x2.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TT
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTT;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_2x1.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_2x1.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TT
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTT;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_2x2.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_2x2.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TT
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTT;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_4x4.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_4x4.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TT
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTT;

--- a/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_8x8.cpp
+++ b/test/gemm/test/mma_sync_multi_lds_test_16x16_tt_8x8.cpp
@@ -41,7 +41,7 @@ namespace rocwmma
         // Types: ALL + double
         // Block Sizes: 16 x 16 x BlockK
         // Layouts: TT
-        using Types = typename Base::TestTypes16x16;
+        using Types = typename Base::TestTypesIOC;
         using BlockSizes
             = std::tuple<std::tuple<I<16>, I<16>, I<16>>, std::tuple<I<16>, I<16>, I<32>>>;
         using Layouts     = typename Base::TestLayoutsTT;


### PR DESCRIPTION
Rmove multi lds mma sync support for fp64 due to build and run time issues on MI200

Disable benchmark test flag by default 
