### PR TITLE
Change Clang C++ version to C++17 instead of C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,9 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+#Set Clang C++ Version
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fclang-abi-compat=17")
+
 # Top level configs
 if( CMAKE_PROJECT_NAME STREQUAL "rocwmma" )
   option( ROCWMMA_BUILD_TESTS "Build rocWMMA tests" ON )


### PR DESCRIPTION
Compiler implements mangling rules for C++20 concepts by default which are different compared to C++17.
Explicitly set the Cmake flag to use clang 17 version.