### PR TITLE
Standardize documentation for ReadtheDocs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,13 @@
 version: 2
 updates:
   - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/docs/.sphinx" # Location of package manifests
+    directory: "/docs/sphinx" # Location of package manifests
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"
+    labels:
+      - "documentation"
+      - "dependencies"
+      - "ci:docs-only"
+    reviewers:
+      - "samjwu"

--- a/.gitignore
+++ b/.gitignore
@@ -47,13 +47,3 @@ build*
 \#*\#
 *~
 *.log
-
-# documentation artifacts
-build/
-_build/
-_images/
-_static/
-_templates/
-_toc.yml
-docBin/
-_doxygen/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,13 +6,13 @@ version: 2
 sphinx:
    configuration: docs/conf.py
 
-formats: [htmlzip]
+formats: [htmlzip, pdf, epub]
 
 python:
    install:
-   - requirements: docs/.sphinx/requirements.txt
+   - requirements: docs/sphinx/requirements.txt
 
 build:
-   os: ubuntu-20.04
+   os: ubuntu-22.04
    tools:
       python: "3.8"

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To build our documentation locally, use the following commands.
 ```bash
 cd docs
 
-pip3 install -r .sphinx/requirements.txt
+pip3 install -r sphinx/requirements.txt
 
 python3 -m sphinx -T -E -b html -d _build/doctrees -D language=en . _build/html
 ```
@@ -769,7 +769,7 @@ The HIP runtime compilation (hipRTC) environment allows simultaneous compilation
 running of device code on AMD GPUs. The rocWMMA library is compatible with hipRTC, so you can
 leverage it for runtime-generated kernels. A simple GEMM sample is included to demonstrate
 compatibility. For more information, refer to the
-[HIP API reference](https://rocm.docs.amd.com/projects/HIP/en/latest/.doxygen/docBin/html/index.html).
+[HIP API reference](https://rocm.docs.amd.com/projects/HIP/en/latest/doxygen/html/index.html).
 
 ```important
 The `rocwmma::bfloat16_t` data type is not currently supported in hipRTC.

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,6 @@
+# documentation artifacts
+_build/
+_doxygen/
+sphinx/_toc.yml
+doxygen/html/
+doxygen/xml/

--- a/docs/.sphinx/requirements.in
+++ b/docs/.sphinx/requirements.in
@@ -1,1 +1,0 @@
-rocm-docs-core>=0.24.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,11 +4,31 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
+import re
+
 from rocm_docs import ROCmDocs
 
-docs_core = ROCmDocs("rocWMMA Documentation")
-docs_core.run_doxygen()
+with open('../CMakeLists.txt', encoding='utf-8') as f:
+    match = re.search(r'set \( VERSION_STRING\s+\"?([0-9.]+)[^0-9.]+', f.read())
+    if not match:
+        raise ValueError("VERSION not found!")
+    version_number = match[1]
+left_nav_title = f"rocWMMA {version_number} Documentation"
+
+# for PDF output on Read the Docs
+project = "rocWMMA Documentation"
+author = "Advanced Micro Devices, Inc."
+copyright = "Copyright (c) 2024 Advanced Micro Devices, Inc. All rights reserved."
+version = version_number
+release = version_number
+
+external_toc_path = "./sphinx/_toc.yml"
+
+docs_core = ROCmDocs(left_nav_title)
+docs_core.run_doxygen(doxygen_root="doxygen", doxygen_path="doxygen/xml")
 docs_core.setup()
+
+external_projects_current_project = "rocwmma"
 
 for sphinx_var in ROCmDocs.SPHINX_VARS:
     globals()[sphinx_var] = getattr(docs_core, sphinx_var)

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -58,7 +58,7 @@ PROJECT_LOGO           =
 # entered, it will be relative to the location where doxygen was started. If
 # left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = docBin
+OUTPUT_DIRECTORY       = .
 
 # If the CREATE_SUBDIRS tag is set to YES then doxygen will create 4096 sub-
 # directories (in 2 levels) under the output directory of each output format and
@@ -957,7 +957,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = ../README.md
+USE_MDFILE_AS_MAINPAGE =
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing

--- a/docs/license.rst
+++ b/docs/license.rst
@@ -1,0 +1,4 @@
+License
+=======
+
+.. include:: ../LICENSE.md

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -1,3 +1,7 @@
 # Anywhere {branch} is used, the branch name will be substituted.
 # These comments will also be removed.
 root: index
+subtrees:
+  - caption: About
+    entries:
+    - file: license

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,0 +1,1 @@
+rocm-docs-core==0.30.3

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -84,9 +84,7 @@ pygments==2.15.0
     #   pydata-sphinx-theme
     #   sphinx
 pyjwt[crypto]==2.6.0
-    # via
-    #   pygithub
-    #   pyjwt
+    # via pygithub
 pynacl==1.5.0
     # via pygithub
 pytz==2023.3.post1


### PR DESCRIPTION
Apply the following changes to project documentation for ReadtheDocs:

add version number to documentation left navigation bar and page title
add an "About" section with a license page
enable htmlzip, pdf, epub formats when publishing on Read the Docs
set pdf title, author, copyright, and version
rename .sphinx/.doxygen to sphinx/doxygen
update rocm-docs-core dependency
update dependabot config

related to https://github.com/RadeonOpenCompute/rocm-docs-core/issues/330