### PR TITLE
Link rocWMMA to hiprtc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,7 @@ endif()
 message( VERBOSE "AMDGPU_TARGETS=${AMDGPU_TARGETS}")
 
 find_package( hip REQUIRED )
+find_package(hiprtc REQUIRED)
 find_package( OpenMP REQUIRED )
 
 find_path(ROCM_SMI_ROOT "include/rocm_smi/rocm_smi.h"
@@ -106,7 +107,7 @@ find_library(ROCM_SMI_LIBRARY rocm_smi64
     PATHS "${ROCM_SMI_ROOT}/lib")
 
 add_library(rocwmma INTERFACE)
-target_link_libraries(rocwmma INTERFACE hip::device hip::host OpenMP::OpenMP_CXX ${ROCM_SMI_LIBRARY})
+target_link_libraries(rocwmma INTERFACE hip::device hip::host hiprtc::hiprtc OpenMP::OpenMP_CXX ${ROCM_SMI_LIBRARY})
 
 rocm_install_targets(
   TARGETS rocwmma


### PR DESCRIPTION
Link rocWMMA to hiprtc

----

In Linux, hiprtc symbols are present even in hip library (libamdhip64.so) along with hiprtc library (libhiprtc.so). This was done to maintain backward compatibility with the existing apps using hiprtc APIs.

From ROCm6.0.1 hiprtc symbols will be removed from hip library libamdhip64.so. Earlier, the deprecation warning regarding this has been given in the past few releases to the users.