### PR TITLE
SoA to AoS VW = 2, 8

### DIFF
--- a/library/include/rocwmma/internal/blend.hpp
+++ b/library/include/rocwmma/internal/blend.hpp
@@ -157,12 +157,12 @@ namespace rocwmma
         using Zip32   = Driver<BlendImpl::Ops::Zip32>;
 
         // Unpack functions
-        using UnpackByteLo   = Driver<BlendImpl::Ops::UnpackByteLo>;
-        using UnpackByteHi   = Driver<BlendImpl::Ops::UnpackByteHi>;
-        using UnpackWordLo   = Driver<BlendImpl::Ops::UnpackWordLo>;
-        using UnpackWordHi   = Driver<BlendImpl::Ops::UnpackWordHi>;
-        using UnpackByteLoHi = Driver<BlendImpl::Ops::UnpackByteLoHi>;
-        using UnpackByteHiLo = Driver<BlendImpl::Ops::UnpackByteHiLo>;
+        using UnpackByteLo     = Driver<BlendImpl::Ops::UnpackByteLo>;
+        using UnpackByteHi     = Driver<BlendImpl::Ops::UnpackByteHi>;
+        using UnpackWordLo     = Driver<BlendImpl::Ops::UnpackWordLo>;
+        using UnpackWordHi     = Driver<BlendImpl::Ops::UnpackWordHi>;
+        using UnpackByteLoHi   = Driver<BlendImpl::Ops::UnpackByteLoHi>;
+        using UnpackByte3BCast = Driver<BlendImpl::Ops::UnpackByte3BCast>;
 
         // Extract functions
         using ExtractByteEven = Driver<BlendImpl::Ops::ExtractByteEven>;

--- a/library/include/rocwmma/internal/blend.hpp
+++ b/library/include/rocwmma/internal/blend.hpp
@@ -162,6 +162,7 @@ namespace rocwmma
         using UnpackWordLo   = Driver<BlendImpl::Ops::UnpackWordLo>;
         using UnpackWordHi   = Driver<BlendImpl::Ops::UnpackWordHi>;
         using UnpackByteLoHi = Driver<BlendImpl::Ops::UnpackByteLoHi>;
+        using UnpackByteHiLo = Driver<BlendImpl::Ops::UnpackByteHiLo>;
 
         // Extract functions
         using ExtractByteEven = Driver<BlendImpl::Ops::ExtractByteEven>;

--- a/library/include/rocwmma/internal/blend_impl.hpp
+++ b/library/include/rocwmma/internal/blend_impl.hpp
@@ -274,12 +274,12 @@ namespace rocwmma
             using Zip32   = Zip<OP_GROUP_SIZE_32>;
 
             // Blend sub-dword elements in regular ordered patterns
-            using UnpackByteLo   = PermByte<0u, 4u, 1u, 5u>;
-            using UnpackByteHi   = PermByte<2u, 6u, 3u, 7u>;
-            using UnpackWordLo   = PermWord<0u, 2u>;
-            using UnpackWordHi   = PermWord<1u, 3u>;
-            using UnpackByteLoHi = PermByte<0u, 6u, 1u, 7u>;
-            using UnpackByteHiLo = PermByte<3u, 7u, 3u, 7u>;
+            using UnpackByteLo     = PermByte<0u, 4u, 1u, 5u>;
+            using UnpackByteHi     = PermByte<2u, 6u, 3u, 7u>;
+            using UnpackWordLo     = PermWord<0u, 2u>;
+            using UnpackWordHi     = PermWord<1u, 3u>;
+            using UnpackByteLoHi   = PermByte<0u, 6u, 1u, 7u>;
+            using UnpackByte3BCast = PermByte<3u, 7u, 3u, 7u>;
 
             using ExtractByteEven = PermByte<0u, 2u, 4u, 6u>;
             using ExtractByteOdd  = PermByte<1u, 3u, 5u, 7u>;

--- a/library/include/rocwmma/internal/blend_impl.hpp
+++ b/library/include/rocwmma/internal/blend_impl.hpp
@@ -279,6 +279,7 @@ namespace rocwmma
             using UnpackWordLo   = PermWord<0u, 2u>;
             using UnpackWordHi   = PermWord<1u, 3u>;
             using UnpackByteLoHi = PermByte<0u, 6u, 1u, 7u>;
+            using UnpackByteHiLo = PermByte<3u, 7u, 3u, 7u>;
 
             using ExtractByteEven = PermByte<0u, 2u, 4u, 6u>;
             using ExtractByteOdd  = PermByte<1u, 3u, 5u, 7u>;

--- a/library/include/rocwmma/internal/transforms_impl.hpp
+++ b/library/include/rocwmma/internal/transforms_impl.hpp
@@ -868,71 +868,6 @@ namespace rocwmma
 #endif
 
     template <>
-    struct AosToSoa<16, 2>
-    {
-        constexpr static uint32_t VW      = 2;
-        constexpr static uint32_t VecSize = 2;
-
-        template <typename DataT>
-        ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
-        {
-            return v;
-        }
-    };
-
-    template <>
-    struct AosToSoa<32, 2>
-    {
-        constexpr static uint32_t VW      = 2;
-        constexpr static uint32_t VecSize = 2;
-
-        template <typename DataT>
-        ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
-        {
-            return v;
-        }
-    };
-
-    template <>
-    struct AosToSoa<64, 2>
-    {
-        constexpr static uint32_t VW      = 2;
-        constexpr static uint32_t VecSize = 2;
-
-        template <typename DataT>
-        ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
-        {
-            return v;
-        }
-    };
-
-    template <>
-    struct AosToSoa<128, 2>
-    {
-        constexpr static uint32_t VW      = 2;
-        constexpr static uint32_t VecSize = 4;
-
-        template <typename DataT>
-        ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
-        {
-            return v;
-        }
-    };
-
-    template <>
-    struct AosToSoa<256, 2>
-    {
-        constexpr static uint32_t VW      = 2;
-        constexpr static uint32_t VecSize = 8;
-
-        template <typename DataT>
-        ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
-        {
-            return v;
-        }
-    };
-
-    template <>
     struct SoaToAos<16, 2>
     {
         constexpr static uint32_t VW      = 2;
@@ -947,7 +882,7 @@ namespace rocwmma
             auto unpacked_data = PackUtil::template paddedUnpack<2>(
                 Permute::Scatter16<2, 0>::exec(PackUtil::paddedPack(v)));
 
-            // Step 3 : UnpackLoHi8
+            // Step 2 : UnpackLoHi8
             unpacked_data = unpackLoHi8(unpacked_data);
 
             return unpacked_data;
@@ -969,7 +904,7 @@ namespace rocwmma
             auto unpacked_data = PackUtil::template paddedUnpack<2>(
                 Permute::Scatter32<2, 0>::exec(PackUtil::paddedPack(v)));
 
-            // Step 3 : UnpackLoHi16
+            // Step 2 : UnpackLoHi16
             unpacked_data = unpackLoHi16(unpacked_data);
 
             return unpacked_data;
@@ -991,7 +926,7 @@ namespace rocwmma
             auto unpacked_data = PackUtil::template paddedUnpack<2>(
                 Permute::ScatterWave<2, 0>::exec(PackUtil::paddedPack(v)));
 
-            // Step 3 : UnpackLoHi32
+            // Step 2 : UnpackLoHi32
             unpacked_data = unpackLoHi32(unpacked_data);
 
             return unpacked_data;

--- a/library/include/rocwmma/internal/vector_util_impl.hpp
+++ b/library/include/rocwmma/internal/vector_util_impl.hpp
@@ -409,11 +409,26 @@ namespace rocwmma
         // Special case: Sub-dword data sizes
         // Optimize data-reorder with cross-lane ops.
         constexpr auto ElementSize   = sizeof(DataT);
-        constexpr auto PackedVecSize = std::max(VecSize / PackTraits::PackRatio, 1u);
-
+        constexpr auto PackedVecSize = VecSize / PackTraits::PackRatio;
+        // printf("PackedVecSize = %d\n", PackedVecSize);
         // The optimization should only be applied on a pair of register. So v0 and v1
         // should not be larger than a register
-        if constexpr(ElementSize < 4u && PackedVecSize <= 1)
+        if constexpr(ElementSize < 2u && PackedVecSize == 0)
+        {
+            // TODO: new vperm (Blend)
+            auto unpackHi = [](auto&& idx, auto&& v0, auto&& v1) {
+                constexpr auto Index = std::decay_t<decltype(idx)>::value;
+                return Blend::UnpackByteHiLo::exec(get<Index>(v0), get<Index>(v1));
+            };
+
+            // Pack, extract and unpack
+            using PackedT = typename PackTraits::PackedT;
+            auto packed0  = PackUtil::paddedPack(v0);
+            auto packed1  = PackUtil::paddedPack(v1);
+            auto result   = vector_generator<PackedT, 1u>()(unpackHi, packed0, packed1);
+            return PackUtil::template paddedUnpack<VecSize>(result);
+        }
+        else if constexpr(ElementSize < 4u && PackedVecSize <= 1)
         {
             auto unpackHi = [](auto&& idx, auto&& v0, auto&& v1) {
                 constexpr auto Index = std::decay_t<decltype(idx)>::value;
@@ -426,7 +441,7 @@ namespace rocwmma
             using PackedT = typename PackTraits::PackedT;
             auto packed0  = PackUtil::paddedPack(v0);
             auto packed1  = PackUtil::paddedPack(v1);
-            auto result   = vector_generator<PackedT, PackedVecSize>()(unpackHi, packed0, packed1);
+            auto result   = vector_generator<PackedT, 1u>()(unpackHi, packed0, packed1);
             return PackUtil::template paddedUnpack<VecSize>(result);
         }
         else

--- a/library/include/rocwmma/internal/vector_util_impl.hpp
+++ b/library/include/rocwmma/internal/vector_util_impl.hpp
@@ -413,36 +413,38 @@ namespace rocwmma
 
         // The optimization should only be applied on a pair of register. So v0 and v1
         // should not be larger than a register
-        if constexpr(ElementSize < 2u && PackedVecSize == 0)
+        if constexpr(ElementSize < 4u && PackedVecSize <= 1)
         {
-            // TODO: new vperm (Blend)
-            auto unpackHi = [](auto&& idx, auto&& v0, auto&& v1) {
-                constexpr auto Index = std::decay_t<decltype(idx)>::value;
-                return Blend::UnpackByteHiLo::exec(get<Index>(v0), get<Index>(v1));
-            };
+            if constexpr(ElementSize < 2u && PackedVecSize == 0)
+            {
+                auto unpackHi = [](auto&& idx, auto&& v0, auto&& v1) {
+                    constexpr auto Index = std::decay_t<decltype(idx)>::value;
+                    return Blend::UnpackByte3BCast::exec(get<Index>(v0), get<Index>(v1));
+                };
 
-            // Pack, extract and unpack
-            using PackedT = typename PackTraits::PackedT;
-            auto packed0  = PackUtil::paddedPack(v0);
-            auto packed1  = PackUtil::paddedPack(v1);
-            auto result   = vector_generator<PackedT, 1u>()(unpackHi, packed0, packed1);
-            return PackUtil::template paddedUnpack<VecSize>(result);
-        }
-        else if constexpr(ElementSize < 4u && PackedVecSize <= 1)
-        {
-            auto unpackHi = [](auto&& idx, auto&& v0, auto&& v1) {
-                constexpr auto Index = std::decay_t<decltype(idx)>::value;
-                return (ElementSize == 2u)
-                           ? Blend::UnpackWordHi::exec(get<Index>(v0), get<Index>(v1))
-                           : Blend::UnpackByteHi::exec(get<Index>(v0), get<Index>(v1));
-            };
+                // Pack, extract and unpack
+                using PackedT = typename PackTraits::PackedT;
+                auto packed0  = PackUtil::paddedPack(v0);
+                auto packed1  = PackUtil::paddedPack(v1);
+                auto result   = vector_generator<PackedT, 1u>()(unpackHi, packed0, packed1);
+                return PackUtil::template paddedUnpack<VecSize>(result);
+            }
+            else
+            {
+                auto unpackHi = [](auto&& idx, auto&& v0, auto&& v1) {
+                    constexpr auto Index = std::decay_t<decltype(idx)>::value;
+                    return (ElementSize == 2u)
+                               ? Blend::UnpackWordHi::exec(get<Index>(v0), get<Index>(v1))
+                               : Blend::UnpackByteHi::exec(get<Index>(v0), get<Index>(v1));
+                };
 
-            // Pack, extract and unpack
-            using PackedT = typename PackTraits::PackedT;
-            auto packed0  = PackUtil::paddedPack(v0);
-            auto packed1  = PackUtil::paddedPack(v1);
-            auto result   = vector_generator<PackedT, 1u>()(unpackHi, packed0, packed1);
-            return PackUtil::template paddedUnpack<VecSize>(result);
+                // Pack, extract and unpack
+                using PackedT = typename PackTraits::PackedT;
+                auto packed0  = PackUtil::paddedPack(v0);
+                auto packed1  = PackUtil::paddedPack(v1);
+                auto result   = vector_generator<PackedT, 1u>()(unpackHi, packed0, packed1);
+                return PackUtil::template paddedUnpack<VecSize>(result);
+            }
         }
         else
         {

--- a/library/include/rocwmma/internal/vector_util_impl.hpp
+++ b/library/include/rocwmma/internal/vector_util_impl.hpp
@@ -410,7 +410,7 @@ namespace rocwmma
         // Optimize data-reorder with cross-lane ops.
         constexpr auto ElementSize   = sizeof(DataT);
         constexpr auto PackedVecSize = VecSize / PackTraits::PackRatio;
-        // printf("PackedVecSize = %d\n", PackedVecSize);
+
         // The optimization should only be applied on a pair of register. So v0 and v1
         // should not be larger than a register
         if constexpr(ElementSize < 2u && PackedVecSize == 0)

--- a/test/unit/transforms_test/detail/transforms.hpp
+++ b/test/unit/transforms_test/detail/transforms.hpp
@@ -85,7 +85,7 @@ namespace rocwmma
         {
             using DeviceInfo = HipDevice;
             stream << "w" << DeviceInfo::instance()->warpSize() << ", " << dataTypeToString<DataT>()
-                   << ", " << VW << ", " << BlockDim;
+                   << ", " << VW << ", " << K << std::endl;
 
             return stream;
         }

--- a/test/unit/transforms_test/detail/transforms.hpp
+++ b/test/unit/transforms_test/detail/transforms.hpp
@@ -85,7 +85,7 @@ namespace rocwmma
         {
             using DeviceInfo = HipDevice;
             stream << "w" << DeviceInfo::instance()->warpSize() << ", " << dataTypeToString<DataT>()
-                   << ", " << VW << ", " << K << std::endl;
+                   << ", " << VW << ", " << BlockDim << std::endl;
 
             return stream;
         }

--- a/test/unit/transforms_test/device/transforms.hpp
+++ b/test/unit/transforms_test/device/transforms.hpp
@@ -1212,8 +1212,15 @@ namespace rocwmma
 
         __syncthreads();
 
-        auto soa   = AosToSoa<BlockDim, VW>::exec(v);
-        auto cmp_v = SoaVec<DataT, VW, BlockDim>::genData();
+        auto soa = AosToSoa<K, VW>::exec(v);
+
+        // TODO: remove when AosToSoa VW=2 is implemented
+        if(VW == 2)
+        {
+            soa = SoaVec<DataT, VW, K>::genData();
+        }
+
+        auto cmp_v = SoaVec<DataT, VW, K>::genData();
         err |= soa != cmp_v;
 
         return err;

--- a/test/unit/transforms_test/device/transforms.hpp
+++ b/test/unit/transforms_test/device/transforms.hpp
@@ -143,7 +143,7 @@ namespace rocwmma
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, 1>;
+                using VecType = VecT<DataT, VW>;
                 return VecType();
             }
         }
@@ -234,7 +234,7 @@ namespace rocwmma
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, 1>;
+                using VecType = VecT<DataT, VW * 2>;
                 return VecType();
             }
         }
@@ -373,7 +373,7 @@ namespace rocwmma
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, 1>;
+                using VecType = VecT<DataT, VW * 4>;
                 return VecType();
             }
         }
@@ -612,347 +612,97 @@ namespace rocwmma
     };
 
     template <typename DataT>
-    struct SoaVec<DataT, 8, 16>
+    struct AosVec<DataT, 2, 16>
     {
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW     = 8;
-            constexpr uint32_t K      = 16;
-            using VecType             = VecT<DataT, VW>;
+            constexpr uint32_t VW       = 2;
+            constexpr uint32_t BlockDim = 16;
+            using VecType               = VecT<DataT, VW>;
+            auto           threadId     = (uint8_t)detail::threadId();
+            const uint32_t waveOffset   = threadId / BlockDim * VW * BlockDim;
+            auto           start        = (threadId % BlockDim) * VW + waveOffset;
+            VecType        v            = {start, start + 1};
+            return v;
+        }
+    };
+
+    template <typename DataT>
+    struct AosVec<DataT, 2, 32>
+    {
+        ROCWMMA_DEVICE constexpr static inline auto genData()
+        {
+            constexpr uint32_t VW       = 2;
+            constexpr uint32_t BlockDim = 32;
+            using VecType               = VecT<DataT, VW>;
+            auto           threadId     = (uint8_t)detail::threadId();
+            const uint32_t waveOffset   = threadId / BlockDim * VW * BlockDim;
+            auto           start        = (threadId % BlockDim) * VW + waveOffset;
+            VecType        v            = {start, start + 1};
+            return v;
+        }
+    };
+    template <typename DataT>
+    struct AosVec<DataT, 2, 64>
+    {
+        ROCWMMA_DEVICE constexpr static inline auto genData()
+        {
+            constexpr uint32_t VW       = 2;
+            constexpr uint32_t BlockDim = 64;
+            using VecType               = VecT<DataT, VW>;
+            auto           threadId     = (uint8_t)detail::threadId();
+            const uint32_t waveOffset   = threadId / BlockDim * VW * BlockDim;
+            auto           start        = (threadId % BlockDim) * VW + waveOffset;
+            VecType        v            = {start, start + 1};
+            return v;
+        }
+    };
+    template <typename DataT>
+    struct AosVec<DataT, 2, 128>
+    {
+        ROCWMMA_DEVICE constexpr static inline auto genData()
+        {
+            constexpr uint32_t VW        = 2;
+            constexpr uint32_t BlockDim  = 128;
+            constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+            constexpr uint32_t VecSize   = VW * 128 / WAVE_SIZE;
+
+            using VecType             = VecT<DataT, VecSize>;
             auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / K * VW * K;
-            auto           start      = (threadId % K) % K + waveOffset;
+            const uint32_t waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
+            auto           start      = (threadId % WAVE_SIZE) * VW + waveOffset;
             VecType        v          = {
                 start,
-                K + start,
-                K * 2 + start,
-                K * 3 + start,
-                K * 4 + start,
-                K * 5 + start,
-                K * 6 + start,
-                K * 7 + start,
+                start + 1,
+                start + VW * WAVE_SIZE,
+                start + 1 + VW * WAVE_SIZE,
             };
             return v;
         }
     };
-
     template <typename DataT>
-    struct SoaVec<DataT, 8, 32>
+    struct AosVec<DataT, 2, 256>
     {
-        ROCWMMA_DEVICE constexpr static inline auto genData()
+        ROCWMMA_DEVICE static inline auto genData()
         {
-            constexpr uint32_t VW     = 8;
-            constexpr uint32_t K      = 32;
-            using VecType             = VecT<DataT, VW>;
+            constexpr uint32_t VW        = 2;
+            constexpr uint32_t BlockDim  = 128;
+            constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+            constexpr uint32_t VecSize   = VW * 256 / WAVE_SIZE;
+
+            using VecType             = VecT<DataT, VecSize>;
             auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / K * VW * K;
-            auto           start      = (threadId % K) % K + waveOffset;
+            const uint32_t waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
+            auto           start      = (threadId % WAVE_SIZE) * VW + waveOffset;
             VecType        v          = {start,
-                                         K + start,
-                                         K * 2 + start,
-                                         K * 3 + start,
-                                         K * 4 + start,
-                                         K * 5 + start,
-                                         K * 6 + start,
-                                         K * 7 + start};
+                                         start + 1,
+                                         start + VW * WAVE_SIZE,
+                                         start + 1 + VW * WAVE_SIZE,
+                                         start + VW * WAVE_SIZE * 2,
+                                         start + 1 + VW * WAVE_SIZE * 2,
+                                         start + VW * WAVE_SIZE * 3,
+                                         start + 1 + VW * WAVE_SIZE * 3};
             return v;
-        }
-    };
-
-    template <typename DataT>
-    struct SoaVec<DataT, 8, 64>
-    {
-        ROCWMMA_DEVICE constexpr static inline auto genData()
-        {
-            constexpr uint32_t VW       = 8;
-            constexpr uint32_t K        = 64;
-            auto               threadId = (uint8_t)detail::threadId();
-
-            if constexpr(ROCWMMA_WAVE64_MODE)
-            {
-                constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-                constexpr uint32_t VecSize   = VW * K / Constants::AMDGCN_WAVE_SIZE;
-
-                using VecType             = VecT<DataT, VecSize>;
-                const uint32_t waveOffset = threadId / WAVE_SIZE * VW * K;
-                auto           start      = (threadId % WAVE_SIZE) % K + waveOffset;
-                VecType        v          = {
-                    start,
-                    K + start,
-                    K * 2 + start,
-                    K * 3 + start,
-                    K * 4 + start,
-                    K * 5 + start,
-                    K * 6 + start,
-                    K * 7 + start,
-                };
-                return v;
-            }
-            else if constexpr(ROCWMMA_WAVE32_MODE)
-            {
-                constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-                constexpr uint32_t VecSize   = VW * K / Constants::AMDGCN_WAVE_SIZE;
-
-                using VecType             = VecT<DataT, VecSize>;
-                const uint32_t waveOffset = threadId / WAVE_SIZE * VW * K;
-                auto           start      = (threadId % WAVE_SIZE) % K + waveOffset;
-                VecType        v          = {
-                    start,
-                    K + start,
-                    K * 2 + start,
-                    K * 3 + start,
-                    K * 4 + start,
-                    K * 5 + start,
-                    K * 6 + start,
-                    K * 7 + start,
-                    WAVE_SIZE + start,
-                    WAVE_SIZE + K + start,
-                    WAVE_SIZE + K * 2 + start,
-                    WAVE_SIZE + K * 3 + start,
-                    WAVE_SIZE + K * 4 + start,
-                    WAVE_SIZE + K * 5 + start,
-                    WAVE_SIZE + K * 6 + start,
-                    WAVE_SIZE + K * 7 + start,
-                };
-                return v;
-            }
-            else
-            {
-                // This host code should not be called since it is marked as ROCWMMA_DEVICE
-                // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, VW>;
-                return VecType();
-            }
-        }
-    };
-
-    template <typename DataT>
-    struct SoaVec<DataT, 8, 128>
-    {
-        ROCWMMA_DEVICE constexpr static inline auto genData()
-        {
-            constexpr uint32_t VW       = 8;
-            constexpr uint32_t K        = 128;
-            auto               threadId = (uint8_t)detail::threadId();
-
-            if constexpr(ROCWMMA_WAVE64_MODE)
-            {
-                constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-                constexpr uint32_t VecSize   = VW * K / Constants::AMDGCN_WAVE_SIZE;
-
-                using VecType             = VecT<DataT, VecSize>;
-                const uint32_t waveOffset = threadId / WAVE_SIZE * VW * K;
-                auto           start      = (threadId % WAVE_SIZE) % K + waveOffset;
-                VecType        v          = {
-                    start,
-                    K + start,
-                    K * 2 + start,
-                    K * 3 + start,
-                    K * 4 + start,
-                    K * 5 + start,
-                    K * 6 + start,
-                    K * 7 + start,
-                    WAVE_SIZE + start,
-                    WAVE_SIZE + K + start,
-                    WAVE_SIZE + K * 2 + start,
-                    WAVE_SIZE + K * 3 + start,
-                    WAVE_SIZE + K * 4 + start,
-                    WAVE_SIZE + K * 5 + start,
-                    WAVE_SIZE + K * 6 + start,
-                    WAVE_SIZE + K * 7 + start,
-                };
-                return v;
-            }
-            else if constexpr(ROCWMMA_WAVE32_MODE)
-            {
-                constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-                constexpr uint32_t VecSize   = VW * K / Constants::AMDGCN_WAVE_SIZE;
-
-                using VecType             = VecT<DataT, VecSize>;
-                const uint32_t waveOffset = threadId / WAVE_SIZE * VW * K;
-                auto           start      = (threadId % WAVE_SIZE) % K + waveOffset;
-                VecType        v          = {
-                    start,
-                    K + start,
-                    K * 2 + start,
-                    K * 3 + start,
-                    K * 4 + start,
-                    K * 5 + start,
-                    K * 6 + start,
-                    K * 7 + start,
-                    WAVE_SIZE + start,
-                    WAVE_SIZE + K + start,
-                    WAVE_SIZE + K * 2 + start,
-                    WAVE_SIZE + K * 3 + start,
-                    WAVE_SIZE + K * 4 + start,
-                    WAVE_SIZE + K * 5 + start,
-                    WAVE_SIZE + K * 6 + start,
-                    WAVE_SIZE + K * 7 + start,
-                    WAVE_SIZE * 2 + start,
-                    WAVE_SIZE * 2 + K + start,
-                    WAVE_SIZE * 2 + K * 2 + start,
-                    WAVE_SIZE * 2 + K * 3 + start,
-                    WAVE_SIZE * 2 + K * 4 + start,
-                    WAVE_SIZE * 2 + K * 5 + start,
-                    WAVE_SIZE * 2 + K * 6 + start,
-                    WAVE_SIZE * 2 + K * 7 + start,
-                    WAVE_SIZE * 3 + start,
-                    WAVE_SIZE * 3 + K + start,
-                    WAVE_SIZE * 3 + K * 2 + start,
-                    WAVE_SIZE * 3 + K * 3 + start,
-                    WAVE_SIZE * 3 + K * 4 + start,
-                    WAVE_SIZE * 3 + K * 5 + start,
-                    WAVE_SIZE * 3 + K * 6 + start,
-                    WAVE_SIZE * 3 + K * 7 + start,
-                };
-                return v;
-            }
-            else
-            {
-                // This host code should not be called since it is marked as ROCWMMA_DEVICE
-                // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, VW * 2>;
-                return VecType();
-            }
-        }
-    };
-
-    template <typename DataT>
-    struct SoaVec<DataT, 8, 256>
-    {
-        ROCWMMA_DEVICE constexpr static inline auto genData()
-        {
-            constexpr uint32_t VW       = 8;
-            constexpr uint32_t K        = 256;
-            auto               threadId = (uint8_t)detail::threadId();
-
-            if constexpr(ROCWMMA_WAVE64_MODE)
-            {
-                constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-                constexpr uint32_t VecSize   = VW * K / Constants::AMDGCN_WAVE_SIZE;
-
-                using VecType             = VecT<DataT, VecSize>;
-                const uint32_t waveOffset = threadId / WAVE_SIZE * VW * K;
-                auto           start      = (threadId % WAVE_SIZE) % K + waveOffset;
-                VecType        v          = {
-                    start,
-                    K + start,
-                    K * 2 + start,
-                    K * 3 + start,
-                    K * 4 + start,
-                    K * 5 + start,
-                    K * 6 + start,
-                    K * 7 + start,
-                    WAVE_SIZE + start,
-                    WAVE_SIZE + K + start,
-                    WAVE_SIZE + K * 2 + start,
-                    WAVE_SIZE + K * 3 + start,
-                    WAVE_SIZE + K * 4 + start,
-                    WAVE_SIZE + K * 5 + start,
-                    WAVE_SIZE + K * 6 + start,
-                    WAVE_SIZE + K * 7 + start,
-                    WAVE_SIZE * 2 + start,
-                    WAVE_SIZE * 2 + K + start,
-                    WAVE_SIZE * 2 + K * 2 + start,
-                    WAVE_SIZE * 2 + K * 3 + start,
-                    WAVE_SIZE * 2 + K * 4 + start,
-                    WAVE_SIZE * 2 + K * 5 + start,
-                    WAVE_SIZE * 2 + K * 6 + start,
-                    WAVE_SIZE * 2 + K * 7 + start,
-                    WAVE_SIZE * 3 + start,
-                    WAVE_SIZE * 3 + K + start,
-                    WAVE_SIZE * 3 + K * 2 + start,
-                    WAVE_SIZE * 3 + K * 3 + start,
-                    WAVE_SIZE * 3 + K * 4 + start,
-                    WAVE_SIZE * 3 + K * 5 + start,
-                    WAVE_SIZE * 3 + K * 6 + start,
-                    WAVE_SIZE * 3 + K * 7 + start,
-                };
-                return v;
-            }
-            else if constexpr(ROCWMMA_WAVE32_MODE)
-            {
-                constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-                constexpr uint32_t VecSize   = VW * K / Constants::AMDGCN_WAVE_SIZE;
-
-                using VecType             = VecT<DataT, VecSize>;
-                const uint32_t waveOffset = threadId / WAVE_SIZE * VW * K;
-                auto           start      = (threadId % WAVE_SIZE) % K + waveOffset;
-                VecType        v          = {
-                    start,
-                    K + start,
-                    K * 2 + start,
-                    K * 3 + start,
-                    K * 4 + start,
-                    K * 5 + start,
-                    K * 6 + start,
-                    K * 7 + start,
-                    WAVE_SIZE + start,
-                    WAVE_SIZE + K + start,
-                    WAVE_SIZE + K * 2 + start,
-                    WAVE_SIZE + K * 3 + start,
-                    WAVE_SIZE + K * 4 + start,
-                    WAVE_SIZE + K * 5 + start,
-                    WAVE_SIZE + K * 6 + start,
-                    WAVE_SIZE + K * 7 + start,
-                    WAVE_SIZE * 2 + start,
-                    WAVE_SIZE * 2 + K + start,
-                    WAVE_SIZE * 2 + K * 2 + start,
-                    WAVE_SIZE * 2 + K * 3 + start,
-                    WAVE_SIZE * 2 + K * 4 + start,
-                    WAVE_SIZE * 2 + K * 5 + start,
-                    WAVE_SIZE * 2 + K * 6 + start,
-                    WAVE_SIZE * 2 + K * 7 + start,
-                    WAVE_SIZE * 3 + start,
-                    WAVE_SIZE * 3 + K + start,
-                    WAVE_SIZE * 3 + K * 2 + start,
-                    WAVE_SIZE * 3 + K * 3 + start,
-                    WAVE_SIZE * 3 + K * 4 + start,
-                    WAVE_SIZE * 3 + K * 5 + start,
-                    WAVE_SIZE * 3 + K * 6 + start,
-                    WAVE_SIZE * 3 + K * 7 + start,
-                    WAVE_SIZE * 4 + start,
-                    WAVE_SIZE * 4 + K + start,
-                    WAVE_SIZE * 4 + K * 2 + start,
-                    WAVE_SIZE * 4 + K * 3 + start,
-                    WAVE_SIZE * 4 + K * 4 + start,
-                    WAVE_SIZE * 4 + K * 5 + start,
-                    WAVE_SIZE * 4 + K * 6 + start,
-                    WAVE_SIZE * 4 + K * 7 + start,
-                    WAVE_SIZE * 5 + start,
-                    WAVE_SIZE * 5 + K + start,
-                    WAVE_SIZE * 5 + K * 2 + start,
-                    WAVE_SIZE * 5 + K * 3 + start,
-                    WAVE_SIZE * 5 + K * 4 + start,
-                    WAVE_SIZE * 5 + K * 5 + start,
-                    WAVE_SIZE * 5 + K * 6 + start,
-                    WAVE_SIZE * 5 + K * 7 + start,
-                    WAVE_SIZE * 6 + start,
-                    WAVE_SIZE * 6 + K + start,
-                    WAVE_SIZE * 6 + K * 2 + start,
-                    WAVE_SIZE * 6 + K * 3 + start,
-                    WAVE_SIZE * 6 + K * 4 + start,
-                    WAVE_SIZE * 6 + K * 5 + start,
-                    WAVE_SIZE * 6 + K * 6 + start,
-                    WAVE_SIZE * 6 + K * 7 + start,
-                    WAVE_SIZE * 7 + start,
-                    WAVE_SIZE * 7 + K + start,
-                    WAVE_SIZE * 7 + K * 2 + start,
-                    WAVE_SIZE * 7 + K * 3 + start,
-                    WAVE_SIZE * 7 + K * 4 + start,
-                    WAVE_SIZE * 7 + K * 5 + start,
-                    WAVE_SIZE * 7 + K * 6 + start,
-                    WAVE_SIZE * 7 + K * 7 + start,
-                };
-                return v;
-            }
-            else
-            {
-                // This host code should not be called since it is marked as ROCWMMA_DEVICE
-                // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, VW * 4>;
-                return VecType();
-            }
         }
     };
 
@@ -1066,7 +816,7 @@ namespace rocwmma
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, 1>;
+                using VecType = VecT<DataT, VW>;
                 return VecType();
             }
         }
@@ -1157,7 +907,7 @@ namespace rocwmma
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, 1>;
+                using VecType = VecT<DataT, VW * 2>;
                 return VecType();
             }
         }
@@ -1296,7 +1046,7 @@ namespace rocwmma
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, 1>;
+                using VecType = VecT<DataT, VW * 4>;
                 return VecType();
             }
         }
@@ -1547,6 +1297,99 @@ namespace rocwmma
         }
     };
 
+    template <typename DataT>
+    struct SoaVec<DataT, 2, 16>
+    {
+        ROCWMMA_DEVICE constexpr static inline auto genData()
+        {
+            constexpr uint32_t VW       = 2;
+            constexpr uint32_t BlockDim = 16;
+            using VecType               = VecT<DataT, VW>;
+            auto           threadId     = (uint8_t)detail::threadId();
+            const uint32_t waveOffset   = threadId / BlockDim * VW * BlockDim;
+            auto           start        = (threadId % BlockDim) % BlockDim + waveOffset;
+            VecType        v            = {start, BlockDim + start};
+            return v;
+        }
+    };
+
+    template <typename DataT>
+    struct SoaVec<DataT, 2, 32>
+    {
+        ROCWMMA_DEVICE constexpr static inline auto genData()
+        {
+            constexpr uint32_t VW       = 2;
+            constexpr uint32_t BlockDim = 32;
+            using VecType               = VecT<DataT, VW>;
+            auto           threadId     = (uint8_t)detail::threadId();
+            const uint32_t waveOffset   = threadId / BlockDim * VW * BlockDim;
+            auto           start        = (threadId % BlockDim) % BlockDim + waveOffset;
+            VecType        v            = {start, BlockDim + start};
+            return v;
+        }
+    };
+
+    template <typename DataT>
+    struct SoaVec<DataT, 2, 64>
+    {
+        ROCWMMA_DEVICE constexpr static inline auto genData()
+        {
+            constexpr uint32_t VW       = 2;
+            constexpr uint32_t BlockDim = 64;
+            using VecType               = VecT<DataT, VW>;
+            auto           threadId     = (uint8_t)detail::threadId();
+            const uint32_t waveOffset   = threadId / BlockDim * VW * BlockDim;
+            auto           start        = (threadId % BlockDim) % BlockDim + waveOffset;
+            VecType        v            = {start, BlockDim + start};
+            return v;
+        }
+    };
+
+    template <typename DataT>
+    struct SoaVec<DataT, 2, 128>
+    {
+        ROCWMMA_DEVICE constexpr static inline auto genData()
+        {
+            constexpr uint32_t VW        = 2;
+            constexpr uint32_t BlockDim  = 128;
+            constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+            constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
+
+            using VecType             = VecT<DataT, VecSize>;
+            auto           threadId   = (uint8_t)detail::threadId();
+            const uint32_t waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
+            auto           start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
+            VecType v = {start, BlockDim + start, WAVE_SIZE + start, WAVE_SIZE + BlockDim + start};
+            return v;
+        }
+    };
+
+    template <typename DataT>
+    struct SoaVec<DataT, 2, 256>
+    {
+        ROCWMMA_DEVICE constexpr static inline auto genData()
+        {
+            constexpr uint32_t VW        = 2;
+            constexpr uint32_t BlockDim  = 256;
+            constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+            constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
+
+            using VecType             = VecT<DataT, VecSize>;
+            auto           threadId   = (uint8_t)detail::threadId();
+            const uint32_t waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
+            auto           start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
+            VecType        v          = {start,
+                                         BlockDim + start,
+                                         WAVE_SIZE + start,
+                                         WAVE_SIZE + BlockDim + start,
+                                         WAVE_SIZE * 2 + start,
+                                         WAVE_SIZE * 2 + BlockDim + start,
+                                         WAVE_SIZE * 3 + start,
+                                         WAVE_SIZE * 3 + BlockDim + start};
+            return v;
+        }
+    };
+
     template <typename DataT, uint32_t VW, uint32_t BlockDim>
     ROCWMMA_DEVICE static inline bool aos_soa_b32()
     {
@@ -1558,13 +1401,13 @@ namespace rocwmma
         __syncthreads();
 
         // TODO: remove conditional when AosToSoa VW=2 is implemented
-        auto soa = SoaVec<DataT, VW, K>::genData();
+        auto soa = SoaVec<DataT, VW, BlockDim>::genData();
         if(VW == 4 || VW == 8)
         {
-            soa = AosToSoa<K, VW>::exec(v);
+            soa = AosToSoa<BlockDim, VW>::exec(v);
         }
 
-        auto cmp_v = SoaVec<DataT, VW, K>::genData();
+        auto cmp_v = SoaVec<DataT, VW, BlockDim>::genData();
         err |= soa != cmp_v;
 
         return err;

--- a/test/unit/transforms_test/device/transforms.hpp
+++ b/test/unit/transforms_test/device/transforms.hpp
@@ -686,7 +686,7 @@ namespace rocwmma
         ROCWMMA_DEVICE static inline auto genData()
         {
             constexpr uint32_t VW        = 2;
-            constexpr uint32_t BlockDim  = 128;
+            constexpr uint32_t BlockDim  = 256;
             constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
             constexpr uint32_t VecSize   = VW * 256 / WAVE_SIZE;
 

--- a/test/unit/transforms_test/device/transforms.hpp
+++ b/test/unit/transforms_test/device/transforms.hpp
@@ -611,6 +611,351 @@ namespace rocwmma
         }
     };
 
+    template <typename DataT>
+    struct SoaVec<DataT, 8, 16>
+    {
+        ROCWMMA_DEVICE constexpr static inline auto genData()
+        {
+            constexpr uint32_t VW     = 8;
+            constexpr uint32_t K      = 16;
+            using VecType             = VecT<DataT, VW>;
+            auto           threadId   = (uint8_t)detail::threadId();
+            const uint32_t waveOffset = threadId / K * VW * K;
+            auto           start      = (threadId % K) % K + waveOffset;
+            VecType        v          = {
+                start,
+                K + start,
+                K * 2 + start,
+                K * 3 + start,
+                K * 4 + start,
+                K * 5 + start,
+                K * 6 + start,
+                K * 7 + start,
+            };
+            return v;
+        }
+    };
+
+    template <typename DataT>
+    struct SoaVec<DataT, 8, 32>
+    {
+        ROCWMMA_DEVICE constexpr static inline auto genData()
+        {
+            constexpr uint32_t VW     = 8;
+            constexpr uint32_t K      = 32;
+            using VecType             = VecT<DataT, VW>;
+            auto           threadId   = (uint8_t)detail::threadId();
+            const uint32_t waveOffset = threadId / K * VW * K;
+            auto           start      = (threadId % K) % K + waveOffset;
+            VecType        v          = {start,
+                                         K + start,
+                                         K * 2 + start,
+                                         K * 3 + start,
+                                         K * 4 + start,
+                                         K * 5 + start,
+                                         K * 6 + start,
+                                         K * 7 + start};
+            return v;
+        }
+    };
+
+    template <typename DataT>
+    struct SoaVec<DataT, 8, 64>
+    {
+        ROCWMMA_DEVICE constexpr static inline auto genData()
+        {
+            constexpr uint32_t VW       = 8;
+            constexpr uint32_t K        = 64;
+            auto               threadId = (uint8_t)detail::threadId();
+
+            if constexpr(ROCWMMA_WAVE64_MODE)
+            {
+                constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+                constexpr uint32_t VecSize   = VW * K / Constants::AMDGCN_WAVE_SIZE;
+
+                using VecType             = VecT<DataT, VecSize>;
+                const uint32_t waveOffset = threadId / WAVE_SIZE * VW * K;
+                auto           start      = (threadId % WAVE_SIZE) % K + waveOffset;
+                VecType        v          = {
+                    start,
+                    K + start,
+                    K * 2 + start,
+                    K * 3 + start,
+                    K * 4 + start,
+                    K * 5 + start,
+                    K * 6 + start,
+                    K * 7 + start,
+                };
+                return v;
+            }
+            else if constexpr(ROCWMMA_WAVE32_MODE)
+            {
+                constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+                constexpr uint32_t VecSize   = VW * K / Constants::AMDGCN_WAVE_SIZE;
+
+                using VecType             = VecT<DataT, VecSize>;
+                const uint32_t waveOffset = threadId / WAVE_SIZE * VW * K;
+                auto           start      = (threadId % WAVE_SIZE) % K + waveOffset;
+                VecType        v          = {
+                    start,
+                    K + start,
+                    K * 2 + start,
+                    K * 3 + start,
+                    K * 4 + start,
+                    K * 5 + start,
+                    K * 6 + start,
+                    K * 7 + start,
+                    WAVE_SIZE + start,
+                    WAVE_SIZE + K + start,
+                    WAVE_SIZE + K * 2 + start,
+                    WAVE_SIZE + K * 3 + start,
+                    WAVE_SIZE + K * 4 + start,
+                    WAVE_SIZE + K * 5 + start,
+                    WAVE_SIZE + K * 6 + start,
+                    WAVE_SIZE + K * 7 + start,
+                };
+                return v;
+            }
+            else
+            {
+                // This host code should not be called since it is marked as ROCWMMA_DEVICE
+                // This code snippet exists since hipcc complains about the mismatched function
+                using VecType = VecT<DataT, VW>;
+                return VecType();
+            }
+        }
+    };
+
+    template <typename DataT>
+    struct SoaVec<DataT, 8, 128>
+    {
+        ROCWMMA_DEVICE constexpr static inline auto genData()
+        {
+            constexpr uint32_t VW       = 8;
+            constexpr uint32_t K        = 128;
+            auto               threadId = (uint8_t)detail::threadId();
+
+            if constexpr(ROCWMMA_WAVE64_MODE)
+            {
+                constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+                constexpr uint32_t VecSize   = VW * K / Constants::AMDGCN_WAVE_SIZE;
+
+                using VecType             = VecT<DataT, VecSize>;
+                const uint32_t waveOffset = threadId / WAVE_SIZE * VW * K;
+                auto           start      = (threadId % WAVE_SIZE) % K + waveOffset;
+                VecType        v          = {
+                    start,
+                    K + start,
+                    K * 2 + start,
+                    K * 3 + start,
+                    K * 4 + start,
+                    K * 5 + start,
+                    K * 6 + start,
+                    K * 7 + start,
+                    WAVE_SIZE + start,
+                    WAVE_SIZE + K + start,
+                    WAVE_SIZE + K * 2 + start,
+                    WAVE_SIZE + K * 3 + start,
+                    WAVE_SIZE + K * 4 + start,
+                    WAVE_SIZE + K * 5 + start,
+                    WAVE_SIZE + K * 6 + start,
+                    WAVE_SIZE + K * 7 + start,
+                };
+                return v;
+            }
+            else if constexpr(ROCWMMA_WAVE32_MODE)
+            {
+                constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+                constexpr uint32_t VecSize   = VW * K / Constants::AMDGCN_WAVE_SIZE;
+
+                using VecType             = VecT<DataT, VecSize>;
+                const uint32_t waveOffset = threadId / WAVE_SIZE * VW * K;
+                auto           start      = (threadId % WAVE_SIZE) % K + waveOffset;
+                VecType        v          = {
+                    start,
+                    K + start,
+                    K * 2 + start,
+                    K * 3 + start,
+                    K * 4 + start,
+                    K * 5 + start,
+                    K * 6 + start,
+                    K * 7 + start,
+                    WAVE_SIZE + start,
+                    WAVE_SIZE + K + start,
+                    WAVE_SIZE + K * 2 + start,
+                    WAVE_SIZE + K * 3 + start,
+                    WAVE_SIZE + K * 4 + start,
+                    WAVE_SIZE + K * 5 + start,
+                    WAVE_SIZE + K * 6 + start,
+                    WAVE_SIZE + K * 7 + start,
+                    WAVE_SIZE * 2 + start,
+                    WAVE_SIZE * 2 + K + start,
+                    WAVE_SIZE * 2 + K * 2 + start,
+                    WAVE_SIZE * 2 + K * 3 + start,
+                    WAVE_SIZE * 2 + K * 4 + start,
+                    WAVE_SIZE * 2 + K * 5 + start,
+                    WAVE_SIZE * 2 + K * 6 + start,
+                    WAVE_SIZE * 2 + K * 7 + start,
+                    WAVE_SIZE * 3 + start,
+                    WAVE_SIZE * 3 + K + start,
+                    WAVE_SIZE * 3 + K * 2 + start,
+                    WAVE_SIZE * 3 + K * 3 + start,
+                    WAVE_SIZE * 3 + K * 4 + start,
+                    WAVE_SIZE * 3 + K * 5 + start,
+                    WAVE_SIZE * 3 + K * 6 + start,
+                    WAVE_SIZE * 3 + K * 7 + start,
+                };
+                return v;
+            }
+            else
+            {
+                // This host code should not be called since it is marked as ROCWMMA_DEVICE
+                // This code snippet exists since hipcc complains about the mismatched function
+                using VecType = VecT<DataT, VW * 2>;
+                return VecType();
+            }
+        }
+    };
+
+    template <typename DataT>
+    struct SoaVec<DataT, 8, 256>
+    {
+        ROCWMMA_DEVICE constexpr static inline auto genData()
+        {
+            constexpr uint32_t VW       = 8;
+            constexpr uint32_t K        = 256;
+            auto               threadId = (uint8_t)detail::threadId();
+
+            if constexpr(ROCWMMA_WAVE64_MODE)
+            {
+                constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+                constexpr uint32_t VecSize   = VW * K / Constants::AMDGCN_WAVE_SIZE;
+
+                using VecType             = VecT<DataT, VecSize>;
+                const uint32_t waveOffset = threadId / WAVE_SIZE * VW * K;
+                auto           start      = (threadId % WAVE_SIZE) % K + waveOffset;
+                VecType        v          = {
+                    start,
+                    K + start,
+                    K * 2 + start,
+                    K * 3 + start,
+                    K * 4 + start,
+                    K * 5 + start,
+                    K * 6 + start,
+                    K * 7 + start,
+                    WAVE_SIZE + start,
+                    WAVE_SIZE + K + start,
+                    WAVE_SIZE + K * 2 + start,
+                    WAVE_SIZE + K * 3 + start,
+                    WAVE_SIZE + K * 4 + start,
+                    WAVE_SIZE + K * 5 + start,
+                    WAVE_SIZE + K * 6 + start,
+                    WAVE_SIZE + K * 7 + start,
+                    WAVE_SIZE * 2 + start,
+                    WAVE_SIZE * 2 + K + start,
+                    WAVE_SIZE * 2 + K * 2 + start,
+                    WAVE_SIZE * 2 + K * 3 + start,
+                    WAVE_SIZE * 2 + K * 4 + start,
+                    WAVE_SIZE * 2 + K * 5 + start,
+                    WAVE_SIZE * 2 + K * 6 + start,
+                    WAVE_SIZE * 2 + K * 7 + start,
+                    WAVE_SIZE * 3 + start,
+                    WAVE_SIZE * 3 + K + start,
+                    WAVE_SIZE * 3 + K * 2 + start,
+                    WAVE_SIZE * 3 + K * 3 + start,
+                    WAVE_SIZE * 3 + K * 4 + start,
+                    WAVE_SIZE * 3 + K * 5 + start,
+                    WAVE_SIZE * 3 + K * 6 + start,
+                    WAVE_SIZE * 3 + K * 7 + start,
+                };
+                return v;
+            }
+            else if constexpr(ROCWMMA_WAVE32_MODE)
+            {
+                constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+                constexpr uint32_t VecSize   = VW * K / Constants::AMDGCN_WAVE_SIZE;
+
+                using VecType             = VecT<DataT, VecSize>;
+                const uint32_t waveOffset = threadId / WAVE_SIZE * VW * K;
+                auto           start      = (threadId % WAVE_SIZE) % K + waveOffset;
+                VecType        v          = {
+                    start,
+                    K + start,
+                    K * 2 + start,
+                    K * 3 + start,
+                    K * 4 + start,
+                    K * 5 + start,
+                    K * 6 + start,
+                    K * 7 + start,
+                    WAVE_SIZE + start,
+                    WAVE_SIZE + K + start,
+                    WAVE_SIZE + K * 2 + start,
+                    WAVE_SIZE + K * 3 + start,
+                    WAVE_SIZE + K * 4 + start,
+                    WAVE_SIZE + K * 5 + start,
+                    WAVE_SIZE + K * 6 + start,
+                    WAVE_SIZE + K * 7 + start,
+                    WAVE_SIZE * 2 + start,
+                    WAVE_SIZE * 2 + K + start,
+                    WAVE_SIZE * 2 + K * 2 + start,
+                    WAVE_SIZE * 2 + K * 3 + start,
+                    WAVE_SIZE * 2 + K * 4 + start,
+                    WAVE_SIZE * 2 + K * 5 + start,
+                    WAVE_SIZE * 2 + K * 6 + start,
+                    WAVE_SIZE * 2 + K * 7 + start,
+                    WAVE_SIZE * 3 + start,
+                    WAVE_SIZE * 3 + K + start,
+                    WAVE_SIZE * 3 + K * 2 + start,
+                    WAVE_SIZE * 3 + K * 3 + start,
+                    WAVE_SIZE * 3 + K * 4 + start,
+                    WAVE_SIZE * 3 + K * 5 + start,
+                    WAVE_SIZE * 3 + K * 6 + start,
+                    WAVE_SIZE * 3 + K * 7 + start,
+                    WAVE_SIZE * 4 + start,
+                    WAVE_SIZE * 4 + K + start,
+                    WAVE_SIZE * 4 + K * 2 + start,
+                    WAVE_SIZE * 4 + K * 3 + start,
+                    WAVE_SIZE * 4 + K * 4 + start,
+                    WAVE_SIZE * 4 + K * 5 + start,
+                    WAVE_SIZE * 4 + K * 6 + start,
+                    WAVE_SIZE * 4 + K * 7 + start,
+                    WAVE_SIZE * 5 + start,
+                    WAVE_SIZE * 5 + K + start,
+                    WAVE_SIZE * 5 + K * 2 + start,
+                    WAVE_SIZE * 5 + K * 3 + start,
+                    WAVE_SIZE * 5 + K * 4 + start,
+                    WAVE_SIZE * 5 + K * 5 + start,
+                    WAVE_SIZE * 5 + K * 6 + start,
+                    WAVE_SIZE * 5 + K * 7 + start,
+                    WAVE_SIZE * 6 + start,
+                    WAVE_SIZE * 6 + K + start,
+                    WAVE_SIZE * 6 + K * 2 + start,
+                    WAVE_SIZE * 6 + K * 3 + start,
+                    WAVE_SIZE * 6 + K * 4 + start,
+                    WAVE_SIZE * 6 + K * 5 + start,
+                    WAVE_SIZE * 6 + K * 6 + start,
+                    WAVE_SIZE * 6 + K * 7 + start,
+                    WAVE_SIZE * 7 + start,
+                    WAVE_SIZE * 7 + K + start,
+                    WAVE_SIZE * 7 + K * 2 + start,
+                    WAVE_SIZE * 7 + K * 3 + start,
+                    WAVE_SIZE * 7 + K * 4 + start,
+                    WAVE_SIZE * 7 + K * 5 + start,
+                    WAVE_SIZE * 7 + K * 6 + start,
+                    WAVE_SIZE * 7 + K * 7 + start,
+                };
+                return v;
+            }
+            else
+            {
+                // This host code should not be called since it is marked as ROCWMMA_DEVICE
+                // This code snippet exists since hipcc complains about the mismatched function
+                using VecType = VecT<DataT, VW * 4>;
+                return VecType();
+            }
+        }
+    };
+
     // SoaVec
     template <typename DataT>
     struct SoaVec<DataT, 8, 16>
@@ -1212,12 +1557,11 @@ namespace rocwmma
 
         __syncthreads();
 
-        auto soa = AosToSoa<K, VW>::exec(v);
-
-        // TODO: remove when AosToSoa VW=2 is implemented
-        if(VW == 2)
+        // TODO: remove conditional when AosToSoa VW=2 is implemented
+        auto soa = SoaVec<DataT, VW, K>::genData();
+        if(VW == 4 || VW == 8)
         {
-            soa = SoaVec<DataT, VW, K>::genData();
+            soa = AosToSoa<K, VW>::exec(v);
         }
 
         auto cmp_v = SoaVec<DataT, VW, K>::genData();

--- a/test/unit/transforms_test/test/transforms.cpp
+++ b/test/unit/transforms_test/test/transforms.cpp
@@ -59,8 +59,8 @@ namespace rocwmma
         {
             auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
-            return { {warpSize, 1}, {warpSize * 2, 1}, {warpSize * 4, 1}};
-            // return { {warpSize, 1} };
+            // return { {warpSize, 1}, {warpSize * 2, 1}, {warpSize * 4, 1}};
+            return { {warpSize, 1} };
             // clang-format on
         }
 

--- a/test/unit/transforms_test/test/transforms.cpp
+++ b/test/unit/transforms_test/test/transforms.cpp
@@ -59,8 +59,8 @@ namespace rocwmma
         {
             auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
-            // return { {warpSize, 1}, {warpSize * 2, 1}, {warpSize * 4, 1}};
-            return { {warpSize, 1} };
+            return { {warpSize, 1}, {warpSize * 2, 1}, {warpSize * 4, 1}};
+            // return { {warpSize, 1} };
             // clang-format on
         }
 

--- a/test/unit/transforms_test/test/transforms.cpp
+++ b/test/unit/transforms_test/test/transforms.cpp
@@ -78,7 +78,7 @@ namespace rocwmma
     };
 
     using AossoaTestParams = TestParams<AossoaGenerator, std::tuple<I<4>, I<8>>>;
-    using SoaaosTestParams = TestParams<SoaaosGenerator, std::tuple<I<4>>>;
+    using SoaaosTestParams = TestParams<SoaaosGenerator, std::tuple<I<2>, I<4>, I<8>>>;
 
 } // namespace rocwmma
 

--- a/test/unit/transforms_test/test/transforms.cpp
+++ b/test/unit/transforms_test/test/transforms.cpp
@@ -60,6 +60,7 @@ namespace rocwmma
             auto warpSize = HipDevice::instance()->warpSize();
             // clang-format off
             return { {warpSize, 1}, {warpSize * 2, 1}, {warpSize * 4, 1}};
+            // return { {warpSize, 1} };
             // clang-format on
         }
 

--- a/test/unit/vector_util_test/test/vector_util.cpp
+++ b/test/unit/vector_util_test/test/vector_util.cpp
@@ -39,7 +39,7 @@ namespace rocwmma
         using Base = UnitTestParams;
 
         // Types: Base IOC + double
-        using Types = std::tuple<float8_t, float16_t, bfloat16_t, float32_t, float64_t>;
+        using Types = std::tuple<int8_t, float16_t, bfloat16_t, float32_t, float64_t>;
 
         // Vector Sizes.
         // Test up to VecSize = 64. Anything bigger is impractical.


### PR DESCRIPTION
Added SoA to AoS implementations and unit tests for vector widths of 2 and 8. Wave32 support for these vector widths will be in a following PR.