### PR TITLE
Adjust ColInlineVW layout

### DIFF
--- a/library/include/rocwmma/internal/transforms_impl.hpp
+++ b/library/include/rocwmma/internal/transforms_impl.hpp
@@ -873,8 +873,8 @@ namespace rocwmma
     template <>
     struct AosToSoa<256, 2>
     {
-        constexpr static uint32_t VW = 2;
-        constexpr static VecSize     = 16;
+        constexpr static uint32_t VW      = 2;
+        constexpr static uint32_t VecSize = 16;
 
         template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
@@ -1116,14 +1116,14 @@ namespace rocwmma
             auto hi1 = extractHi(hi);
 
             // Subdivide work to each batch of WAVE_SIZE
-            auto v0 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(lo0));
-            auto v1 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(lo0));
-            auto v2 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(lo1));
-            auto v3 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(lo1));
-            auto v4 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(hi0));
-            auto v5 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(hi0));
-            auto v6 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(hi1));
-            auto v7 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(hi1));
+            auto v0 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(lo0));
+            auto v1 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(lo0));
+            auto v2 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(lo1));
+            auto v3 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(lo1));
+            auto v4 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(hi0));
+            auto v5 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(hi0));
+            auto v6 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(hi1));
+            auto v7 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(hi1));
 
             return concat(concat(concat(v0, v1), concat(v2, v3)),
                           concat(concat(v4, v5), concat(v6, v7)));
@@ -1530,14 +1530,14 @@ namespace rocwmma
             auto hi1 = extractHi(hi);
 
             // Subdivide work to each batch of WAVE_SIZE
-            auto v0 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(lo0));
-            auto v1 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(lo0));
-            auto v2 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(lo1));
-            auto v3 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(lo1));
-            auto v4 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(hi0));
-            auto v5 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(hi0));
-            auto v6 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(hi1));
-            auto v7 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(hi1));
+            auto v0 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(lo0));
+            auto v1 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(lo0));
+            auto v2 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(lo1));
+            auto v3 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(lo1));
+            auto v4 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(hi0));
+            auto v5 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(hi0));
+            auto v6 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(hi1));
+            auto v7 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(hi1));
 
             return concat(concat(concat(v0, v1), concat(v2, v3)),
                           concat(concat(v4, v5), concat(v6, v7)));

--- a/library/include/rocwmma/internal/transforms_impl.hpp
+++ b/library/include/rocwmma/internal/transforms_impl.hpp
@@ -191,47 +191,6 @@ namespace rocwmma
                       PackUtil::template paddedUnpack<VecSize / 2u>(hi));
     }
 
-    template <typename DataT, uint32_t VecSize>
-    ROCWMMA_DEVICE constexpr static inline auto soa_aos_wave_b32_vw4(VecT<DataT, VecSize> const& v)
-    {
-        using PackUtil = PackUtil<DataT>;
-
-        // Step 1 : Scatter
-        auto lo            = Permute::ScatterWave<4, 0>::exec(PackUtil::paddedPack(extractLo(v)));
-        auto hi            = Permute::ScatterWave<4, 32>::exec(PackUtil::paddedPack(extractHi(v)));
-        auto unpacked_data = concat(PackUtil::template paddedUnpack<2u>(lo),
-                                    PackUtil::template paddedUnpack<2u>(hi));
-
-        // Step 2 : UnpackLoHi16
-
-        unpacked_data = PackUtil::template paddedUnpack<4>(Swizzle::RotateR32<16>::exec(
-            PackUtil::paddedPack(concat(extractEven(unpacked_data), extractOdd(unpacked_data)))));
-
-        lo          = PackUtil::paddedPack(extractLo(unpacked_data));
-        hi          = PackUtil::paddedPack(extractHi(unpacked_data));
-        auto rot_lo = Swizzle::RotateR32<16>::exec(lo);
-        auto zip_lo = Blend::Zip16::exec(rot_lo, hi);
-        auto zip_hi = Blend::Zip16::exec(hi, rot_lo);
-        zip_hi      = Swizzle::RotateR32<16>::exec(zip_hi);
-
-        unpacked_data = concat(PackUtil::template paddedUnpack<2>(zip_lo),
-                               PackUtil::template paddedUnpack<2>(zip_hi));
-
-        // Step 3 : UnpackLoHi32
-        lo = PackUtil::paddedPack(extractEven(unpacked_data));
-        hi = PackUtil::paddedPack(extractOdd(unpacked_data));
-
-        zip_lo = Blend::Zip32::exec(lo, hi);
-        zip_hi = Blend::Zip32::exec(hi, lo);
-
-        auto rot_hi = Permute::RotateWaveR<32>::exec(zip_hi);
-
-        unpacked_data = concat(PackUtil::template paddedUnpack<2u>(zip_lo),
-                               PackUtil::template paddedUnpack<2u>(rot_hi));
-
-        return unpacked_data;
-    };
-
     template <uint32_t BlockDim, uint32_t VectorWidth>
     struct AosToSoa
     {
@@ -316,16 +275,17 @@ namespace rocwmma
     };
 
 #if ROCWMMA_WAVE64_MODE
+
     template <>
     struct AosToSoa<64, 8>
     {
-        template <typename DataT, uint32_t VecSize>
+        constexpr static uint32_t VW      = 8;
+        constexpr static uint32_t VecSize = 8;
+
+        template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            using PackUtil        = PackUtil<DataT>;
-            constexpr uint32_t VW = 8;
-            static_assert(VecSize == VW * (64 / Constants::AMDGCN_WAVE_SIZE_64),
-                          "VecSize must be specific number");
+            using PackUtil = PackUtil<DataT>;
 
             // Step 1 : Unpack groups of 8
             auto result = unpackLoHi8(v);
@@ -353,56 +313,39 @@ namespace rocwmma
             return PackUtil::template paddedUnpack<VecSize>(concat(lo, hi));
         }
     };
+
 #elif ROCWMMA_WAVE32_MODE
+
     template <>
     struct AosToSoa<64, 8>
     {
-        template <typename DataT, uint32_t VecSize>
+        constexpr static uint32_t VW      = 8;
+        constexpr static uint32_t VecSize = 16;
+
+        template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            constexpr uint32_t VW = 8;
-            static_assert(VecSize == VW * (64 / Constants::AMDGCN_WAVE_SIZE_32),
-                          "VecSize must be specific number");
+            // Subdivide work to each batch of WAVE_SIZE
             auto v0 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(v));
             auto v1 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(v));
 
-            // Re-pack banks
-            auto repack_data = VecT<DataT, VecSize>{
-                v0.data[0],
-                v0.data[2],
-                v0.data[4],
-                v0.data[6],
-                v1.data[0],
-                v1.data[2],
-                v1.data[4],
-                v1.data[6],
-                v0.data[1],
-                v0.data[3],
-                v0.data[5],
-                v0.data[7],
-                v1.data[1],
-                v1.data[3],
-                v1.data[5],
-                v1.data[7],
-            };
-
-            return repack_data;
+            return concat(v0, v1);
         }
     };
+
 #endif
 
 #if ROCWMMA_WAVE64_MODE
+
     template <>
     struct AosToSoa<128, 8>
     {
-        template <typename DataT, uint32_t VecSize>
+        constexpr static uint32_t VW      = 8;
+        constexpr static uint32_t VecSize = 16;
+
+        template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            constexpr uint32_t VW = 8;
-            static_assert(VecSize == VW * (128 / Constants::AMDGCN_WAVE_SIZE_64),
-                          "VecSize must be specific number");
-            using PackUtil = PackUtil<DataT>;
-
             // There are TWO sets of VW = 8 registers (because this case BlockDim / 64 = 2):
             // 1. Vecs 0-7
             // 2. Vecs 8-15
@@ -412,69 +355,63 @@ namespace rocwmma
             //         0 |   0   |   1   |   ...   |   7   |
             //         1 |   8   |   9   |   ...   |   15  |
             //       ... |   ... |   ... |   ...   |  ...  |
-            //        63 |__504__|__505__|___...___|__511__|
+            //        63 |__952__|__953__|___...___|__959__|
             //
             // Register/ |          VW = 8                 |
             //     Tidx  |___8___|___9___|___...___|___15__|
-            //         0 |  512  |  513  |   ...   |  519  |
-            //         1 |  520  |  521  |   ...   |  527  |
+            //         0 |  64   |  65   |   ...   |   71  |
+            //         1 |  72   |  73   |   ...   |   79  |
             //       ... |   ... |   ... |   ...   |  ...  |
             //        63 |__1016_|__1017_|___...___|__1023_|
 
-            // Extract each batch of registers and put them through the 64 size
-            auto result_b0 = AosToSoa<64, 8>::exec(extractLo(v));
-            auto result_b1 = AosToSoa<64, 8>::exec(extractHi(v));
+            // Subdivide work to each batch of WAVE_SIZE
+            auto result_b0 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractLo(v));
+            auto result_b1 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractHi(v));
 
-            // Re-pack banks
-            auto repacked_b0 = concat(extractEven(result_b0), extractEven(result_b1));
-            auto repacked_b1 = concat(extractOdd(result_b0), extractOdd(result_b1));
-            return concat(repacked_b0, repacked_b1);
+            return concat(result_b0, result_b1);
         }
     };
+
 #elif ROCWMMA_WAVE32_MODE
+
     template <>
     struct AosToSoa<128, 8>
     {
-        template <typename DataT, uint32_t VecSize>
+        constexpr static uint32_t VW      = 8;
+        constexpr static uint32_t VecSize = 32;
+
+        template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            constexpr uint32_t VW = 8;
-            static_assert(VecSize == VW * (128 / Constants::AMDGCN_WAVE_SIZE_32),
-                          "VecSize must be specific number");
             auto lo = extractLo(v);
             auto hi = extractHi(v);
+
+            // Subdivide work to each batch of WAVE_SIZE
             auto v0 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(lo));
             auto v1 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(lo));
             auto v2 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(hi));
             auto v3 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(hi));
 
-            // Re-pack banks
-            auto repack_data = VecT<DataT, VecSize>{
-                v0.data[0], v0.data[4], v1.data[0], v1.data[4], v2.data[0], v2.data[4], v3.data[0],
-                v3.data[4], v0.data[1], v0.data[5], v1.data[1], v1.data[5], v2.data[1], v2.data[5],
-                v3.data[1], v3.data[5], v0.data[2], v0.data[6], v1.data[2], v1.data[6], v2.data[2],
-                v2.data[6], v3.data[2], v3.data[6], v0.data[3], v0.data[7], v1.data[3], v1.data[7],
-                v2.data[3], v2.data[7], v3.data[3], v3.data[7],
-            };
-
-            return repack_data;
+            return concat(concat(v0, v1), concat(v2, v3));
         }
     };
+
 #endif
 
 #if ROCWMMA_WAVE64_MODE
+
     template <>
     struct AosToSoa<256, 8>
     {
-        template <typename DataT, uint32_t VecSize>
+        constexpr static uint32_t VW      = 8;
+        constexpr static uint32_t VecSize = 32;
+
+        template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            constexpr uint32_t VW = 8;
-            static_assert(VecSize == VW * (256 / Constants::AMDGCN_WAVE_SIZE_64),
-                          "VecSize must be specific number");
             using PackUtil = PackUtil<DataT>;
 
-            // There are FOUR sets of VW = 8 registers (because this case BlockDim / 64 = 2):
+            // There are FOUR sets of VW = 8 registers (because this case BlockDim / 64 = 4):
             // 1. Vecs 0-7
             // 2. Vecs 8-15
             // 3. Vecs 16-23
@@ -485,114 +422,83 @@ namespace rocwmma
             //         0 |   0   |   1   |   ...   |   7   |
             //         1 |   8   |   9   |   ...   |   15  |
             //       ... |   ... |   ... |   ...   |  ...  |
-            //        63 |__504__|__505__|___...___|__511__|
+            //        63 |__1848_|__1849_|___...___|__1855_|
             //
             // Register/ |          VW = 8                 |
             //     Tidx  |___8___|___9___|___...___|___15__|
-            //         0 |  512  |  513  |   ...   |  519  |
-            //         1 |  520  |  521  |   ...   |  527  |
+            //         0 |  64   |  65   |   ...   |   71  |
+            //         1 |  72   |  73   |   ...   |   79  |
             //       ... |   ... |   ... |   ...   |  ...  |
-            //        63 |__1016_|__1017_|___...___|__1023_|
+            //        63 |__1912_|__1913_|___...___|__1919_|
             //
             // Register/ |          VW = 8                    |
             //     Tidx  |___16___|___17___|___...___|___23___|
-            //         0 |  1024  |  1025  |   ...   |  1031  |
-            //         1 |  1032  |  1033  |   ...   |  1039  |
+            //         0 |  128   |  129   |   ...   |  135   |
+            //         1 |  136   |  137   |   ...   |  143   |
             //       ... |   .... |   .... |   ...   |  ....  |
-            //        63 |__1528__|__1529__|___...___|__1535__|
+            //        63 |__1976__|__1977__|___...___|__1983__|
             //
             // Register/ |          VW = 8                    |
             //     Tidx  |___24___|___25___|___...___|___31___|
-            //         0 |  1536  |  1537  |   ...   |  1543  |
-            //         1 |  1544  |  1545  |   ...   |  1551  |
+            //         0 |  192   |  193   |   ...   |  199   |
+            //         1 |  200   |  201   |   ...   |  207   |
             //       ... |   ...  |   ...  |   ...   |  ...   |
             //        63 |__2040__|__2041__|___...___|__2047 _|
 
             // Extract each batch of registers and put them through the 64 size
-            auto lo0 = extractLo(v);
-            auto hi0 = extractHi(v);
+            auto lo = extractLo(v);
+            auto hi = extractHi(v);
 
-            auto result_b0 = AosToSoa<64, 8>::exec(extractLo(lo0));
-            auto result_b1 = AosToSoa<64, 8>::exec(extractHi(lo0));
-            auto result_b2 = AosToSoa<64, 8>::exec(extractLo(hi0));
-            auto result_b3 = AosToSoa<64, 8>::exec(extractHi(hi0));
+            // Subdivide work to each batch of WAVE_SIZE
+            auto v0 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractLo(lo));
+            auto v1 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractHi(lo));
+            auto v2 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractLo(hi));
+            auto v3 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractHi(hi));
 
-            // Re-pack banks
-            return VecT<DataT, VecSize>{
-                get<0>(result_b0), get<4>(result_b0), get<0>(result_b1), get<4>(result_b1),
-                get<0>(result_b2), get<4>(result_b2), get<0>(result_b3), get<4>(result_b3),
-
-                get<1>(result_b0), get<5>(result_b0), get<1>(result_b1), get<5>(result_b1),
-                get<1>(result_b2), get<5>(result_b2), get<1>(result_b3), get<5>(result_b3),
-
-                get<2>(result_b0), get<6>(result_b0), get<2>(result_b1), get<6>(result_b1),
-                get<2>(result_b2), get<6>(result_b2), get<2>(result_b3), get<6>(result_b3),
-
-                get<3>(result_b0), get<7>(result_b0), get<3>(result_b1), get<7>(result_b1),
-                get<3>(result_b2), get<7>(result_b2), get<3>(result_b3), get<7>(result_b3)};
+            return concat(concat(v0, v1), concat(v2, v3));
         }
     };
+
 #elif ROCWMMA_WAVE32_MODE
+
     template <>
     struct AosToSoa<256, 8>
     {
-        template <typename DataT, uint32_t VecSize>
+        constexpr static uint32_t VW      = 8;
+        constexpr static uint32_t VecSize = 64;
+
+        template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            constexpr uint32_t VW = 8;
-            static_assert(VecSize == VW * (256 / Constants::AMDGCN_WAVE_SIZE_32),
-                          "VecSize must be specific number");
-            auto lo             = extractLo(v);
-            auto hi             = extractHi(v);
-            auto v0             = extractLo(lo);
-            auto v1             = extractHi(lo);
-            auto v2             = extractLo(hi);
-            auto v3             = extractHi(hi);
-            auto unpacked_data0 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(v0));
-            auto unpacked_data1 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(v0));
-            auto unpacked_data2 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(v1));
-            auto unpacked_data3 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(v1));
-            auto unpacked_data4 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(v2));
-            auto unpacked_data5 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(v2));
-            auto unpacked_data6 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(v3));
-            auto unpacked_data7 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(v3));
+            auto lo  = extractLo(v);
+            auto hi  = extractHi(v);
+            auto lo0 = extractLo(lo);
+            auto lo1 = extractHi(lo);
+            auto hi0 = extractLo(hi);
+            auto hi1 = extractHi(hi);
 
-            // Re-pack banks
-            auto repack_data = VecT<DataT, VecSize>{
-                unpacked_data0.data[0], unpacked_data1.data[0], unpacked_data2.data[0],
-                unpacked_data3.data[0], unpacked_data4.data[0], unpacked_data5.data[0],
-                unpacked_data6.data[0], unpacked_data7.data[0], unpacked_data0.data[1],
-                unpacked_data1.data[1], unpacked_data2.data[1], unpacked_data3.data[1],
-                unpacked_data4.data[1], unpacked_data5.data[1], unpacked_data6.data[1],
-                unpacked_data7.data[1], unpacked_data0.data[2], unpacked_data1.data[2],
-                unpacked_data2.data[2], unpacked_data3.data[2], unpacked_data4.data[2],
-                unpacked_data5.data[2], unpacked_data6.data[2], unpacked_data7.data[2],
-                unpacked_data0.data[3], unpacked_data1.data[3], unpacked_data2.data[3],
-                unpacked_data3.data[3], unpacked_data4.data[3], unpacked_data5.data[3],
-                unpacked_data6.data[3], unpacked_data7.data[3], unpacked_data0.data[4],
-                unpacked_data1.data[4], unpacked_data2.data[4], unpacked_data3.data[4],
-                unpacked_data4.data[4], unpacked_data5.data[4], unpacked_data6.data[4],
-                unpacked_data7.data[4], unpacked_data0.data[5], unpacked_data1.data[5],
-                unpacked_data2.data[5], unpacked_data3.data[5], unpacked_data4.data[5],
-                unpacked_data5.data[5], unpacked_data6.data[5], unpacked_data7.data[5],
-                unpacked_data0.data[6], unpacked_data1.data[6], unpacked_data2.data[6],
-                unpacked_data3.data[6], unpacked_data4.data[6], unpacked_data5.data[6],
-                unpacked_data6.data[6], unpacked_data7.data[6], unpacked_data0.data[7],
-                unpacked_data1.data[7], unpacked_data2.data[7], unpacked_data3.data[7],
-                unpacked_data4.data[7], unpacked_data5.data[7], unpacked_data6.data[7],
-                unpacked_data7.data[7],
-            };
+            // Subdivide work to each batch of WAVE_SIZE
+            auto v0 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(lo0));
+            auto v1 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(lo0));
+            auto v2 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(lo1));
+            auto v3 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(lo1));
+            auto v4 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(hi0));
+            auto v5 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(hi0));
+            auto v6 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(hi1));
+            auto v7 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(hi1));
 
-            return repack_data;
+            return concat(concat(concat(v0, v1), concat(v2, v3)),
+                          concat(concat(v4, v5), concat(v6, v7)));
         }
     };
+
 #endif
 
     template <>
     struct AosToSoa<16, 4>
     {
         constexpr static uint32_t VW      = 4;
-        constexpr static uint32_t VecSize = VW;
+        constexpr static uint32_t VecSize = 4;
 
         template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
@@ -617,7 +523,7 @@ namespace rocwmma
     struct AosToSoa<32, 4>
     {
         constexpr static uint32_t VW      = 4;
-        constexpr static uint32_t VecSize = VW;
+        constexpr static uint32_t VecSize = 4;
 
         template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
@@ -647,15 +553,16 @@ namespace rocwmma
     };
 
 #if ROCWMMA_WAVE64_MODE
+
     template <>
     struct AosToSoa<64, 4>
     {
-        template <typename DataT, uint32_t VecSize>
+        constexpr static uint32_t VW      = 4;
+        constexpr static uint32_t VecSize = 4;
+
+        template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            constexpr uint32_t VW = 4;
-            static_assert(VecSize == VW * (64 / Constants::AMDGCN_WAVE_SIZE_64),
-                          "VecSize must be specific number");
             using PackUtil = PackUtil<DataT>;
 
             // Step 1 : UnpackLohi16
@@ -678,200 +585,137 @@ namespace rocwmma
                           PackUtil::template paddedUnpack<VW / 2>(hi));
         }
     };
+
 #elif ROCWMMA_WAVE32_MODE
+
     template <>
     struct AosToSoa<64, 4>
     {
-        template <typename DataT, uint32_t VecSize>
+        constexpr static uint32_t VW      = 4;
+        constexpr static uint32_t VecSize = 8;
+
+        template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            constexpr uint32_t VW = 4;
-            static_assert(VecSize == VW * (64 / Constants::AMDGCN_WAVE_SIZE_32),
-                          "VecSize must be specific number");
+            // Subdivide work to each batch of WAVE_SIZE
             auto v0 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(v));
             auto v1 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(v));
 
-            // Re-pack banks
-            auto repack_data = VecT<DataT, VecSize>{v0.data[0],
-                                                    v0.data[2],
-                                                    v1.data[0],
-                                                    v1.data[2],
-                                                    v0.data[1],
-                                                    v0.data[3],
-                                                    v1.data[1],
-                                                    v1.data[3]};
-
-            return repack_data;
+            return concat(v0, v1);
         }
     };
+
 #endif
 
 #if ROCWMMA_WAVE64_MODE
+
     template <>
     struct AosToSoa<128, 4>
     {
-        template <typename DataT, uint32_t VecSize>
+        constexpr static uint32_t VW      = 4;
+        constexpr static uint32_t VecSize = 8;
+
+        template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            constexpr uint32_t VW = 4;
-            static_assert(VecSize == VW * (128 / Constants::AMDGCN_WAVE_SIZE_64),
-                          "VecSize must be specific number");
-            // Re-pack banks
+            // Subdivide work to each batch of WAVE_SIZE
             auto v0 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractLo(v));
             auto v1 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractHi(v));
 
-            auto repack_data = VecT<DataT, VecSize>{v0.data[0],
-                                                    v0.data[2],
-                                                    v1.data[0],
-                                                    v1.data[2],
-                                                    v0.data[1],
-                                                    v0.data[3],
-                                                    v1.data[1],
-                                                    v1.data[3]};
-
-            return repack_data;
+            return concat(v0, v1);
         }
     };
+
 #elif ROCWMMA_WAVE32_MODE
+
     template <>
     struct AosToSoa<128, 4>
     {
-        template <typename DataT, uint32_t VecSize>
+        constexpr static uint32_t VW      = 4;
+        constexpr static uint32_t VecSize = 16;
+
+        template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            constexpr uint32_t VW = 4;
-            static_assert(VecSize == VW * (128 / Constants::AMDGCN_WAVE_SIZE_32),
-                          "VecSize must be specific number");
-            // Re-pack banks
-            auto v_lo = extractLo(v);
-            auto v_hi = extractHi(v);
-            auto v0   = extractLo(v_lo);
-            auto v1   = extractHi(v_lo);
-            auto v2   = extractLo(v_hi);
-            auto v3   = extractHi(v_hi);
+            auto lo = extractLo(v);
+            auto hi = extractHi(v);
 
-            // Step 1 - 3 : Applied on VW width banks
-            auto unpacked_data0 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(v0);
-            auto unpacked_data1 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(v1);
-            auto unpacked_data2 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(v2);
-            auto unpacked_data3 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(v3);
-            auto repack_data    = VecT<DataT, VecSize>{unpacked_data0.data[0],
-                                                       unpacked_data1.data[0],
-                                                       unpacked_data2.data[0],
-                                                       unpacked_data3.data[0],
-                                                       unpacked_data0.data[1],
-                                                       unpacked_data1.data[1],
-                                                       unpacked_data2.data[1],
-                                                       unpacked_data3.data[1],
-                                                       unpacked_data0.data[2],
-                                                       unpacked_data1.data[2],
-                                                       unpacked_data2.data[2],
-                                                       unpacked_data3.data[2],
-                                                       unpacked_data0.data[3],
-                                                       unpacked_data1.data[3],
-                                                       unpacked_data2.data[3],
-                                                       unpacked_data3.data[3]};
+            // Subdivide work to each batch of WAVE_SIZE
+            auto v0 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(lo));
+            auto v1 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(lo));
+            auto v2 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(hi));
+            auto v3 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(hi));
 
-            return repack_data;
+            return concat(concat(v0, v1), concat(v2, v3));
         }
     };
+
 #endif
 
 #if ROCWMMA_WAVE64_MODE
+
     template <>
     struct AosToSoa<256, 4>
     {
-        template <typename DataT, uint32_t VecSize>
+        constexpr static uint32_t VW      = 4;
+        constexpr static uint32_t VecSize = 16;
+
+        template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            constexpr uint32_t VW = 4;
-            static_assert(VecSize == VW * (256 / Constants::AMDGCN_WAVE_SIZE_64),
-                          "VecSize must be specific number");
-            // Step 4 : Re-pack banks
-            auto v_lo = extractLo(v);
-            auto v_hi = extractHi(v);
-            auto v0   = extractLo(v_lo);
-            auto v1   = extractHi(v_lo);
-            auto v2   = extractLo(v_hi);
-            auto v3   = extractHi(v_hi);
+            auto lo = extractLo(v);
+            auto hi = extractHi(v);
 
-            // Step 1 - 3 : Applied on VW width banks
-            auto unpacked_data0 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(v0);
-            auto unpacked_data1 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(v1);
-            auto unpacked_data2 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(v2);
-            auto unpacked_data3 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(v3);
+            // Subdivide work to each batch of WAVE_SIZE
+            auto v0 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractLo(lo));
+            auto v1 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractHi(lo));
+            auto v2 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractLo(hi));
+            auto v3 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractHi(hi));
 
-            auto repack_data = VecT<DataT, VecSize>{unpacked_data0.data[0],
-                                                    unpacked_data1.data[0],
-                                                    unpacked_data2.data[0],
-                                                    unpacked_data3.data[0],
-                                                    unpacked_data0.data[1],
-                                                    unpacked_data1.data[1],
-                                                    unpacked_data2.data[1],
-                                                    unpacked_data3.data[1],
-                                                    unpacked_data0.data[2],
-                                                    unpacked_data1.data[2],
-                                                    unpacked_data2.data[2],
-                                                    unpacked_data3.data[2],
-                                                    unpacked_data0.data[3],
-                                                    unpacked_data1.data[3],
-                                                    unpacked_data2.data[3],
-                                                    unpacked_data3.data[3]};
-
-            return repack_data;
+            return concat(concat(v0, v1), concat(v2, v3));
         }
     };
+
 #elif ROCWMMA_WAVE32_MODE
+
     template <>
     struct AosToSoa<256, 4>
     {
-        template <typename DataT, uint32_t VecSize>
+        constexpr static uint32_t VW      = 4;
+        constexpr static uint32_t VecSize = 32;
+
+        template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            constexpr uint32_t VW = 4;
-            static_assert(VecSize == VW * (256 / Constants::AMDGCN_WAVE_SIZE_32),
-                          "VecSize must be specific number");
-            // Step 4 : Re-pack banks
-            auto v_lo = extractLo(v);
-            auto v_hi = extractHi(v);
-            auto v0   = extractLo(v_lo);
-            auto v1   = extractHi(v_lo);
-            auto v2   = extractLo(v_hi);
-            auto v3   = extractHi(v_hi);
+            auto lo  = extractLo(v);
+            auto hi  = extractHi(v);
+            auto lo0 = extractLo(lo);
+            auto lo1 = extractHi(lo);
+            auto hi0 = extractLo(hi);
+            auto hi1 = extractHi(hi);
 
-            // Step 1 - 3 : Applied on VW width banks
-            auto unpacked_data0 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(v0));
-            auto unpacked_data1 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(v0));
-            auto unpacked_data2 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(v1));
-            auto unpacked_data3 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(v1));
-            auto unpacked_data4 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(v2));
-            auto unpacked_data5 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(v2));
-            auto unpacked_data6 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(v3));
-            auto unpacked_data7 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(v3));
+            // Subdivide work to each batch of WAVE_SIZE
+            auto v0 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(lo0));
+            auto v1 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(lo0));
+            auto v2 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(lo1));
+            auto v3 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(lo1));
+            auto v4 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(hi0));
+            auto v5 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(hi0));
+            auto v6 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(hi1));
+            auto v7 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(hi1));
 
-            auto repack_data = VecT<DataT, VecSize>{
-                unpacked_data0.data[0], unpacked_data2.data[0], unpacked_data4.data[0],
-                unpacked_data6.data[0], unpacked_data0.data[1], unpacked_data2.data[1],
-                unpacked_data4.data[1], unpacked_data6.data[1], unpacked_data0.data[2],
-                unpacked_data2.data[2], unpacked_data4.data[2], unpacked_data6.data[2],
-                unpacked_data0.data[3], unpacked_data2.data[3], unpacked_data4.data[3],
-                unpacked_data6.data[3], unpacked_data1.data[0], unpacked_data3.data[0],
-                unpacked_data5.data[0], unpacked_data7.data[0], unpacked_data1.data[1],
-                unpacked_data3.data[1], unpacked_data5.data[1], unpacked_data7.data[1],
-                unpacked_data1.data[2], unpacked_data3.data[2], unpacked_data5.data[2],
-                unpacked_data7.data[2], unpacked_data1.data[3], unpacked_data3.data[3],
-                unpacked_data5.data[3], unpacked_data7.data[3]};
-
-            return repack_data;
+            return concat(concat(concat(v0, v1), concat(v2, v3)),
+                          concat(concat(v4, v5), concat(v6, v7)));
         }
     };
+
 #endif
 
     template <>
     struct AosToSoa<16, 2>
     {
         constexpr static uint32_t VW      = 2;
-        constexpr static uint32_t VecSize = VW;
+        constexpr static uint32_t VecSize = 2;
 
         template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
@@ -893,7 +737,7 @@ namespace rocwmma
     struct AosToSoa<32, 2>
     {
         constexpr static uint32_t VW      = 2;
-        constexpr static uint32_t VecSize = VW;
+        constexpr static uint32_t VecSize = 2;
 
         template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
@@ -916,7 +760,7 @@ namespace rocwmma
     struct AosToSoa<64, 2>
     {
         constexpr static uint32_t VW      = 2;
-        constexpr static uint32_t VecSize = VW;
+        constexpr static uint32_t VecSize = 2;
 
         template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
@@ -968,16 +812,11 @@ namespace rocwmma
         template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
+            // Subdivide work to each batch of WAVE_SIZE
             auto v0 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractLo(v));
             auto v1 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractHi(v));
 
-            // Re-pack banks
-            auto repack_data = VecT<DataT, VecSize>{v0.data[0],
-                                                    v1.data[0],
-                                                    v0.data[1],
-                                                    v1.data[1]};
-
-            return repack_data;
+            return concat(v0, v1);
         }
     };
 #elif ROCWMMA_WAVE32_MODE
@@ -1029,22 +868,16 @@ namespace rocwmma
         template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            using PackUtil = PackUtil<DataT>;
+            auto lo = extractLo(v);
+            auto hi = extractHi(v);
 
-            auto lo0 = extractLo(v);
-            auto hi0 = extractHi(v);
+            // Subdivide work to each batch of WAVE_SIZE
+            auto v0 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractLo(lo));
+            auto v1 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractHi(lo));
+            auto v2 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractLo(hi));
+            auto v3 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractHi(hi));
 
-            // Applied on VW width banks
-            auto result_b0 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, 2>::exec(extractLo(lo0));
-            auto result_b1 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, 2>::exec(extractHi(lo0));
-            auto result_b2 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, 2>::exec(extractLo(hi0));
-            auto result_b3 = AosToSoa<Constants::AMDGCN_WAVE_SIZE_64, 2>::exec(extractHi(hi0));
-
-            // Re-pack banks
-            return VecT<DataT, VecSize>{get<0>(result_b0), get<0>(result_b2),
-                                        get<1>(result_b0), get<1>(result_b2),
-                                        get<0>(result_b1), get<0>(result_b3),
-                                        get<1>(result_b1), get<1>(result_b3)};
+            return concat(concat(v0, v1), concat(v2, v3));
         }
     };
 #elif ROCWMMA_WAVE32_MODE
@@ -1196,15 +1029,11 @@ namespace rocwmma
         template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            // Step 1 :  RE-PACK Banks
-            auto v0 = unpackLo(extractLo(v), extractHi(v));
-            auto v1 = unpackHi(extractLo(v), extractHi(v));
+            // Subdivide work to each batch of WAVE_SIZE
+            auto v0 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractLo(v));
+            auto v1 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractHi(v));
 
-            // Step 2 - 4 :  Applied on VW width banks
-            auto unpacked_data0 = SoaToAos<64, 2>::exec(v0);
-            auto unpacked_data1 = SoaToAos<64, 2>::exec(v1);
-
-            return concat(unpacked_data0, unpacked_data1);
+            return concat(v0, v1);
         }
     };
 #elif ROCWMMA_WAVE32_MODE
@@ -1246,21 +1075,16 @@ namespace rocwmma
         template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            // Step 1 :  RE-PACK Banks
-            auto v0 = VecT<DataT, VecSize / 4>{v.data[0], v.data[2]};
-            auto v1 = VecT<DataT, VecSize / 4>{v.data[4], v.data[6]};
-            auto v2 = VecT<DataT, VecSize / 4>{v.data[1], v.data[3]};
-            auto v3 = VecT<DataT, VecSize / 4>{v.data[5], v.data[7]};
+            auto lo = extractLo(v);
+            auto hi = extractHi(v);
 
-            // Step 2 - 4 :  Applied on VW width banks
-            auto unpacked_data0 = SoaToAos<64, 2>::exec(v0);
-            auto unpacked_data1 = SoaToAos<64, 2>::exec(v1);
-            auto unpacked_data2 = SoaToAos<64, 2>::exec(v2);
-            auto unpacked_data3 = SoaToAos<64, 2>::exec(v3);
+            // Subdivide work to each batch of WAVE_SIZE
+            auto v0 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractLo(lo));
+            auto v1 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractHi(lo));
+            auto v2 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractLo(hi));
+            auto v3 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractHi(hi));
 
-            auto unpacked_data = concat(concat(unpacked_data0, unpacked_data1),
-                                        concat(unpacked_data2, unpacked_data3));
-            return unpacked_data;
+            return concat(concat(v0, v1), concat(v2, v3));
         }
     };
 #elif ROCWMMA_WAVE32_MODE
@@ -1306,7 +1130,7 @@ namespace rocwmma
     struct SoaToAos<16, 4>
     {
         constexpr static uint32_t VW      = 4;
-        constexpr static uint32_t VecSize = VW;
+        constexpr static uint32_t VecSize = 4;
 
         template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
@@ -1331,7 +1155,7 @@ namespace rocwmma
     struct SoaToAos<32, 4>
     {
         constexpr static uint32_t VW      = 4;
-        constexpr static uint32_t VecSize = VW;
+        constexpr static uint32_t VecSize = 4;
 
         template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
@@ -1361,16 +1185,17 @@ namespace rocwmma
     };
 
 #if ROCWMMA_WAVE64_MODE
+
     template <>
     struct SoaToAos<64, 4>
     {
-        template <typename DataT, uint32_t VecSize>
+        constexpr static uint32_t VW      = 4;
+        constexpr static uint32_t VecSize = 4;
+
+        template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            using PackUtil        = PackUtil<DataT>;
-            constexpr uint32_t VW = 4;
-            static_assert(VecSize == VW * (64 / Constants::AMDGCN_WAVE_SIZE_64),
-                          "VecSize must be specific number");
+            using PackUtil = PackUtil<DataT>;
 
             // Step 1 : Scatter
             auto lo = Permute::ScatterWave<4, 0>::exec(PackUtil::paddedPack(extractLo(v)));
@@ -1409,145 +1234,127 @@ namespace rocwmma
             return unpacked_data;
         }
     };
+
 #elif ROCWMMA_WAVE32_MODE
+
     template <>
     struct SoaToAos<64, 4>
     {
-        template <typename DataT, uint32_t VecSize>
+        constexpr static uint32_t VW      = 4;
+        constexpr static uint32_t VecSize = 8;
+
+        template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            constexpr uint32_t VW = 4;
-            static_assert(VecSize == VW * (64 / Constants::AMDGCN_WAVE_SIZE_32),
-                          "VecSize must be specific number");
-            // Step 1 :  RE-PACK Banks
-            auto v0 = unpackLo(extractLo(v), extractHi(v));
-            auto v1 = unpackHi(extractLo(v), extractHi(v));
+            // Subdivide work to each batch of WAVE_SIZE
+            auto v0 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(v));
+            auto v1 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(v));
 
-            // Step 2 - 4 :  Applied on VW width banks
-            auto unpacked_data0 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(v0);
-            auto unpacked_data1 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(v1);
-
-            return concat(unpacked_data0, unpacked_data1);
+            return concat(v0, v1);
         }
     };
+
 #endif
 
 #if ROCWMMA_WAVE64_MODE
+
     template <>
     struct SoaToAos<128, 4>
     {
-        template <typename DataT, uint32_t VecSize>
+        constexpr static uint32_t VW      = 4;
+        constexpr static uint32_t VecSize = 8;
+
+        template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            constexpr uint32_t VW = 4;
-            static_assert(VecSize == VW * (128 / Constants::AMDGCN_WAVE_SIZE_64),
-                          "VecSize must be specific number");
+            // Subdivide work to each batch of WAVE_SIZE
+            auto v0 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractLo(v));
+            auto v1 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractHi(v));
 
-            // Step 1 :  RE-PACK Banks
-            auto v0 = unpackLo(extractLo(v), extractHi(v));
-            auto v1 = unpackHi(extractLo(v), extractHi(v));
-
-            // Step 2 - 4 :  Applied on VW width banks
-            auto unpacked_data0 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(v0);
-            auto unpacked_data1 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(v1);
-
-            return concat(unpacked_data0, unpacked_data1);
+            return concat(v0, v1);
         }
     };
+
 #elif ROCWMMA_WAVE32_MODE
+
     template <>
     struct SoaToAos<128, 4>
     {
-        template <typename DataT, uint32_t VecSize>
+        constexpr static uint32_t VW      = 4;
+        constexpr static uint32_t VecSize = 16;
+
+        template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            constexpr uint32_t VW = 4;
-            static_assert(VecSize == VW * (128 / Constants::AMDGCN_WAVE_SIZE_32),
-                          "VecSize must be specific number");
+            auto lo = extractLo(v);
+            auto hi = extractHi(v);
 
-            // Step 1 :  RE-PACK Banks
-            auto v0 = VecT<DataT, VW>{v.data[0], v.data[4], v.data[8], v.data[12]};
-            auto v1 = VecT<DataT, VW>{v.data[1], v.data[5], v.data[9], v.data[13]};
-            auto v2 = VecT<DataT, VW>{v.data[2], v.data[6], v.data[10], v.data[14]};
-            auto v3 = VecT<DataT, VW>{v.data[3], v.data[7], v.data[11], v.data[15]};
+            // Subdivide work to each batch of WAVE_SIZE
+            auto v0 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(lo));
+            auto v1 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(lo));
+            auto v2 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(hi));
+            auto v3 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(hi));
 
-            // Step 2 - 4 :  Applied on VW width banks
-            auto unpacked_data0 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(v0);
-            auto unpacked_data1 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(v1);
-            auto unpacked_data2 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(v2);
-            auto unpacked_data3 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(v3);
-
-            auto unpacked_data = concat(concat(unpacked_data0, unpacked_data1),
-                                        concat(unpacked_data2, unpacked_data3));
-            return unpacked_data;
+            return concat(concat(v0, v1), concat(v2, v3));
         }
     };
+
 #endif
 
 #if ROCWMMA_WAVE64_MODE
+
     template <>
     struct SoaToAos<256, 4>
     {
-        template <typename DataT, uint32_t VecSize>
+        constexpr static uint32_t VW      = 4;
+        constexpr static uint32_t VecSize = 16;
+
+        template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            constexpr uint32_t VW = 4;
-            static_assert(VecSize == VW * (256 / Constants::AMDGCN_WAVE_SIZE_64),
-                          "VecSize must be specific number");
+            auto lo = extractLo(v);
+            auto hi = extractHi(v);
 
-            // Step 1 :  RE-PACK Banks
-            auto v0 = VecT<DataT, VW>{v.data[0], v.data[4], v.data[8], v.data[12]};
-            auto v1 = VecT<DataT, VW>{v.data[1], v.data[5], v.data[9], v.data[13]};
-            auto v2 = VecT<DataT, VW>{v.data[2], v.data[6], v.data[10], v.data[14]};
-            auto v3 = VecT<DataT, VW>{v.data[3], v.data[7], v.data[11], v.data[15]};
+            // Subdivide work to each batch of WAVE_SIZE
+            auto v0 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractLo(lo));
+            auto v1 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractHi(lo));
+            auto v2 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractLo(hi));
+            auto v3 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractHi(hi));
 
-            // Step 2 - 4 :  Applied on VW width banks
-            auto unpacked_data0 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(v0);
-            auto unpacked_data1 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(v1);
-            auto unpacked_data2 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(v2);
-            auto unpacked_data3 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(v3);
-
-            auto unpacked_data = concat(concat(unpacked_data0, unpacked_data1),
-                                        concat(unpacked_data2, unpacked_data3));
-            return unpacked_data;
+            return concat(concat(v0, v1), concat(v2, v3));
         }
     };
+
 #elif ROCWMMA_WAVE32_MODE
+
     template <>
     struct SoaToAos<256, 4>
     {
-        template <typename DataT, uint32_t VecSize>
+        constexpr static uint32_t VW      = 4;
+        constexpr static uint32_t VecSize = 32;
+
+        template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            constexpr uint32_t VW = 4;
-            static_assert(VecSize == VW * (256 / Constants::AMDGCN_WAVE_SIZE_32),
-                          "VecSize must be specific number");
+            auto lo  = extractLo(v);
+            auto hi  = extractHi(v);
+            auto lo0 = extractLo(lo);
+            auto lo1 = extractHi(lo);
+            auto hi0 = extractLo(hi);
+            auto hi1 = extractHi(hi);
 
-            // Step 1 :  RE-PACK Banks
-            auto v0 = VecT<DataT, VW>{v.data[0], v.data[4], v.data[8], v.data[12]};
-            auto v2 = VecT<DataT, VW>{v.data[1], v.data[5], v.data[9], v.data[13]};
-            auto v4 = VecT<DataT, VW>{v.data[2], v.data[6], v.data[10], v.data[14]};
-            auto v6 = VecT<DataT, VW>{v.data[3], v.data[7], v.data[11], v.data[15]};
-            auto v1 = VecT<DataT, VW>{v.data[16], v.data[20], v.data[24], v.data[28]};
-            auto v3 = VecT<DataT, VW>{v.data[17], v.data[21], v.data[25], v.data[29]};
-            auto v5 = VecT<DataT, VW>{v.data[18], v.data[22], v.data[26], v.data[30]};
-            auto v7 = VecT<DataT, VW>{v.data[19], v.data[23], v.data[27], v.data[31]};
+            // Subdivide work to each batch of WAVE_SIZE
+            auto v0 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(lo0));
+            auto v1 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(lo0));
+            auto v2 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(lo1));
+            auto v3 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(lo1));
+            auto v4 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(hi0));
+            auto v5 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(hi0));
+            auto v6 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractLo(hi1));
+            auto v7 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(extractHi(hi1));
 
-            // Step 2 - 4 :  Applied on VW width banks
-            auto unpacked_data0 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(v0);
-            auto unpacked_data1 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(v1);
-            auto unpacked_data2 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(v2);
-            auto unpacked_data3 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(v3);
-            auto unpacked_data4 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(v4);
-            auto unpacked_data5 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(v5);
-            auto unpacked_data6 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(v6);
-            auto unpacked_data7 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_32, VW>::exec(v7);
-
-            auto unpacked_data = concat(concat(concat(unpacked_data0, unpacked_data1),
-                                               concat(unpacked_data2, unpacked_data3)),
-                                        concat(concat(unpacked_data4, unpacked_data5),
-                                               concat(unpacked_data6, unpacked_data7)));
-            return unpacked_data;
+            return concat(concat(concat(v0, v1), concat(v2, v3)),
+                          concat(concat(v4, v5), concat(v6, v7)));
         }
     };
 #endif
@@ -1688,15 +1495,11 @@ namespace rocwmma
         template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            // Step 1 :  RE-PACK Banks
-            auto v0 = unpackLo(extractLo(v), extractHi(v));
-            auto v1 = unpackHi(extractLo(v), extractHi(v));
+            // Subdivide work to each batch of WAVE_SIZE
+            auto v0 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractLo(v));
+            auto v1 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractHi(v));
 
-            // Step 2 - 4 :  Applied on VW width banks
-            auto unpacked_data0 = SoaToAos<64, 8>::exec(v0);
-            auto unpacked_data1 = SoaToAos<64, 8>::exec(v1);
-
-            return concat(unpacked_data0, unpacked_data1);
+            return concat(v0, v1);
         }
     };
 #elif ROCWMMA_WAVE32_MODE
@@ -1767,50 +1570,16 @@ namespace rocwmma
         template <typename DataT>
         ROCWMMA_DEVICE constexpr static inline auto exec(VecT<DataT, VecSize> const& v)
         {
-            // Step 1 :  RE-PACK Banks
-            auto v0 = VecT<DataT, VW>{v.data[0],
-                                      v.data[8],
-                                      v.data[16],
-                                      v.data[24],
-                                      v.data[1],
-                                      v.data[9],
-                                      v.data[17],
-                                      v.data[25]};
-            auto v1 = VecT<DataT, VW>{v.data[2],
-                                      v.data[10],
-                                      v.data[18],
-                                      v.data[26],
-                                      v.data[3],
-                                      v.data[11],
-                                      v.data[19],
-                                      v.data[27]};
-            auto v2 = VecT<DataT, VW>{v.data[4],
-                                      v.data[12],
-                                      v.data[20],
-                                      v.data[28],
-                                      v.data[5],
-                                      v.data[13],
-                                      v.data[21],
-                                      v.data[29]};
-            auto v3 = VecT<DataT, VW>{v.data[6],
-                                      v.data[14],
-                                      v.data[22],
-                                      v.data[30],
-                                      v.data[7],
-                                      v.data[15],
-                                      v.data[23],
-                                      v.data[31]};
+            auto lo = extractLo(v);
+            auto hi = extractHi(v);
 
-            // Step 2 - 4 :  Applied on VW width banks
-            auto unpacked_data0 = SoaToAos<64, 8>::exec(v0);
-            auto unpacked_data1 = SoaToAos<64, 8>::exec(v1);
-            auto unpacked_data2 = SoaToAos<64, 8>::exec(v2);
-            auto unpacked_data3 = SoaToAos<64, 8>::exec(v3);
+            // Subdivide work to each batch of WAVE_SIZE
+            auto v0 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractLo(lo));
+            auto v1 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractHi(lo));
+            auto v2 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractLo(hi));
+            auto v3 = SoaToAos<Constants::AMDGCN_WAVE_SIZE_64, VW>::exec(extractHi(hi));
 
-            auto unpacked_data = concat(concat(unpacked_data0, unpacked_data1),
-                                        concat(unpacked_data2, unpacked_data3));
-
-            return unpacked_data;
+            return concat(concat(v0, v1), concat(v2, v3));
         }
     };
 #elif ROCWMMA_WAVE32_MODE
@@ -1907,344 +1676,6 @@ namespace rocwmma
         };
     };
 #endif
-
-    // SOA -> AOS
-    // Transform from ortho VW to inline VW
-    template <typename DataT>
-    ROCWMMA_DEVICE static inline auto soa_aos_16xk_b32(VecT<DataT, 8> const& v)
-    {
-        return 0;
-    }
-
-    template <typename DataT>
-    ROCWMMA_DEVICE static inline auto soa_aos_16xk_b32(VecT<DataT, 4> const& v)
-    {
-        return 0;
-    }
-
-    template <typename DataT>
-    ROCWMMA_DEVICE static inline auto soa_aos_16xk_b32(VecT<DataT, 2> const& v)
-    {
-        return 0;
-    }
-
-    template <typename DataT>
-    ROCWMMA_DEVICE static inline auto soa_aos_32xk_b32(VecT<DataT, 8> const& v)
-    {
-        return 0;
-    }
-
-    template <typename DataT>
-    ROCWMMA_DEVICE static inline auto soa_aos_32xk_b32(VecT<DataT, 4> const& v)
-    {
-        return 0;
-    }
-
-    template <typename DataT>
-    ROCWMMA_DEVICE static inline auto soa_aos_32xk_b32(VecT<DataT, 2> const& v)
-    {
-        return 0;
-    }
-
-    template <typename DataT>
-    ROCWMMA_DEVICE static inline auto soa_aos_64xk_b32(VecT<DataT, 8> const& v)
-    {
-        return 0;
-    }
-
-    template <typename DataT>
-    ROCWMMA_DEVICE static inline auto soa_aos_64xk_b32(VecT<DataT, 4> const& v)
-    {
-        return 0;
-    }
-
-    template <typename DataT>
-    ROCWMMA_DEVICE static inline auto soa_aos_64xk_b32(VecT<DataT, 2> const& v)
-    {
-        return 0;
-    }
-
-    template <typename DataT>
-    ROCWMMA_DEVICE static inline auto soa_aos_128xk_b32(VecT<DataT, 8> const& v)
-    {
-        return 0;
-    }
-
-    template <typename DataT>
-    ROCWMMA_DEVICE static inline auto soa_aos_128xk_b32(VecT<DataT, 4> const& v0,
-                                                        VecT<DataT, 4> const& v1)
-    {
-        return 0;
-    }
-
-    template <typename DataT>
-    ROCWMMA_DEVICE static inline auto soa_aos_128xk_b32(VecT<DataT, 2> const& v)
-    {
-        return 0;
-    }
-
-    template <typename DataT>
-    ROCWMMA_DEVICE static inline auto soa_aos_256xk_b32(VecT<DataT, 8> const& v)
-    {
-        return 0;
-    }
-
-    template <typename DataT>
-    ROCWMMA_DEVICE static inline auto soa_aos_256xk_b32(VecT<DataT, 4> const& v)
-    {
-        return 0;
-    }
-
-    template <typename DataT>
-    ROCWMMA_DEVICE static inline auto soa_aos_256xk_b32(VecT<DataT, 2> const& v)
-    {
-        return 0;
-    }
-
-    template <typename DataT>
-    ROCWMMA_DEVICE auto aos_soa_16x16_vw4_b32_opt(VecT<DataT, 4> const& v)
-    {
-        // Step 1
-        // {
-
-        //     using DppRotateR16_4_0xF_0xA  = Dpp<DppImpl::Ops::RotateR16<4>, 0xF, 0xA>;
-        //     using DppRotateR16_12_0xF_0x5 = Dpp<DppImpl::Ops::RotateR16<12>, 0xF, 0x5>;
-
-        //     auto const v0 = get<0>(v);
-        //     auto const v1 = get<1>(v);
-        //     auto const v2 = get<2>(v);
-        //     auto const v3 = get<3>(v);
-
-        //     get<0>(v) = DppRotateR16_4_0xF_0xA::exec(v1, v0);
-        //     get<1>(v) = DppRotateR16_12_0xF_0x5::exec(v0, v1);
-        //     get<2>(v) = DppRotateR16_4_0xF_0xA::exec(v3, v2);
-        //     get<3>(v) = DppRotateR16_12_0xF_0x5::exec(v2, v3);
-        // }
-
-        // // Step 2
-        // {
-        //     using DppRotateR16_8_0xF_0xC = Dpp<DppImpl::Ops::RotateR16<8>, 0xF, 0xC>;
-        //     using DppRotateR16_8_0xF_0x3 = Dpp<DppImpl::Ops::RotateR16<8>, 0xF, 0x3>;
-
-        //     auto const v0 = get<0>(v);
-        //     auto const v1 = get<1>(v);
-        //     auto const v2 = get<2>(v);
-        //     auto const v3 = get<3>(v);
-
-        //     get<0>(v) = DppRotateR16_8_0xF_0xC::exec(v2, v0);
-        //     get<1>(v) = DppRotateR16_8_0xF_0xC::exec(v3, v1);
-        //     get<2>(v) = DppRotateR16_8_0xF_0x3::exec(v0, v2);
-        //     get<3>(v) = DppRotateR16_8_0xF_0x3::exec(v1, v3);
-        // }
-
-        // // Step 3
-        // {
-        //     using Gather16_4_0 = Permute<PermuteImpl::Ops::Gather16<4, 0>>;
-
-        //     constexpr uint32_t waveSize = 64u;
-        //     Gather16_4_0::exec(v, threadIdx.x % waveSize);
-        // }
-        return 0;
-    }
-
-    template <typename DataT>
-    ROCWMMA_DEVICE auto aos_soa_16x8_vw2_b32_opt(VecT<DataT, 2> const& v)
-    {
-        // Step 1
-        // {
-        //     using DppRotateR16_8_0xF_0x3 = Dpp<DppImpl::Ops::RotateR16<8>, 0xF, 0x3>;
-        //     using DppRotateR16_8_0xF_0xC = Dpp<DppImpl::Ops::RotateR16<8>, 0xF, 0xC>;
-
-        //     auto const v0 = get<0>(v);
-        //     auto const v1 = get<1>(v);
-
-        //     get<0>(v) = DppRotateR16_8_0xF_0xC::exec(v1, v0);
-        //     get<1>(v) = DppRotateR16_8_0xF_0x3::exec(v0, v1);
-        // }
-
-        // // Step 2
-        // {
-        //     using Gather16_2_0 = Permute<PermuteImpl::Ops::Gather16<2, 0>>;
-
-        //     constexpr uint32_t waveSize = 64u;
-        //     Gather16_2_0::exec(v, threadIdx.x % waveSize);
-        // }
-        return 0;
-    }
-
-    template <typename DataT>
-    ROCWMMA_DEVICE auto aos_soa_32x4_vw2_b32_opt(VecT<DataT, 2> const& v)
-    {
-        // Step 1
-        // {
-        //     using SwzRotateR32_16 = Swizzle<SwizzleImpl::Ops::RotateR32<16>>;
-        //     SwzRotateR32_16::exec(get<0>(v));
-        // }
-
-        // // Step 2
-        // {
-        //     using DppMMove_0x5_0xF = Dpp<DppImpl::Ops::MaskMove, 0x5, 0xF>;
-        //     using DppMMove_0xA_0xF = Dpp<DppImpl::Ops::MaskMove, 0xA, 0xF>;
-
-        //     auto const v0 = get<0>(v);
-        //     auto const v1 = get<1>(v);
-
-        //     get<0>(v) = DppMMove_0x5_0xF::exec(v1, v0);
-        //     get<1>(v) = DppMMove_0xA_0xF::exec(v1, v0);
-        // }
-
-        // // Step 3
-        // {
-        //     using Gather32_2_16 = Permute<PermuteImpl::Ops::Gather32<2, 16>>;
-        //     using Gather32_2_0 = Permute<PermuteImpl::Ops::Gather32<2, 0>>;
-
-        //     constexpr uint32_t waveSize = 64u;
-        //     Gather32_2_16::exec(get<0>(v), threadIdx.x % waveSize);
-        //     Gather32_2_0::exec(get<1>(v), threadIdx.x % waveSize);
-        // }
-        return 0;
-    }
-
-    template <typename DataT>
-    ROCWMMA_DEVICE auto aos_soa_32x8_vw4_b32_opt(VecT<DataT, 4> const& v)
-    {
-        // {
-        //     using DppRotateR16_8_0xF_0xC = Dpp<DppImpl::Ops::RotateR16<8>, 0xF, 0xC>;
-        //     using DppRotateR16_8_0xF_0x3 = Dpp<DppImpl::Ops::RotateR16<8>, 0xF, 0x3>;
-
-        //     auto const v0 = get<0>(v);
-        //     auto const v1 = get<1>(v);
-        //     auto const v2 = get<2>(v);
-        //     auto const v3 = get<3>(v);
-
-        //     get<0>(v) = DppRotateR16_8_0xF_0xC::exec(v1, v0);
-        //     get<1>(v) = DppRotateR16_8_0xF_0x3::exec(v0, v1);
-        //     get<2>(v) = DppRotateR16_8_0xF_0xC::exec(v3, v2);
-        //     get<3>(v) = DppRotateR16_8_0xF_0x3::exec(v2, v3);
-        // }
-
-        // // Step 1
-        // {
-        //     using SwzRotateR32_16 = Swizzle<SwizzleImpl::Ops::RotateR32<16>>;
-        //     SwzRotateR32_16::exec(get<2>(v));
-        //     SwzRotateR32_16::exec(get<3>(v));
-        // }
-
-        // // Step 2
-        // {
-        //     using DppMMove_0x5_0xF = Dpp<DppImpl::Ops::MaskMove, 0x5, 0xF>;
-
-        //     auto const v0 = get<0>(v);
-        //     auto const v1 = get<1>(v);
-        //     auto const v2 = get<2>(v);
-        //     auto const v3 = get<3>(v);
-
-        //     get<0>(v) = DppMMove_0x5_0xF::exec(v0, v2);
-        //     get<1>(v) = DppMMove_0x5_0xF::exec(v1, v3);
-        //     get<2>(v) = DppMMove_0x5_0xF::exec(v2, v0);
-        //     get<3>(v) = DppMMove_0x5_0xF::exec(v3, v1);
-        // }
-
-        // // Step 3
-        // {
-        //     using Gather32_4_16 = Permute<PermuteImpl::Ops::Gather32<4, 16>>;
-        //     using Gather32_4_0 = Permute<PermuteImpl::Ops::Gather32<4, 0>>;
-
-        //     constexpr uint32_t waveSize = 64u;
-        //     Gather32_4_0::exec(get<0>(v), threadIdx.x % waveSize);
-        //     Gather32_4_0::exec(get<1>(v), threadIdx.x % waveSize);
-        //     Gather32_4_16::exec(get<2>(v), threadIdx.x % waveSize);
-        //     Gather32_4_16::exec(get<3>(v), threadIdx.x % waveSize);
-        // }
-        return 0;
-    }
-
-    template <typename DataT>
-    ROCWMMA_DEVICE auto soa_aos_16x16_vw4_b32_opt(VecT<DataT, 4> const& v)
-    {
-        // // Step 1
-        // {
-        //     using Scatter16_4_0 = Permute<PermuteImpl::Ops::Scatter16<4, 0>>;
-
-        //     constexpr uint32_t waveSize = 64u;
-        //     Scatter16_4_0::exec(v, threadIdx.x % waveSize);
-        // }
-
-        // // Step 2
-        // {
-        //     using DppRotateR16_4_0xF_0xA  = Dpp<DppImpl::Ops::RotateR16<4>, 0xF, 0xA>;
-        //     using DppRotateR16_12_0xF_0x5 = Dpp<DppImpl::Ops::RotateR16<12>, 0xF, 0x5>;
-
-        //     auto const v0 = get<0>(v);
-        //     auto const v1 = get<1>(v);
-        //     auto const v2 = get<2>(v);
-        //     auto const v3 = get<3>(v);
-
-        //     get<0>(v) = DppRotateR16_4_0xF_0xA::exec(v1, v0);
-        //     get<1>(v) = DppRotateR16_12_0xF_0x5::exec(v0, v1);
-        //     get<2>(v) = DppRotateR16_4_0xF_0xA::exec(v3, v2);
-        //     get<3>(v) = DppRotateR16_12_0xF_0x5::exec(v2, v3);
-        // }
-
-        // // Step 3
-        // {
-        //     using DppRotateR16_8_0xF_0xC = Dpp<DppImpl::Ops::RotateR16<8>, 0xF, 0xC>;
-        //     using DppRotateR16_8_0xF_0x3 = Dpp<DppImpl::Ops::RotateR16<8>, 0xF, 0x3>;
-
-        //     auto const v0 = get<0>(v);
-        //     auto const v1 = get<1>(v);
-        //     auto const v2 = get<2>(v);
-        //     auto const v3 = get<3>(v);
-
-        //     get<0>(v) = DppRotateR16_8_0xF_0xC::exec(v2, v0);
-        //     get<1>(v) = DppRotateR16_8_0xF_0xC::exec(v3, v1);
-        //     get<2>(v) = DppRotateR16_8_0xF_0x3::exec(v0, v2);
-        //     get<3>(v) = DppRotateR16_8_0xF_0x3::exec(v1, v3);
-        // }
-        return 0;
-    }
-
-    template <typename DataT>
-    ROCWMMA_DEVICE auto soa_aos_16x8_vw2_b32_opt(VecT<DataT, 2> const& v)
-    {
-        // // Step 1
-        // {
-        //     using Scatter16_2_0 = Permute<PermuteImpl::Ops::Scatter16<2, 0>>;
-
-        //     constexpr uint32_t waveSize = 64u;
-        //     Scatter16_2_0::exec(v, threadIdx.x % waveSize);
-        // }
-
-        // // Step 2
-        // {
-        //     using DppRotateR16_8_0xF_0x3 = Dpp<DppImpl::Ops::RotateR16<8>, 0xF, 0x3>;
-        //     using DppRotateR16_8_0xF_0xC = Dpp<DppImpl::Ops::RotateR16<8>, 0xF, 0xC>;
-
-        //     auto const v0 = get<0>(v);
-        //     auto const v1 = get<1>(v);
-
-        //     get<0>(v) = DppRotateR16_8_0xF_0xC::exec(v1, v0);
-        //     get<1>(v) = DppRotateR16_8_0xF_0x3::exec(v0, v1);
-        // }
-        return 0;
-    }
-
-    // template<uint32_t VW>
-    // struct AosToSoa<16, VW>
-    // {
-    //     template <typename DataT, uint32_t VecSize>
-    //     ROCWMMA_DEVICE static inline decltype(auto) exec()(VecT<DataT, VecSize> const& fragData)
-    //     {
-    //         auto it = rocwmma::makeVectorIterator<MaxVW>(fragA.mAccess).begin();
-    //         for(int i=0; i < decltype(it)::range(); i++, it++)
-    //         {
-    //             *it = aos_soa_16xk_b32(*it);
-    //         }
-
-    //         return fragData;
-
-    //     };
-    // };
 
 } // namespace rocwmma
 

--- a/library/include/rocwmma/internal/transforms_impl.hpp
+++ b/library/include/rocwmma/internal/transforms_impl.hpp
@@ -1174,26 +1174,14 @@ namespace rocwmma
                                         PackUtil::template paddedUnpack<VW / 2>(hi));
 
             // Step 2 : UnpackLoHi16
-            unpacked_data = PackUtil::template paddedUnpack<4>(
-                Swizzle::RotateR32<16>::exec(PackUtil::paddedPack(
-                    concat(extractEven(unpacked_data), extractOdd(unpacked_data)))));
-
-            lo          = PackUtil::paddedPack(extractLo(unpacked_data));
-            hi          = PackUtil::paddedPack(extractHi(unpacked_data));
-            auto rot_lo = Swizzle::RotateR32<16>::exec(lo);
-            auto zip_lo = Blend::Zip16::exec(rot_lo, hi);
-            auto zip_hi = Blend::Zip16::exec(hi, rot_lo);
-            zip_hi      = Swizzle::RotateR32<16>::exec(zip_hi);
-
-            unpacked_data = concat(PackUtil::template paddedUnpack<VW / 2>(zip_lo),
-                                   PackUtil::template paddedUnpack<VW / 2>(zip_hi));
+            unpacked_data = unpackLoHi16(unpacked_data);
 
             // Step 3 : UnpackLoHi32 (half-rotate offset)
             lo = PackUtil::paddedPack(extractEven(unpacked_data));
             hi = PackUtil::paddedPack(extractOdd(unpacked_data));
 
-            zip_lo = Blend::Zip32::exec(lo, hi);
-            zip_hi = Blend::Zip32::exec(hi, lo);
+            auto zip_lo = Blend::Zip32::exec(lo, hi);
+            auto zip_hi = Blend::Zip32::exec(hi, lo);
 
             auto rot_hi = Permute::RotateWaveR<32>::exec(zip_hi);
 

--- a/test/unit/transforms_test/device/transforms.hpp
+++ b/test/unit/transforms_test/device/transforms.hpp
@@ -55,7 +55,7 @@ namespace rocwmma
     {
         static constexpr uint32_t VW       = 8;
         static constexpr uint32_t BlockDim = 16;
-        using VecType = VecT<DataT, VW>;
+        using VecType                      = VecT<DataT, VW>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
@@ -72,7 +72,7 @@ namespace rocwmma
                 start + 5,
                 start + 6,
                 start + 7,
-                };
+            };
         }
     };
 
@@ -81,7 +81,7 @@ namespace rocwmma
     {
         static constexpr uint32_t VW       = 8;
         static constexpr uint32_t BlockDim = 32;
-        using VecType = VecT<DataT, VW>;
+        using VecType                      = VecT<DataT, VW>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
@@ -89,7 +89,7 @@ namespace rocwmma
             auto const waveOffset = threadId / BlockDim * VW * BlockDim;
             auto const start      = (threadId % BlockDim) * VW + waveOffset;
 
-            return VecType {
+            return VecType{
                 start,
                 start + 1,
                 start + 2,
@@ -98,37 +98,37 @@ namespace rocwmma
                 start + 5,
                 start + 6,
                 start + 7,
-                };
+            };
         }
     };
 
     template <typename DataT>
     struct AosVec<DataT, 8, 64>
     {
-        static constexpr uint32_t VW       = 8;
-        static constexpr uint32_t BlockDim = 64;
+        static constexpr uint32_t VW        = 8;
+        static constexpr uint32_t BlockDim  = 64;
         static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
         static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-        using VecType            = VecT<DataT, VecSize>;
+        using VecType                       = VecT<DataT, VecSize>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
             auto const threadId   = (uint8_t)detail::threadId();
             auto const waveOffset = (threadId * VW / WAVE_SIZE) * BlockDim;
-            auto const start     = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
+            auto const start      = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
                 return VecType{
                     start,
-                                 start + 1,
-                                 start + 2,
-                                 start + 3,
-                                 start + 4,
-                                 start + 5,
-                                 start + 6,
-                                 start + 7,
-                                 };
+                    start + 1,
+                    start + 2,
+                    start + 3,
+                    start + 4,
+                    start + 5,
+                    start + 6,
+                    start + 7,
+                };
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
             {
@@ -163,17 +163,17 @@ namespace rocwmma
     template <typename DataT>
     struct AosVec<DataT, 8, 128>
     {
-        static constexpr uint32_t VW       = 8;
-        static constexpr uint32_t BlockDim = 128;
+        static constexpr uint32_t VW        = 8;
+        static constexpr uint32_t BlockDim  = 128;
         static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
         static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-        using VecType = VecT<DataT, VecSize>;
+        using VecType                       = VecT<DataT, VecSize>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
             auto const threadId   = (uint8_t)detail::threadId();
             auto const waveOffset = (threadId * VW / WAVE_SIZE) * BlockDim;
-            auto const start     = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
+            auto const start      = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
@@ -245,17 +245,17 @@ namespace rocwmma
     template <typename DataT>
     struct AosVec<DataT, 8, 256>
     {
-        static constexpr uint32_t VW       = 8;
-        static constexpr uint32_t BlockDim = 256;
+        static constexpr uint32_t VW        = 8;
+        static constexpr uint32_t BlockDim  = 256;
         static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
         static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-        using VecType = VecT<DataT, VecSize>;
+        using VecType                       = VecT<DataT, VecSize>;
 
         ROCWMMA_DEVICE static inline auto genData()
         {
             auto const threadId   = (uint8_t)detail::threadId();
             auto const waveOffset = (threadId * VW / WAVE_SIZE) * BlockDim;
-            auto const start     = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
+            auto const start      = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
@@ -377,7 +377,7 @@ namespace rocwmma
     {
         static constexpr uint32_t VW       = 4;
         static constexpr uint32_t BlockDim = 16;
-        using VecType = VecT<DataT, VW>;
+        using VecType                      = VecT<DataT, VW>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
@@ -389,7 +389,7 @@ namespace rocwmma
                 start + 1,
                 start + 2,
                 start + 3,
-                };
+            };
         }
     };
 
@@ -398,7 +398,7 @@ namespace rocwmma
     {
         static constexpr uint32_t VW       = 4;
         static constexpr uint32_t BlockDim = 32;
-        using VecType = VecT<DataT, VW>;
+        using VecType                      = VecT<DataT, VW>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
@@ -411,25 +411,25 @@ namespace rocwmma
                 start + 1,
                 start + 2,
                 start + 3,
-                };
+            };
         }
     };
 
     template <typename DataT>
     struct AosVec<DataT, 4, 64>
     {
-        static constexpr uint32_t VW       = 4;
-        static constexpr uint32_t BlockDim = 64;
+        static constexpr uint32_t VW        = 4;
+        static constexpr uint32_t BlockDim  = 64;
         static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
         static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-        using VecType = VecT<DataT, VecSize>;
+        using VecType                       = VecT<DataT, VecSize>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
             auto const threadId   = (uint8_t)detail::threadId();
             auto const waveOffset = (threadId * VW / WAVE_SIZE) * BlockDim;
-            auto const start = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
-         
+            auto const start      = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
+
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
                 return VecType{
@@ -437,20 +437,20 @@ namespace rocwmma
                     start + 1,
                     start + 2,
                     start + 3,
-                    };
+                };
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
-            {                
-                return VecType {
+            {
+                return VecType{
                     start,
-                                            start + 1,
-                                            start + 2,
-                                            start + 3,
-                                            start + WAVE_SIZE * 1,
-                                            start + WAVE_SIZE * 1 + 1,
-                                            start + WAVE_SIZE * 1 + 2,
-                                            start + WAVE_SIZE * 1 + 3,
-                                            };
+                    start + 1,
+                    start + 2,
+                    start + 3,
+                    start + WAVE_SIZE * 1,
+                    start + WAVE_SIZE * 1 + 1,
+                    start + WAVE_SIZE * 1 + 2,
+                    start + WAVE_SIZE * 1 + 3,
+                };
             }
             else
             {
@@ -464,30 +464,30 @@ namespace rocwmma
     template <typename DataT>
     struct AosVec<DataT, 4, 128>
     {
-        static constexpr uint32_t VW       = 4;
-        static constexpr uint32_t BlockDim = 128;
+        static constexpr uint32_t VW        = 4;
+        static constexpr uint32_t BlockDim  = 128;
         static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
         static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-        using VecType = VecT<DataT, VecSize>;
+        using VecType                       = VecT<DataT, VecSize>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
             auto const threadId   = (uint8_t)detail::threadId();
             auto const waveOffset = (threadId * VW / WAVE_SIZE) * BlockDim;
-            auto const start     = threadId % (WAVE_SIZE / VW) * VW + waveOffset;            
+            auto const start      = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
                 return VecType{
                     start,
-                                            start + 1,
-                                            start + 2,
-                                            start + 3,
-                                            start + WAVE_SIZE * 1,
-                                            start + WAVE_SIZE * 1 + 1,
-                                            start + WAVE_SIZE * 1 + 2,
-                                            start + WAVE_SIZE * 1 + 3,
-                                            };
+                    start + 1,
+                    start + 2,
+                    start + 3,
+                    start + WAVE_SIZE * 1,
+                    start + WAVE_SIZE * 1 + 1,
+                    start + WAVE_SIZE * 1 + 2,
+                    start + WAVE_SIZE * 1 + 3,
+                };
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
             {
@@ -522,18 +522,18 @@ namespace rocwmma
     template <typename DataT>
     struct AosVec<DataT, 4, 256>
     {
-        static constexpr uint32_t VW       = 4;
-        static constexpr uint32_t BlockDim = 256;
+        static constexpr uint32_t VW        = 4;
+        static constexpr uint32_t BlockDim  = 256;
         static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
         static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-        using VecType = VecT<DataT, VecSize>;
+        using VecType                       = VecT<DataT, VecSize>;
 
         ROCWMMA_DEVICE static inline auto genData()
         {
             auto const threadId   = (uint8_t)detail::threadId();
             auto const waveOffset = (threadId * VW / WAVE_SIZE) * BlockDim;
-            auto const start     = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
-         
+            auto const start      = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
+
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
                 return VecType{
@@ -606,7 +606,7 @@ namespace rocwmma
     {
         static constexpr uint32_t VW       = 2;
         static constexpr uint32_t BlockDim = 16;
-        using VecType = VecT<DataT, VW>;
+        using VecType                      = VecT<DataT, VW>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
@@ -617,7 +617,7 @@ namespace rocwmma
             return VecType{
                 start,
                 start + 1,
-                 };
+            };
         }
     };
 
@@ -626,7 +626,7 @@ namespace rocwmma
     {
         static constexpr uint32_t VW       = 2;
         static constexpr uint32_t BlockDim = 32;
-        using VecType = VecT<DataT, VW>;
+        using VecType                      = VecT<DataT, VW>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
@@ -637,17 +637,17 @@ namespace rocwmma
             return VecType{
                 start,
                 start + 1,
-                };
+            };
         }
     };
     template <typename DataT>
     struct AosVec<DataT, 2, 64>
     {
-        static constexpr uint32_t VW       = 2;
-        static constexpr uint32_t BlockDim = 64;
+        static constexpr uint32_t VW        = 2;
+        static constexpr uint32_t BlockDim  = 64;
         static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
         static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-        using VecType = VecT<DataT, VecSize>;
+        using VecType                       = VecT<DataT, VecSize>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
@@ -660,16 +660,16 @@ namespace rocwmma
                 return VecType{
                     start,
                     start + 1,
-                     };
+                };
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
             {
                 return VecType{
-                     start,
-                     start + 1,
-                     start + WAVE_SIZE * 1,
-                     start + WAVE_SIZE * 1 + 1,
-                     };
+                    start,
+                    start + 1,
+                    start + WAVE_SIZE * 1,
+                    start + WAVE_SIZE * 1 + 1,
+                };
             }
             else
             {
@@ -682,25 +682,25 @@ namespace rocwmma
     template <typename DataT>
     struct AosVec<DataT, 2, 128>
     {
-        static constexpr uint32_t VW       = 2;
-        static constexpr uint32_t BlockDim = 128;
+        static constexpr uint32_t VW        = 2;
+        static constexpr uint32_t BlockDim  = 128;
         static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
         static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-        using VecType = VecT<DataT, VecSize>;
+        using VecType                       = VecT<DataT, VecSize>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
             auto const threadId   = (uint8_t)detail::threadId();
             auto const waveOffset = (threadId * VW / WAVE_SIZE) * BlockDim;
-            auto const start     = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
+            auto const start      = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
                 return VecType{
-                start,
-                start + 1,
-                start + WAVE_SIZE * 1,
-                start + WAVE_SIZE * 1 + 1,
+                    start,
+                    start + 1,
+                    start + WAVE_SIZE * 1,
+                    start + WAVE_SIZE * 1 + 1,
                 };
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
@@ -727,50 +727,50 @@ namespace rocwmma
     template <typename DataT>
     struct AosVec<DataT, 2, 256>
     {
-        static constexpr uint32_t VW       = 2;
-        static constexpr uint32_t BlockDim = 256;
+        static constexpr uint32_t VW        = 2;
+        static constexpr uint32_t BlockDim  = 256;
         static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
         static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-        using VecType = VecT<DataT, VecSize>;
+        using VecType                       = VecT<DataT, VecSize>;
 
         ROCWMMA_DEVICE static inline auto genData()
         {
             auto const threadId   = (uint8_t)detail::threadId();
             auto const waveOffset = (threadId * VW / WAVE_SIZE) * BlockDim;
-            auto const start     = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
+            auto const start      = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
                 return VecType{
-                start,
-                start + 1,
-                start + WAVE_SIZE * 1,
-                start + WAVE_SIZE * 1 + 1,
-                start + WAVE_SIZE * 2,
-                start + WAVE_SIZE * 2 + 1,
-                start + WAVE_SIZE * 3,
-                start + WAVE_SIZE * 3 + 1,
+                    start,
+                    start + 1,
+                    start + WAVE_SIZE * 1,
+                    start + WAVE_SIZE * 1 + 1,
+                    start + WAVE_SIZE * 2,
+                    start + WAVE_SIZE * 2 + 1,
+                    start + WAVE_SIZE * 3,
+                    start + WAVE_SIZE * 3 + 1,
                 };
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
             {
                 return VecType{
-                        start,
-                                 start + 1,
-                                 start + WAVE_SIZE * 1,
-                                 start + WAVE_SIZE * 1 + 1,
-                                 start + WAVE_SIZE * 2,
-                                 start + WAVE_SIZE * 2 + 1,
-                                 start + WAVE_SIZE * 3,
-                                 start + WAVE_SIZE * 3 + 1,
-                                 start + WAVE_SIZE * 4,
-                                 start + WAVE_SIZE * 4 + 1,
-                                 start + WAVE_SIZE * 5,
-                                 start + WAVE_SIZE * 5 + 1,
-                                 start + WAVE_SIZE * 6,
-                                 start + WAVE_SIZE * 6 + 1,
-                                 start + WAVE_SIZE * 7,
-                                 start + WAVE_SIZE * 7 + 1,
+                    start,
+                    start + 1,
+                    start + WAVE_SIZE * 1,
+                    start + WAVE_SIZE * 1 + 1,
+                    start + WAVE_SIZE * 2,
+                    start + WAVE_SIZE * 2 + 1,
+                    start + WAVE_SIZE * 3,
+                    start + WAVE_SIZE * 3 + 1,
+                    start + WAVE_SIZE * 4,
+                    start + WAVE_SIZE * 4 + 1,
+                    start + WAVE_SIZE * 5,
+                    start + WAVE_SIZE * 5 + 1,
+                    start + WAVE_SIZE * 6,
+                    start + WAVE_SIZE * 6 + 1,
+                    start + WAVE_SIZE * 7,
+                    start + WAVE_SIZE * 7 + 1,
                 };
             }
             else
@@ -788,14 +788,14 @@ namespace rocwmma
     {
         static constexpr uint32_t VW       = 8;
         static constexpr uint32_t BlockDim = 16;
-        using VecType = VecT<DataT, VW>;
+        using VecType                      = VecT<DataT, VW>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
             auto const threadId   = (uint8_t)detail::threadId();
             auto const waveOffset = threadId / BlockDim * VW * BlockDim;
             auto const start      = (threadId % BlockDim) % BlockDim + waveOffset;
-            
+
             return VecType{
                 start,
                 BlockDim + start,
@@ -814,7 +814,7 @@ namespace rocwmma
     {
         static constexpr uint32_t VW       = 8;
         static constexpr uint32_t BlockDim = 32;
-        using VecType = VecT<DataT, VW>;
+        using VecType                      = VecT<DataT, VW>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
@@ -822,26 +822,27 @@ namespace rocwmma
             auto const waveOffset = threadId / BlockDim * VW * BlockDim;
             auto const start      = (threadId % BlockDim) % BlockDim + waveOffset;
 
-            return VecType{start,
-                             BlockDim + start,
-                             BlockDim * 2 + start,
-                             BlockDim * 3 + start,
-                             BlockDim * 4 + start,
-                             BlockDim * 5 + start,
-                             BlockDim * 6 + start,
-                             BlockDim * 7 + start,
-                             };
+            return VecType{
+                start,
+                BlockDim + start,
+                BlockDim * 2 + start,
+                BlockDim * 3 + start,
+                BlockDim * 4 + start,
+                BlockDim * 5 + start,
+                BlockDim * 6 + start,
+                BlockDim * 7 + start,
+            };
         }
     };
 
     template <typename DataT>
     struct SoaVec<DataT, 8, 64>
     {
-        static constexpr uint32_t VW       = 8;
-        static constexpr uint32_t BlockDim = 64;
+        static constexpr uint32_t VW        = 8;
+        static constexpr uint32_t BlockDim  = 64;
         static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
         static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-        using VecType = VecT<DataT, VecSize>;
+        using VecType                       = VecT<DataT, VecSize>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
@@ -895,11 +896,11 @@ namespace rocwmma
     template <typename DataT>
     struct SoaVec<DataT, 8, 128>
     {
-        static constexpr uint32_t VW       = 8;
-        static constexpr uint32_t BlockDim = 128;
+        static constexpr uint32_t VW        = 8;
+        static constexpr uint32_t BlockDim  = 128;
         static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
         static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-        using VecType = VecT<DataT, VecSize>;
+        using VecType                       = VecT<DataT, VecSize>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
@@ -977,14 +978,14 @@ namespace rocwmma
     template <typename DataT>
     struct SoaVec<DataT, 8, 256>
     {
-        static constexpr uint32_t VW       = 8;
-        static constexpr uint32_t BlockDim = 256;
+        static constexpr uint32_t VW        = 8;
+        static constexpr uint32_t BlockDim  = 256;
         static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
         static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-        using VecType = VecT<DataT, VecSize>;
+        using VecType                       = VecT<DataT, VecSize>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
-        {            
+        {
             auto const threadId   = (uint8_t)detail::threadId();
             auto const waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
             auto const start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
@@ -1109,20 +1110,20 @@ namespace rocwmma
     {
         static constexpr uint32_t VW       = 4;
         static constexpr uint32_t BlockDim = 16;
-        using VecType = VecT<DataT, VW>;
+        using VecType                      = VecT<DataT, VW>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
             auto const threadId   = (uint8_t)detail::threadId();
             auto const waveOffset = threadId / BlockDim * VW * BlockDim;
             auto const start      = (threadId % BlockDim) % BlockDim + waveOffset;
-            
+
             return VecType{
                 start,
                 BlockDim + start,
                 BlockDim * 2 + start,
                 BlockDim * 3 + start,
-                };
+            };
         }
     };
 
@@ -1131,31 +1132,31 @@ namespace rocwmma
     {
         static constexpr uint32_t VW       = 4;
         static constexpr uint32_t BlockDim = 32;
-        using VecType = VecT<DataT, VW>;
+        using VecType                      = VecT<DataT, VW>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
             auto const threadId   = (uint8_t)detail::threadId();
             auto const waveOffset = threadId / BlockDim * VW * BlockDim;
             auto const start      = (threadId % BlockDim) % BlockDim + waveOffset;
-            
+
             return VecType{
                 start,
                 BlockDim + start,
                 BlockDim * 2 + start,
                 BlockDim * 3 + start,
-                };
+            };
         }
     };
 
     template <typename DataT>
     struct SoaVec<DataT, 4, 64>
     {
-        static constexpr uint32_t VW       = 4;
-        static constexpr uint32_t BlockDim = 64;
+        static constexpr uint32_t VW        = 4;
+        static constexpr uint32_t BlockDim  = 64;
         static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
         static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-        using VecType = VecT<DataT, VecSize>;
+        using VecType                       = VecT<DataT, VecSize>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
@@ -1170,7 +1171,7 @@ namespace rocwmma
                     BlockDim + start,
                     BlockDim * 2 + start,
                     BlockDim * 3 + start,
-                    };
+                };
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
             {
@@ -1183,7 +1184,7 @@ namespace rocwmma
                     WAVE_SIZE + BlockDim + start,
                     WAVE_SIZE + BlockDim * 2 + start,
                     WAVE_SIZE + BlockDim * 3 + start,
-                    };
+                };
             }
             else
             {
@@ -1197,12 +1198,11 @@ namespace rocwmma
     template <typename DataT>
     struct SoaVec<DataT, 4, 128>
     {
-
-        static constexpr uint32_t VW       = 4;
-        static constexpr uint32_t BlockDim = 128;
+        static constexpr uint32_t VW        = 4;
+        static constexpr uint32_t BlockDim  = 128;
         static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
         static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-        using VecType = VecT<DataT, VecSize>;
+        using VecType                       = VecT<DataT, VecSize>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
@@ -1211,7 +1211,7 @@ namespace rocwmma
             auto const start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
-            {                
+            {
                 return VecType{
                     start,
                     BlockDim + start,
@@ -1256,11 +1256,11 @@ namespace rocwmma
     template <typename DataT>
     struct SoaVec<DataT, 4, 256>
     {
-        static constexpr uint32_t VW       = 4;
-        static constexpr uint32_t BlockDim = 256;
+        static constexpr uint32_t VW        = 4;
+        static constexpr uint32_t BlockDim  = 256;
         static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
         static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-        using VecType = VecT<DataT, VecSize>;
+        using VecType                       = VecT<DataT, VecSize>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
@@ -1340,18 +1340,18 @@ namespace rocwmma
     {
         static constexpr uint32_t VW       = 2;
         static constexpr uint32_t BlockDim = 16;
-        using VecType = VecT<DataT, VW>;
+        using VecType                      = VecT<DataT, VW>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
             auto const threadId   = (uint8_t)detail::threadId();
             auto const waveOffset = threadId / BlockDim * VW * BlockDim;
             auto const start      = (threadId % BlockDim) % BlockDim + waveOffset;
-            
+
             return VecType{
                 start,
-                 BlockDim + start,
-                 };
+                BlockDim + start,
+            };
         }
     };
 
@@ -1360,29 +1360,29 @@ namespace rocwmma
     {
         static constexpr uint32_t VW       = 2;
         static constexpr uint32_t BlockDim = 32;
-        using VecType = VecT<DataT, VW>;
+        using VecType                      = VecT<DataT, VW>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
             auto const threadId   = (uint8_t)detail::threadId();
             auto const waveOffset = threadId / BlockDim * VW * BlockDim;
             auto const start      = (threadId % BlockDim) % BlockDim + waveOffset;
-            
+
             return VecType{
                 start,
                 BlockDim + start,
-                };
+            };
         }
     };
 
     template <typename DataT>
     struct SoaVec<DataT, 2, 64>
     {
-        static constexpr uint32_t VW       = 2;
-        static constexpr uint32_t BlockDim = 64;
+        static constexpr uint32_t VW        = 2;
+        static constexpr uint32_t BlockDim  = 64;
         static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
         static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-        using VecType = VecT<DataT, VecSize>;
+        using VecType                       = VecT<DataT, VecSize>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
@@ -1395,16 +1395,16 @@ namespace rocwmma
                 return VecType{
                     start,
                     BlockDim + start,
-                     };
+                };
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
-            {                
+            {
                 return VecType{
                     start,
                     BlockDim + start,
                     WAVE_SIZE + start,
                     WAVE_SIZE + BlockDim + start,
-                    };
+                };
             }
             else
             {
@@ -1418,11 +1418,11 @@ namespace rocwmma
     template <typename DataT>
     struct SoaVec<DataT, 2, 128>
     {
-        static constexpr uint32_t VW       = 2;
-        static constexpr uint32_t BlockDim = 128;
+        static constexpr uint32_t VW        = 2;
+        static constexpr uint32_t BlockDim  = 128;
         static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
         static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-        using VecType = VecT<DataT, VecSize>;
+        using VecType                       = VecT<DataT, VecSize>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
@@ -1431,13 +1431,13 @@ namespace rocwmma
             auto const start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
-            {                
+            {
                 return VecType{
                     start,
                     BlockDim + start,
                     WAVE_SIZE + start,
                     WAVE_SIZE + BlockDim + start,
-                    };
+                };
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
             {
@@ -1464,11 +1464,11 @@ namespace rocwmma
     template <typename DataT>
     struct SoaVec<DataT, 2, 256>
     {
-        static constexpr uint32_t VW       = 2;
-        static constexpr uint32_t BlockDim = 256;
+        static constexpr uint32_t VW        = 2;
+        static constexpr uint32_t BlockDim  = 256;
         static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
         static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-        using VecType = VecT<DataT, VecSize>;
+        using VecType                       = VecT<DataT, VecSize>;
 
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
@@ -1478,38 +1478,38 @@ namespace rocwmma
 
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
-                
+
                 return VecType{
                     start,
-                                 BlockDim + start,
-                                 WAVE_SIZE + start,
-                                 WAVE_SIZE + BlockDim + start,
-                                 WAVE_SIZE * 2 + start,
-                                 WAVE_SIZE * 2 + BlockDim + start,
-                                 WAVE_SIZE * 3 + start,
-                                 WAVE_SIZE * 3 + BlockDim + start,
-                                 };
+                    BlockDim + start,
+                    WAVE_SIZE + start,
+                    WAVE_SIZE + BlockDim + start,
+                    WAVE_SIZE * 2 + start,
+                    WAVE_SIZE * 2 + BlockDim + start,
+                    WAVE_SIZE * 3 + start,
+                    WAVE_SIZE * 3 + BlockDim + start,
+                };
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
             {
                 return VecType{
                     start,
-                                 BlockDim + start,
-                                 WAVE_SIZE + start,
-                                 WAVE_SIZE + BlockDim + start,
-                                 WAVE_SIZE * 2 + start,
-                                 WAVE_SIZE * 2 + BlockDim + start,
-                                 WAVE_SIZE * 3 + start,
-                                 WAVE_SIZE * 3 + BlockDim + start,
-                                 WAVE_SIZE * 4 + start,
-                                 WAVE_SIZE * 4 + BlockDim + start,
-                                 WAVE_SIZE * 5 + start,
-                                 WAVE_SIZE * 5 + BlockDim + start,
-                                 WAVE_SIZE * 6 + start,
-                                 WAVE_SIZE * 6 + BlockDim + start,
-                                 WAVE_SIZE * 7 + start,
-                                 WAVE_SIZE * 7 + BlockDim + start,
-                                 };
+                    BlockDim + start,
+                    WAVE_SIZE + start,
+                    WAVE_SIZE + BlockDim + start,
+                    WAVE_SIZE * 2 + start,
+                    WAVE_SIZE * 2 + BlockDim + start,
+                    WAVE_SIZE * 3 + start,
+                    WAVE_SIZE * 3 + BlockDim + start,
+                    WAVE_SIZE * 4 + start,
+                    WAVE_SIZE * 4 + BlockDim + start,
+                    WAVE_SIZE * 5 + start,
+                    WAVE_SIZE * 5 + BlockDim + start,
+                    WAVE_SIZE * 6 + start,
+                    WAVE_SIZE * 6 + BlockDim + start,
+                    WAVE_SIZE * 7 + start,
+                    WAVE_SIZE * 7 + BlockDim + start,
+                };
             }
             else
             {

--- a/test/unit/transforms_test/device/transforms.hpp
+++ b/test/unit/transforms_test/device/transforms.hpp
@@ -652,8 +652,8 @@ namespace rocwmma
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
             auto const threadId   = (uint8_t)detail::threadId();
-            auto const waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
-            auto const start      = (threadId % WAVE_SIZE) * VW + waveOffset;
+            auto const waveOffset = (threadId * VW / WAVE_SIZE) * BlockDim;
+            auto const start      = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
             {

--- a/test/unit/transforms_test/device/transforms.hpp
+++ b/test/unit/transforms_test/device/transforms.hpp
@@ -53,73 +53,86 @@ namespace rocwmma
     template <typename DataT>
     struct AosVec<DataT, 8, 16>
     {
+        static constexpr uint32_t VW       = 8;
+        static constexpr uint32_t BlockDim = 16;
+        using VecType = VecT<DataT, VW>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 8;
-            constexpr uint32_t BlockDim = 16;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = threadId / BlockDim * VW * BlockDim;
+            auto const start      = (threadId % BlockDim) * VW + waveOffset;
 
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / BlockDim * VW * BlockDim;
-            auto           start      = (threadId % BlockDim) * VW + waveOffset;
-
-            using VecType = VecT<DataT, VW>;
-            VecType v     = {
-                start, start + 1, start + 2, start + 3, start + 4, start + 5, start + 6, start + 7};
-            return v;
+            return VecType{
+                start,
+                start + 1,
+                start + 2,
+                start + 3,
+                start + 4,
+                start + 5,
+                start + 6,
+                start + 7,
+                };
         }
     };
 
     template <typename DataT>
     struct AosVec<DataT, 8, 32>
     {
+        static constexpr uint32_t VW       = 8;
+        static constexpr uint32_t BlockDim = 32;
+        using VecType = VecT<DataT, VW>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 8;
-            constexpr uint32_t BlockDim = 32;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = threadId / BlockDim * VW * BlockDim;
+            auto const start      = (threadId % BlockDim) * VW + waveOffset;
 
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / BlockDim * VW * BlockDim;
-            auto           start      = (threadId % BlockDim) * VW + waveOffset;
-
-            using VecType = VecT<DataT, VW>;
-            VecType v     = {
-                start, start + 1, start + 2, start + 3, start + 4, start + 5, start + 6, start + 7};
-            return v;
+            return VecType {
+                start,
+                start + 1,
+                start + 2,
+                start + 3,
+                start + 4,
+                start + 5,
+                start + 6,
+                start + 7,
+                };
         }
     };
 
     template <typename DataT>
     struct AosVec<DataT, 8, 64>
     {
+        static constexpr uint32_t VW       = 8;
+        static constexpr uint32_t BlockDim = 64;
+        static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+        static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
+        using VecType            = VecT<DataT, VecSize>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 8;
-            constexpr uint32_t BlockDim = 64;
-
-            constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-            constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
-            auto           start      = (threadId % WAVE_SIZE) * VW + waveOffset;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = (threadId * VW / WAVE_SIZE) * BlockDim;
+            auto const start     = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {start,
+                return VecType{
+                    start,
                                  start + 1,
                                  start + 2,
                                  start + 3,
                                  start + 4,
                                  start + 5,
                                  start + 6,
-                                 start + 7};
-                return v;
+                                 start + 7,
+                                 };
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {
+                return VecType{
                     start,
                     start + 1,
                     start + 2,
@@ -128,22 +141,20 @@ namespace rocwmma
                     start + 5,
                     start + 6,
                     start + 7,
-                    start + VW * WAVE_SIZE,
-                    start + 1 + VW * WAVE_SIZE,
-                    start + 2 + VW * WAVE_SIZE,
-                    start + 3 + VW * WAVE_SIZE,
-                    start + 4 + VW * WAVE_SIZE,
-                    start + 5 + VW * WAVE_SIZE,
-                    start + 6 + VW * WAVE_SIZE,
-                    start + 7 + VW * WAVE_SIZE,
+                    start + WAVE_SIZE,
+                    start + WAVE_SIZE + 1,
+                    start + WAVE_SIZE + 2,
+                    start + WAVE_SIZE + 3,
+                    start + WAVE_SIZE + 4,
+                    start + WAVE_SIZE + 5,
+                    start + WAVE_SIZE + 6,
+                    start + WAVE_SIZE + 7,
                 };
-                return v;
             }
             else
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, VW>;
                 return VecType();
             }
         }
@@ -152,22 +163,21 @@ namespace rocwmma
     template <typename DataT>
     struct AosVec<DataT, 8, 128>
     {
+        static constexpr uint32_t VW       = 8;
+        static constexpr uint32_t BlockDim = 128;
+        static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+        static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
+        using VecType = VecT<DataT, VecSize>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 8;
-            constexpr uint32_t BlockDim = 128;
-
-            constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-            constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
-            auto           start      = (threadId % WAVE_SIZE) * VW + waveOffset;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = (threadId * VW / WAVE_SIZE) * BlockDim;
+            auto const start     = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {
+                return VecType{
                     start,
                     start + 1,
                     start + 2,
@@ -176,21 +186,19 @@ namespace rocwmma
                     start + 5,
                     start + 6,
                     start + 7,
-                    start + VW * WAVE_SIZE,
-                    start + 1 + VW * WAVE_SIZE,
-                    start + 2 + VW * WAVE_SIZE,
-                    start + 3 + VW * WAVE_SIZE,
-                    start + 4 + VW * WAVE_SIZE,
-                    start + 5 + VW * WAVE_SIZE,
-                    start + 6 + VW * WAVE_SIZE,
-                    start + 7 + VW * WAVE_SIZE,
+                    start + WAVE_SIZE,
+                    start + WAVE_SIZE + 1,
+                    start + WAVE_SIZE + 2,
+                    start + WAVE_SIZE + 3,
+                    start + WAVE_SIZE + 4,
+                    start + WAVE_SIZE + 5,
+                    start + WAVE_SIZE + 6,
+                    start + WAVE_SIZE + 7,
                 };
-                return v;
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {
+                return VecType{
                     start,
                     start + 1,
                     start + 2,
@@ -199,38 +207,36 @@ namespace rocwmma
                     start + 5,
                     start + 6,
                     start + 7,
-                    start + VW * WAVE_SIZE,
-                    start + 1 + VW * WAVE_SIZE,
-                    start + 2 + VW * WAVE_SIZE,
-                    start + 3 + VW * WAVE_SIZE,
-                    start + 4 + VW * WAVE_SIZE,
-                    start + 5 + VW * WAVE_SIZE,
-                    start + 6 + VW * WAVE_SIZE,
-                    start + 7 + VW * WAVE_SIZE,
-                    start + VW * WAVE_SIZE * 2,
-                    start + 1 + VW * WAVE_SIZE * 2,
-                    start + 2 + VW * WAVE_SIZE * 2,
-                    start + 3 + VW * WAVE_SIZE * 2,
-                    start + 4 + VW * WAVE_SIZE * 2,
-                    start + 5 + VW * WAVE_SIZE * 2,
-                    start + 6 + VW * WAVE_SIZE * 2,
-                    start + 7 + VW * WAVE_SIZE * 2,
-                    start + VW * WAVE_SIZE * 3,
-                    start + 1 + VW * WAVE_SIZE * 3,
-                    start + 2 + VW * WAVE_SIZE * 3,
-                    start + 3 + VW * WAVE_SIZE * 3,
-                    start + 4 + VW * WAVE_SIZE * 3,
-                    start + 5 + VW * WAVE_SIZE * 3,
-                    start + 6 + VW * WAVE_SIZE * 3,
-                    start + 7 + VW * WAVE_SIZE * 3,
+                    start + WAVE_SIZE * 1,
+                    start + WAVE_SIZE * 1 + 1,
+                    start + WAVE_SIZE * 1 + 2,
+                    start + WAVE_SIZE * 1 + 3,
+                    start + WAVE_SIZE * 1 + 4,
+                    start + WAVE_SIZE * 1 + 5,
+                    start + WAVE_SIZE * 1 + 6,
+                    start + WAVE_SIZE * 1 + 7,
+                    start + WAVE_SIZE * 2,
+                    start + WAVE_SIZE * 2 + 1,
+                    start + WAVE_SIZE * 2 + 2,
+                    start + WAVE_SIZE * 2 + 3,
+                    start + WAVE_SIZE * 2 + 4,
+                    start + WAVE_SIZE * 2 + 5,
+                    start + WAVE_SIZE * 2 + 6,
+                    start + WAVE_SIZE * 2 + 7,
+                    start + WAVE_SIZE * 3,
+                    start + WAVE_SIZE * 3 + 1,
+                    start + WAVE_SIZE * 3 + 2,
+                    start + WAVE_SIZE * 3 + 3,
+                    start + WAVE_SIZE * 3 + 4,
+                    start + WAVE_SIZE * 3 + 5,
+                    start + WAVE_SIZE * 3 + 6,
+                    start + WAVE_SIZE * 3 + 7,
                 };
-                return v;
             }
             else
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, VW * 2>;
                 return VecType();
             }
         }
@@ -239,22 +245,21 @@ namespace rocwmma
     template <typename DataT>
     struct AosVec<DataT, 8, 256>
     {
+        static constexpr uint32_t VW       = 8;
+        static constexpr uint32_t BlockDim = 256;
+        static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+        static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
+        using VecType = VecT<DataT, VecSize>;
+
         ROCWMMA_DEVICE static inline auto genData()
         {
-            constexpr uint32_t VW       = 8;
-            constexpr uint32_t BlockDim = 256;
-
-            constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-            constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
-            auto           start      = (threadId % WAVE_SIZE) * VW + waveOffset;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = (threadId * VW / WAVE_SIZE) * BlockDim;
+            auto const start     = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {
+                return VecType{
                     start,
                     start + 1,
                     start + 2,
@@ -263,37 +268,35 @@ namespace rocwmma
                     start + 5,
                     start + 6,
                     start + 7,
-                    start + VW * WAVE_SIZE,
-                    start + 1 + VW * WAVE_SIZE,
-                    start + 2 + VW * WAVE_SIZE,
-                    start + 3 + VW * WAVE_SIZE,
-                    start + 4 + VW * WAVE_SIZE,
-                    start + 5 + VW * WAVE_SIZE,
-                    start + 6 + VW * WAVE_SIZE,
-                    start + 7 + VW * WAVE_SIZE,
-                    start + VW * WAVE_SIZE * 2,
-                    start + 1 + VW * WAVE_SIZE * 2,
-                    start + 2 + VW * WAVE_SIZE * 2,
-                    start + 3 + VW * WAVE_SIZE * 2,
-                    start + 4 + VW * WAVE_SIZE * 2,
-                    start + 5 + VW * WAVE_SIZE * 2,
-                    start + 6 + VW * WAVE_SIZE * 2,
-                    start + 7 + VW * WAVE_SIZE * 2,
-                    start + VW * WAVE_SIZE * 3,
-                    start + 1 + VW * WAVE_SIZE * 3,
-                    start + 2 + VW * WAVE_SIZE * 3,
-                    start + 3 + VW * WAVE_SIZE * 3,
-                    start + 4 + VW * WAVE_SIZE * 3,
-                    start + 5 + VW * WAVE_SIZE * 3,
-                    start + 6 + VW * WAVE_SIZE * 3,
-                    start + 7 + VW * WAVE_SIZE * 3,
+                    start + WAVE_SIZE * 1,
+                    start + WAVE_SIZE * 1 + 1,
+                    start + WAVE_SIZE * 1 + 2,
+                    start + WAVE_SIZE * 1 + 3,
+                    start + WAVE_SIZE * 1 + 4,
+                    start + WAVE_SIZE * 1 + 5,
+                    start + WAVE_SIZE * 1 + 6,
+                    start + WAVE_SIZE * 1 + 7,
+                    start + WAVE_SIZE * 2,
+                    start + WAVE_SIZE * 2 + 1,
+                    start + WAVE_SIZE * 2 + 2,
+                    start + WAVE_SIZE * 2 + 3,
+                    start + WAVE_SIZE * 2 + 4,
+                    start + WAVE_SIZE * 2 + 5,
+                    start + WAVE_SIZE * 2 + 6,
+                    start + WAVE_SIZE * 2 + 7,
+                    start + WAVE_SIZE * 3,
+                    start + WAVE_SIZE * 3 + 1,
+                    start + WAVE_SIZE * 3 + 2,
+                    start + WAVE_SIZE * 3 + 3,
+                    start + WAVE_SIZE * 3 + 4,
+                    start + WAVE_SIZE * 3 + 5,
+                    start + WAVE_SIZE * 3 + 6,
+                    start + WAVE_SIZE * 3 + 7,
                 };
-                return v;
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {
+                return VecType{
                     start,
                     start + 1,
                     start + 2,
@@ -302,70 +305,68 @@ namespace rocwmma
                     start + 5,
                     start + 6,
                     start + 7,
-                    start + VW * WAVE_SIZE,
-                    start + 1 + VW * WAVE_SIZE,
-                    start + 2 + VW * WAVE_SIZE,
-                    start + 3 + VW * WAVE_SIZE,
-                    start + 4 + VW * WAVE_SIZE,
-                    start + 5 + VW * WAVE_SIZE,
-                    start + 6 + VW * WAVE_SIZE,
-                    start + 7 + VW * WAVE_SIZE,
-                    start + VW * WAVE_SIZE * 2,
-                    start + 1 + VW * WAVE_SIZE * 2,
-                    start + 2 + VW * WAVE_SIZE * 2,
-                    start + 3 + VW * WAVE_SIZE * 2,
-                    start + 4 + VW * WAVE_SIZE * 2,
-                    start + 5 + VW * WAVE_SIZE * 2,
-                    start + 6 + VW * WAVE_SIZE * 2,
-                    start + 7 + VW * WAVE_SIZE * 2,
-                    start + VW * WAVE_SIZE * 3,
-                    start + 1 + VW * WAVE_SIZE * 3,
-                    start + 2 + VW * WAVE_SIZE * 3,
-                    start + 3 + VW * WAVE_SIZE * 3,
-                    start + 4 + VW * WAVE_SIZE * 3,
-                    start + 5 + VW * WAVE_SIZE * 3,
-                    start + 6 + VW * WAVE_SIZE * 3,
-                    start + 7 + VW * WAVE_SIZE * 3,
-                    start + VW * WAVE_SIZE * 4,
-                    start + 1 + VW * WAVE_SIZE * 4,
-                    start + 2 + VW * WAVE_SIZE * 4,
-                    start + 3 + VW * WAVE_SIZE * 4,
-                    start + 4 + VW * WAVE_SIZE * 4,
-                    start + 5 + VW * WAVE_SIZE * 4,
-                    start + 6 + VW * WAVE_SIZE * 4,
-                    start + 7 + VW * WAVE_SIZE * 4,
-                    start + VW * WAVE_SIZE * 5,
-                    start + 1 + VW * WAVE_SIZE * 5,
-                    start + 2 + VW * WAVE_SIZE * 5,
-                    start + 3 + VW * WAVE_SIZE * 5,
-                    start + 4 + VW * WAVE_SIZE * 5,
-                    start + 5 + VW * WAVE_SIZE * 5,
-                    start + 6 + VW * WAVE_SIZE * 5,
-                    start + 7 + VW * WAVE_SIZE * 5,
-                    start + VW * WAVE_SIZE * 6,
-                    start + 1 + VW * WAVE_SIZE * 6,
-                    start + 2 + VW * WAVE_SIZE * 6,
-                    start + 3 + VW * WAVE_SIZE * 6,
-                    start + 4 + VW * WAVE_SIZE * 6,
-                    start + 5 + VW * WAVE_SIZE * 6,
-                    start + 6 + VW * WAVE_SIZE * 6,
-                    start + 7 + VW * WAVE_SIZE * 6,
-                    start + VW * WAVE_SIZE * 7,
-                    start + 1 + VW * WAVE_SIZE * 7,
-                    start + 2 + VW * WAVE_SIZE * 7,
-                    start + 3 + VW * WAVE_SIZE * 7,
-                    start + 4 + VW * WAVE_SIZE * 7,
-                    start + 5 + VW * WAVE_SIZE * 7,
-                    start + 6 + VW * WAVE_SIZE * 7,
-                    start + 7 + VW * WAVE_SIZE * 7,
+                    start + WAVE_SIZE * 1,
+                    start + WAVE_SIZE * 1 + 1,
+                    start + WAVE_SIZE * 1 + 2,
+                    start + WAVE_SIZE * 1 + 3,
+                    start + WAVE_SIZE * 1 + 4,
+                    start + WAVE_SIZE * 1 + 5,
+                    start + WAVE_SIZE * 1 + 6,
+                    start + WAVE_SIZE * 1 + 7,
+                    start + WAVE_SIZE * 2,
+                    start + WAVE_SIZE * 2 + 1,
+                    start + WAVE_SIZE * 2 + 2,
+                    start + WAVE_SIZE * 2 + 3,
+                    start + WAVE_SIZE * 2 + 4,
+                    start + WAVE_SIZE * 2 + 5,
+                    start + WAVE_SIZE * 2 + 6,
+                    start + WAVE_SIZE * 2 + 7,
+                    start + WAVE_SIZE * 3,
+                    start + WAVE_SIZE * 3 + 1,
+                    start + WAVE_SIZE * 3 + 2,
+                    start + WAVE_SIZE * 3 + 3,
+                    start + WAVE_SIZE * 3 + 4,
+                    start + WAVE_SIZE * 3 + 5,
+                    start + WAVE_SIZE * 3 + 6,
+                    start + WAVE_SIZE * 3 + 7,
+                    start + WAVE_SIZE * 4,
+                    start + WAVE_SIZE * 4 + 1,
+                    start + WAVE_SIZE * 4 + 2,
+                    start + WAVE_SIZE * 4 + 3,
+                    start + WAVE_SIZE * 4 + 4,
+                    start + WAVE_SIZE * 4 + 5,
+                    start + WAVE_SIZE * 4 + 6,
+                    start + WAVE_SIZE * 4 + 7,
+                    start + WAVE_SIZE * 5,
+                    start + WAVE_SIZE * 5 + 1,
+                    start + WAVE_SIZE * 5 + 2,
+                    start + WAVE_SIZE * 5 + 3,
+                    start + WAVE_SIZE * 5 + 4,
+                    start + WAVE_SIZE * 5 + 5,
+                    start + WAVE_SIZE * 5 + 6,
+                    start + WAVE_SIZE * 5 + 7,
+                    start + WAVE_SIZE * 6,
+                    start + WAVE_SIZE * 6 + 1,
+                    start + WAVE_SIZE * 6 + 2,
+                    start + WAVE_SIZE * 6 + 3,
+                    start + WAVE_SIZE * 6 + 4,
+                    start + WAVE_SIZE * 6 + 5,
+                    start + WAVE_SIZE * 6 + 6,
+                    start + WAVE_SIZE * 6 + 7,
+                    start + WAVE_SIZE * 7,
+                    start + WAVE_SIZE * 7 + 1,
+                    start + WAVE_SIZE * 7 + 2,
+                    start + WAVE_SIZE * 7 + 3,
+                    start + WAVE_SIZE * 7 + 4,
+                    start + WAVE_SIZE * 7 + 5,
+                    start + WAVE_SIZE * 7 + 6,
+                    start + WAVE_SIZE * 7 + 7,
                 };
-                return v;
             }
             else
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, VW * 4>;
                 return VecType();
             }
         }
@@ -374,78 +375,87 @@ namespace rocwmma
     template <typename DataT>
     struct AosVec<DataT, 4, 16>
     {
+        static constexpr uint32_t VW       = 4;
+        static constexpr uint32_t BlockDim = 16;
+        using VecType = VecT<DataT, VW>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 4;
-            constexpr uint32_t BlockDim = 16;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / BlockDim * VW * BlockDim;
-            auto           start      = (threadId % BlockDim) * VW + waveOffset;
-
-            using VecType = VecT<DataT, VW>;
-            VecType v     = {start, start + 1, start + 2, start + 3};
-            return v;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = threadId / BlockDim * VW * BlockDim;
+            auto const start      = (threadId % BlockDim) * VW + waveOffset;
+            return VecType{
+                start,
+                start + 1,
+                start + 2,
+                start + 3,
+                };
         }
     };
 
     template <typename DataT>
     struct AosVec<DataT, 4, 32>
     {
+        static constexpr uint32_t VW       = 4;
+        static constexpr uint32_t BlockDim = 32;
+        using VecType = VecT<DataT, VW>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 4;
-            constexpr uint32_t BlockDim = 32;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = threadId / BlockDim * VW * BlockDim;
+            auto const start      = (threadId % BlockDim) * VW + waveOffset;
 
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / BlockDim * VW * BlockDim;
-            auto           start      = (threadId % BlockDim) * VW + waveOffset;
-
-            using VecType = VecT<DataT, VW>;
-            VecType v     = {start, start + 1, start + 2, start + 3};
-            return v;
+            return VecType{
+                start,
+                start + 1,
+                start + 2,
+                start + 3,
+                };
         }
     };
 
     template <typename DataT>
     struct AosVec<DataT, 4, 64>
     {
+        static constexpr uint32_t VW       = 4;
+        static constexpr uint32_t BlockDim = 64;
+        static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+        static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
+        using VecType = VecT<DataT, VecSize>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 4;
-            constexpr uint32_t BlockDim = 64;
-
-            constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-            constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
-            auto           start      = (threadId % WAVE_SIZE) * VW + waveOffset;
-
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = (threadId * VW / WAVE_SIZE) * BlockDim;
+            auto const start = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
+         
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {start, start + 1, start + 2, start + 3};
-                return v;
+                return VecType{
+                    start,
+                    start + 1,
+                    start + 2,
+                    start + 3,
+                    };
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
-            {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {start,
-                                 start + 1,
-                                 start + 2,
-                                 start + 3,
-                                 start + VW * WAVE_SIZE,
-                                 start + 1 + VW * WAVE_SIZE,
-                                 start + 2 + VW * WAVE_SIZE,
-                                 start + 3 + VW * WAVE_SIZE};
-                return v;
+            {                
+                return VecType {
+                    start,
+                                            start + 1,
+                                            start + 2,
+                                            start + 3,
+                                            start + WAVE_SIZE * 1,
+                                            start + WAVE_SIZE * 1 + 1,
+                                            start + WAVE_SIZE * 1 + 2,
+                                            start + WAVE_SIZE * 1 + 3,
+                                            };
             }
             else
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, VW>;
                 return VecType();
             }
         }
@@ -454,57 +464,56 @@ namespace rocwmma
     template <typename DataT>
     struct AosVec<DataT, 4, 128>
     {
+        static constexpr uint32_t VW       = 4;
+        static constexpr uint32_t BlockDim = 128;
+        static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+        static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
+        using VecType = VecT<DataT, VecSize>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 4;
-            constexpr uint32_t BlockDim = 128;
-
-            constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-            constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
-            auto           start      = (threadId % WAVE_SIZE) * VW + waveOffset;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = (threadId * VW / WAVE_SIZE) * BlockDim;
+            auto const start     = threadId % (WAVE_SIZE / VW) * VW + waveOffset;            
 
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {start,
-                                 start + 1,
-                                 start + 2,
-                                 start + 3,
-                                 start + VW * WAVE_SIZE,
-                                 start + 1 + VW * WAVE_SIZE,
-                                 start + 2 + VW * WAVE_SIZE,
-                                 start + 3 + VW * WAVE_SIZE};
-                return v;
+                return VecType{
+                    start,
+                                            start + 1,
+                                            start + 2,
+                                            start + 3,
+                                            start + WAVE_SIZE * 1,
+                                            start + WAVE_SIZE * 1 + 1,
+                                            start + WAVE_SIZE * 1 + 2,
+                                            start + WAVE_SIZE * 1 + 3,
+                                            };
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {start,
-                                 start + 1,
-                                 start + 2,
-                                 start + 3,
-                                 start + VW * WAVE_SIZE,
-                                 start + 1 + VW * WAVE_SIZE,
-                                 start + 2 + VW * WAVE_SIZE,
-                                 start + 3 + VW * WAVE_SIZE,
-                                 start + VW * WAVE_SIZE * 2,
-                                 start + 1 + VW * WAVE_SIZE * 2,
-                                 start + 2 + VW * WAVE_SIZE * 2,
-                                 start + 3 + VW * WAVE_SIZE * 2,
-                                 start + VW * WAVE_SIZE * 3,
-                                 start + 1 + VW * WAVE_SIZE * 3,
-                                 start + 2 + VW * WAVE_SIZE * 3,
-                                 start + 3 + VW * WAVE_SIZE * 3};
-                return v;
+                return VecType{
+                    start,
+                    start + 1,
+                    start + 2,
+                    start + 3,
+                    start + WAVE_SIZE * 1,
+                    start + WAVE_SIZE * 1 + 1,
+                    start + WAVE_SIZE * 1 + 2,
+                    start + WAVE_SIZE * 1 + 3,
+                    start + WAVE_SIZE * 2,
+                    start + WAVE_SIZE * 2 + 1,
+                    start + WAVE_SIZE * 2 + 2,
+                    start + WAVE_SIZE * 2 + 3,
+                    start + WAVE_SIZE * 3,
+                    start + WAVE_SIZE * 3 + 1,
+                    start + WAVE_SIZE * 3 + 2,
+                    start + WAVE_SIZE * 3 + 3,
+                };
             }
             else
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, VW * 2>;
                 return VecType();
             }
         }
@@ -513,83 +522,80 @@ namespace rocwmma
     template <typename DataT>
     struct AosVec<DataT, 4, 256>
     {
+        static constexpr uint32_t VW       = 4;
+        static constexpr uint32_t BlockDim = 256;
+        static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+        static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
+        using VecType = VecT<DataT, VecSize>;
+
         ROCWMMA_DEVICE static inline auto genData()
         {
-            constexpr uint32_t VW       = 4;
-            constexpr uint32_t BlockDim = 256;
-
-            constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-            constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
-            auto           start      = (threadId % WAVE_SIZE) * VW + waveOffset;
-
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = (threadId * VW / WAVE_SIZE) * BlockDim;
+            auto const start     = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
+         
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {start,
-                                 start + 1,
-                                 start + 2,
-                                 start + 3,
-                                 start + VW * WAVE_SIZE,
-                                 start + 1 + VW * WAVE_SIZE,
-                                 start + 2 + VW * WAVE_SIZE,
-                                 start + 3 + VW * WAVE_SIZE,
-                                 start + VW * WAVE_SIZE * 2,
-                                 start + 1 + VW * WAVE_SIZE * 2,
-                                 start + 2 + VW * WAVE_SIZE * 2,
-                                 start + 3 + VW * WAVE_SIZE * 2,
-                                 start + VW * WAVE_SIZE * 3,
-                                 start + 1 + VW * WAVE_SIZE * 3,
-                                 start + 2 + VW * WAVE_SIZE * 3,
-                                 start + 3 + VW * WAVE_SIZE * 3};
-                return v;
-            }
-            else if constexpr(ROCWMMA_WAVE32_MODE)
-            {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {
+                return VecType{
                     start,
                     start + 1,
                     start + 2,
                     start + 3,
-                    start + VW * WAVE_SIZE,
-                    start + 1 + VW * WAVE_SIZE,
-                    start + 2 + VW * WAVE_SIZE,
-                    start + 3 + VW * WAVE_SIZE,
-                    start + VW * WAVE_SIZE * 2,
-                    start + 1 + VW * WAVE_SIZE * 2,
-                    start + 2 + VW * WAVE_SIZE * 2,
-                    start + 3 + VW * WAVE_SIZE * 2,
-                    start + VW * WAVE_SIZE * 3,
-                    start + 1 + VW * WAVE_SIZE * 3,
-                    start + 2 + VW * WAVE_SIZE * 3,
-                    start + 3 + VW * WAVE_SIZE * 3,
-                    start + VW * WAVE_SIZE * 4,
-                    start + 1 + VW * WAVE_SIZE * 4,
-                    start + 2 + VW * WAVE_SIZE * 4,
-                    start + 3 + VW * WAVE_SIZE * 4,
-                    start + VW * WAVE_SIZE * 5,
-                    start + 1 + VW * WAVE_SIZE * 5,
-                    start + 2 + VW * WAVE_SIZE * 5,
-                    start + 3 + VW * WAVE_SIZE * 5,
-                    start + VW * WAVE_SIZE * 6,
-                    start + 1 + VW * WAVE_SIZE * 6,
-                    start + 2 + VW * WAVE_SIZE * 6,
-                    start + 3 + VW * WAVE_SIZE * 6,
-                    start + VW * WAVE_SIZE * 7,
-                    start + 1 + VW * WAVE_SIZE * 7,
-                    start + 2 + VW * WAVE_SIZE * 7,
-                    start + 3 + VW * WAVE_SIZE * 7,
+                    start + WAVE_SIZE * 1,
+                    start + WAVE_SIZE * 1 + 1,
+                    start + WAVE_SIZE * 1 + 2,
+                    start + WAVE_SIZE * 1 + 3,
+                    start + WAVE_SIZE * 2,
+                    start + WAVE_SIZE * 2 + 1,
+                    start + WAVE_SIZE * 2 + 2,
+                    start + WAVE_SIZE * 2 + 3,
+                    start + WAVE_SIZE * 3,
+                    start + WAVE_SIZE * 3 + 1,
+                    start + WAVE_SIZE * 3 + 2,
+                    start + WAVE_SIZE * 3 + 3,
                 };
-                return v;
+            }
+            else if constexpr(ROCWMMA_WAVE32_MODE)
+            {
+                return VecType{
+                    start,
+                    start + 1,
+                    start + 2,
+                    start + 3,
+                    start + WAVE_SIZE * 1,
+                    start + WAVE_SIZE * 1 + 1,
+                    start + WAVE_SIZE * 1 + 2,
+                    start + WAVE_SIZE * 1 + 3,
+                    start + WAVE_SIZE * 2,
+                    start + WAVE_SIZE * 2 + 1,
+                    start + WAVE_SIZE * 2 + 2,
+                    start + WAVE_SIZE * 2 + 3,
+                    start + WAVE_SIZE * 3,
+                    start + WAVE_SIZE * 3 + 1,
+                    start + WAVE_SIZE * 3 + 2,
+                    start + WAVE_SIZE * 3 + 3,
+                    start + WAVE_SIZE * 4,
+                    start + WAVE_SIZE * 4 + 1,
+                    start + WAVE_SIZE * 4 + 2,
+                    start + WAVE_SIZE * 4 + 3,
+                    start + WAVE_SIZE * 5,
+                    start + WAVE_SIZE * 5 + 1,
+                    start + WAVE_SIZE * 5 + 2,
+                    start + WAVE_SIZE * 5 + 3,
+                    start + WAVE_SIZE * 6,
+                    start + WAVE_SIZE * 6 + 1,
+                    start + WAVE_SIZE * 6 + 2,
+                    start + WAVE_SIZE * 6 + 3,
+                    start + WAVE_SIZE * 7,
+                    start + WAVE_SIZE * 7 + 1,
+                    start + WAVE_SIZE * 7 + 2,
+                    start + WAVE_SIZE * 7 + 3,
+                };
             }
             else
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, VW * 4>;
                 return VecType();
             }
         }
@@ -598,70 +604,77 @@ namespace rocwmma
     template <typename DataT>
     struct AosVec<DataT, 2, 16>
     {
+        static constexpr uint32_t VW       = 2;
+        static constexpr uint32_t BlockDim = 16;
+        using VecType = VecT<DataT, VW>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 2;
-            constexpr uint32_t BlockDim = 16;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = threadId / BlockDim * VW * BlockDim;
+            auto const start      = (threadId % BlockDim) * VW + waveOffset;
 
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / BlockDim * VW * BlockDim;
-            auto           start      = (threadId % BlockDim) * VW + waveOffset;
-
-            using VecType = VecT<DataT, VW>;
-            VecType v     = {start, start + 1};
-            return v;
+            return VecType{
+                start,
+                start + 1,
+                 };
         }
     };
 
     template <typename DataT>
     struct AosVec<DataT, 2, 32>
     {
+        static constexpr uint32_t VW       = 2;
+        static constexpr uint32_t BlockDim = 32;
+        using VecType = VecT<DataT, VW>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 2;
-            constexpr uint32_t BlockDim = 32;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = threadId / BlockDim * VW * BlockDim;
+            auto const start      = (threadId % BlockDim) * VW + waveOffset;
 
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / BlockDim * VW * BlockDim;
-            auto           start      = (threadId % BlockDim) * VW + waveOffset;
-
-            using VecType = VecT<DataT, VW>;
-            VecType v     = {start, start + 1};
-            return v;
+            return VecType{
+                start,
+                start + 1,
+                };
         }
     };
     template <typename DataT>
     struct AosVec<DataT, 2, 64>
     {
+        static constexpr uint32_t VW       = 2;
+        static constexpr uint32_t BlockDim = 64;
+        static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+        static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
+        using VecType = VecT<DataT, VecSize>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 2;
-            constexpr uint32_t BlockDim = 64;
-
-            constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-            constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
-            auto           start      = (threadId % WAVE_SIZE) * VW + waveOffset;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
+            auto const start      = (threadId % WAVE_SIZE) * VW + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
-                using VecType = VecT<DataT, VW>;
-                VecType v     = {start, start + 1};
-                return v;
+                return VecType{
+                    start,
+                    start + 1,
+                     };
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v = {start, start + 1, start + VW * WAVE_SIZE, start + 1 + VW * WAVE_SIZE};
-                return v;
+                return VecType{
+                     start,
+                     start + 1,
+                     start + WAVE_SIZE * 1,
+                     start + WAVE_SIZE * 1 + 1,
+                     };
             }
             else
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, VW>;
                 return VecType();
             }
         }
@@ -669,49 +682,44 @@ namespace rocwmma
     template <typename DataT>
     struct AosVec<DataT, 2, 128>
     {
+        static constexpr uint32_t VW       = 2;
+        static constexpr uint32_t BlockDim = 128;
+        static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+        static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
+        using VecType = VecT<DataT, VecSize>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 2;
-            constexpr uint32_t BlockDim = 128;
-
-            constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-            constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
-            auto           start      = (threadId % WAVE_SIZE) * VW + waveOffset;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = (threadId * VW / WAVE_SIZE) * BlockDim;
+            auto const start     = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {
-                    start,
-                    start + 1,
-                    start + VW * WAVE_SIZE,
-                    start + 1 + VW * WAVE_SIZE,
+                return VecType{
+                start,
+                start + 1,
+                start + WAVE_SIZE * 1,
+                start + WAVE_SIZE * 1 + 1,
                 };
-                return v;
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {
+                return VecType{
                     start,
                     start + 1,
-                    start + VW * WAVE_SIZE,
-                    start + 1 + VW * WAVE_SIZE,
-                    start + VW * WAVE_SIZE * 2,
-                    start + 1 + VW * WAVE_SIZE * 2,
-                    start + VW * WAVE_SIZE * 3,
-                    start + 1 + VW * WAVE_SIZE * 3,
+                    start + WAVE_SIZE * 1,
+                    start + WAVE_SIZE * 1 + 1,
+                    start + WAVE_SIZE * 2,
+                    start + WAVE_SIZE * 2 + 1,
+                    start + WAVE_SIZE * 3,
+                    start + WAVE_SIZE * 3 + 1,
                 };
-                return v;
             }
             else
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, VW * 2>;
                 return VecType();
             }
         }
@@ -719,57 +727,56 @@ namespace rocwmma
     template <typename DataT>
     struct AosVec<DataT, 2, 256>
     {
+        static constexpr uint32_t VW       = 2;
+        static constexpr uint32_t BlockDim = 256;
+        static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+        static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
+        using VecType = VecT<DataT, VecSize>;
+
         ROCWMMA_DEVICE static inline auto genData()
         {
-            constexpr uint32_t VW       = 2;
-            constexpr uint32_t BlockDim = 256;
-
-            constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-            constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
-            auto           start      = (threadId % WAVE_SIZE) * VW + waveOffset;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = (threadId * VW / WAVE_SIZE) * BlockDim;
+            auto const start     = threadId % (WAVE_SIZE / VW) * VW + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {start,
-                                 start + 1,
-                                 start + VW * WAVE_SIZE,
-                                 start + 1 + VW * WAVE_SIZE,
-                                 start + VW * WAVE_SIZE * 2,
-                                 start + 1 + VW * WAVE_SIZE * 2,
-                                 start + VW * WAVE_SIZE * 3,
-                                 start + 1 + VW * WAVE_SIZE * 3};
-                return v;
+                return VecType{
+                start,
+                start + 1,
+                start + WAVE_SIZE * 1,
+                start + WAVE_SIZE * 1 + 1,
+                start + WAVE_SIZE * 2,
+                start + WAVE_SIZE * 2 + 1,
+                start + WAVE_SIZE * 3,
+                start + WAVE_SIZE * 3 + 1,
+                };
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {start,
+                return VecType{
+                        start,
                                  start + 1,
-                                 start + VW * WAVE_SIZE,
-                                 start + 1 + VW * WAVE_SIZE,
-                                 start + VW * WAVE_SIZE * 2,
-                                 start + 1 + VW * WAVE_SIZE * 2,
-                                 start + VW * WAVE_SIZE * 3,
-                                 start + 1 + VW * WAVE_SIZE * 3,
-                                 start + VW * WAVE_SIZE * 4,
-                                 start + 1 + VW * WAVE_SIZE * 4,
-                                 start + VW * WAVE_SIZE * 5,
-                                 start + 1 + VW * WAVE_SIZE * 5,
-                                 start + VW * WAVE_SIZE * 6,
-                                 start + 1 + VW * WAVE_SIZE * 6,
-                                 start + VW * WAVE_SIZE * 7,
-                                 start + 1 + VW * WAVE_SIZE * 7};
-                return v;
+                                 start + WAVE_SIZE * 1,
+                                 start + WAVE_SIZE * 1 + 1,
+                                 start + WAVE_SIZE * 2,
+                                 start + WAVE_SIZE * 2 + 1,
+                                 start + WAVE_SIZE * 3,
+                                 start + WAVE_SIZE * 3 + 1,
+                                 start + WAVE_SIZE * 4,
+                                 start + WAVE_SIZE * 4 + 1,
+                                 start + WAVE_SIZE * 5,
+                                 start + WAVE_SIZE * 5 + 1,
+                                 start + WAVE_SIZE * 6,
+                                 start + WAVE_SIZE * 6 + 1,
+                                 start + WAVE_SIZE * 7,
+                                 start + WAVE_SIZE * 7 + 1,
+                };
             }
             else
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, VW * 4>;
                 return VecType();
             }
         }
@@ -779,17 +786,17 @@ namespace rocwmma
     template <typename DataT>
     struct SoaVec<DataT, 8, 16>
     {
+        static constexpr uint32_t VW       = 8;
+        static constexpr uint32_t BlockDim = 16;
+        using VecType = VecT<DataT, VW>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 8;
-            constexpr uint32_t BlockDim = 16;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / BlockDim * VW * BlockDim;
-            auto           start      = (threadId % BlockDim) % BlockDim + waveOffset;
-
-            using VecType = VecT<DataT, VW>;
-            VecType v     = {
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = threadId / BlockDim * VW * BlockDim;
+            auto const start      = (threadId % BlockDim) % BlockDim + waveOffset;
+            
+            return VecType{
                 start,
                 BlockDim + start,
                 BlockDim * 2 + start,
@@ -799,54 +806,52 @@ namespace rocwmma
                 BlockDim * 6 + start,
                 BlockDim * 7 + start,
             };
-            return v;
         }
     };
 
     template <typename DataT>
     struct SoaVec<DataT, 8, 32>
     {
+        static constexpr uint32_t VW       = 8;
+        static constexpr uint32_t BlockDim = 32;
+        using VecType = VecT<DataT, VW>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 8;
-            constexpr uint32_t BlockDim = 32;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = threadId / BlockDim * VW * BlockDim;
+            auto const start      = (threadId % BlockDim) % BlockDim + waveOffset;
 
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / BlockDim * VW * BlockDim;
-            auto           start      = (threadId % BlockDim) % BlockDim + waveOffset;
-
-            using VecType = VecT<DataT, VW>;
-            VecType v     = {start,
+            return VecType{start,
                              BlockDim + start,
                              BlockDim * 2 + start,
                              BlockDim * 3 + start,
                              BlockDim * 4 + start,
                              BlockDim * 5 + start,
                              BlockDim * 6 + start,
-                             BlockDim * 7 + start};
-            return v;
+                             BlockDim * 7 + start,
+                             };
         }
     };
 
     template <typename DataT>
     struct SoaVec<DataT, 8, 64>
     {
+        static constexpr uint32_t VW       = 8;
+        static constexpr uint32_t BlockDim = 64;
+        static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+        static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
+        using VecType = VecT<DataT, VecSize>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 8;
-            constexpr uint32_t BlockDim = 64;
-
-            constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-            constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
-            auto           start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
+            auto const start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {
+                return VecType{
                     start,
                     BlockDim + start,
                     BlockDim * 2 + start,
@@ -856,13 +861,10 @@ namespace rocwmma
                     BlockDim * 6 + start,
                     BlockDim * 7 + start,
                 };
-                return v;
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
             {
-
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {
+                return VecType{
                     start,
                     BlockDim + start,
                     BlockDim * 2 + start,
@@ -880,13 +882,11 @@ namespace rocwmma
                     WAVE_SIZE + BlockDim * 6 + start,
                     WAVE_SIZE + BlockDim * 7 + start,
                 };
-                return v;
             }
             else
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, VW>;
                 return VecType();
             }
         }
@@ -895,22 +895,21 @@ namespace rocwmma
     template <typename DataT>
     struct SoaVec<DataT, 8, 128>
     {
+        static constexpr uint32_t VW       = 8;
+        static constexpr uint32_t BlockDim = 128;
+        static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+        static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
+        using VecType = VecT<DataT, VecSize>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 8;
-            constexpr uint32_t BlockDim = 128;
-
-            constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-            constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
-            auto           start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
+            auto const start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {
+                return VecType{
                     start,
                     BlockDim + start,
                     BlockDim * 2 + start,
@@ -928,12 +927,10 @@ namespace rocwmma
                     WAVE_SIZE + BlockDim * 6 + start,
                     WAVE_SIZE + BlockDim * 7 + start,
                 };
-                return v;
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {
+                return VecType{
                     start,
                     BlockDim + start,
                     BlockDim * 2 + start,
@@ -967,13 +964,11 @@ namespace rocwmma
                     WAVE_SIZE * 3 + BlockDim * 6 + start,
                     WAVE_SIZE * 3 + BlockDim * 7 + start,
                 };
-                return v;
             }
             else
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, VW * 2>;
                 return VecType();
             }
         }
@@ -982,22 +977,21 @@ namespace rocwmma
     template <typename DataT>
     struct SoaVec<DataT, 8, 256>
     {
+        static constexpr uint32_t VW       = 8;
+        static constexpr uint32_t BlockDim = 256;
+        static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+        static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
+        using VecType = VecT<DataT, VecSize>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
-        {
-            constexpr uint32_t VW       = 8;
-            constexpr uint32_t BlockDim = 256;
-
-            constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-            constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
-            auto           start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
+        {            
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
+            auto const start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {
+                return VecType{
                     start,
                     BlockDim + start,
                     BlockDim * 2 + start,
@@ -1031,12 +1025,10 @@ namespace rocwmma
                     WAVE_SIZE * 3 + BlockDim * 6 + start,
                     WAVE_SIZE * 3 + BlockDim * 7 + start,
                 };
-                return v;
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {
+                return VecType{
                     start,
                     BlockDim + start,
                     BlockDim * 2 + start,
@@ -1102,13 +1094,11 @@ namespace rocwmma
                     WAVE_SIZE * 7 + BlockDim * 6 + start,
                     WAVE_SIZE * 7 + BlockDim * 7 + start,
                 };
-                return v;
             }
             else
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, VW * 4>;
                 return VecType();
             }
         }
@@ -1117,78 +1107,88 @@ namespace rocwmma
     template <typename DataT>
     struct SoaVec<DataT, 4, 16>
     {
+        static constexpr uint32_t VW       = 4;
+        static constexpr uint32_t BlockDim = 16;
+        using VecType = VecT<DataT, VW>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 4;
-            constexpr uint32_t BlockDim = 16;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / BlockDim * VW * BlockDim;
-            auto           start      = (threadId % BlockDim) % BlockDim + waveOffset;
-
-            using VecType = VecT<DataT, VW>;
-            VecType v     = {start, BlockDim + start, BlockDim * 2 + start, BlockDim * 3 + start};
-            return v;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = threadId / BlockDim * VW * BlockDim;
+            auto const start      = (threadId % BlockDim) % BlockDim + waveOffset;
+            
+            return VecType{
+                start,
+                BlockDim + start,
+                BlockDim * 2 + start,
+                BlockDim * 3 + start,
+                };
         }
     };
 
     template <typename DataT>
     struct SoaVec<DataT, 4, 32>
     {
+        static constexpr uint32_t VW       = 4;
+        static constexpr uint32_t BlockDim = 32;
+        using VecType = VecT<DataT, VW>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 4;
-            constexpr uint32_t BlockDim = 32;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / BlockDim * VW * BlockDim;
-            auto           start      = (threadId % BlockDim) % BlockDim + waveOffset;
-
-            using VecType = VecT<DataT, VW>;
-            VecType v     = {start, BlockDim + start, BlockDim * 2 + start, BlockDim * 3 + start};
-            return v;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = threadId / BlockDim * VW * BlockDim;
+            auto const start      = (threadId % BlockDim) % BlockDim + waveOffset;
+            
+            return VecType{
+                start,
+                BlockDim + start,
+                BlockDim * 2 + start,
+                BlockDim * 3 + start,
+                };
         }
     };
 
     template <typename DataT>
     struct SoaVec<DataT, 4, 64>
     {
+        static constexpr uint32_t VW       = 4;
+        static constexpr uint32_t BlockDim = 64;
+        static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+        static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
+        using VecType = VecT<DataT, VecSize>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 4;
-            constexpr uint32_t BlockDim = 64;
-
-            constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-            constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
-            auto           start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
+            auto const start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v = {start, BlockDim + start, BlockDim * 2 + start, BlockDim * 3 + start};
-                return v;
+                return VecType{
+                    start,
+                    BlockDim + start,
+                    BlockDim * 2 + start,
+                    BlockDim * 3 + start,
+                    };
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {start,
-                                 BlockDim + start,
-                                 BlockDim * 2 + start,
-                                 BlockDim * 3 + start,
-                                 WAVE_SIZE + start,
-                                 WAVE_SIZE + BlockDim + start,
-                                 WAVE_SIZE + BlockDim * 2 + start,
-                                 WAVE_SIZE + BlockDim * 3 + start};
-                return v;
+                return VecType{
+                    start,
+                    BlockDim + start,
+                    BlockDim * 2 + start,
+                    BlockDim * 3 + start,
+                    WAVE_SIZE + start,
+                    WAVE_SIZE + BlockDim + start,
+                    WAVE_SIZE + BlockDim * 2 + start,
+                    WAVE_SIZE + BlockDim * 3 + start,
+                    };
             }
             else
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, VW>;
                 return VecType();
             }
         }
@@ -1197,22 +1197,22 @@ namespace rocwmma
     template <typename DataT>
     struct SoaVec<DataT, 4, 128>
     {
+
+        static constexpr uint32_t VW       = 4;
+        static constexpr uint32_t BlockDim = 128;
+        static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+        static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
+        using VecType = VecT<DataT, VecSize>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 4;
-            constexpr uint32_t BlockDim = 128;
-
-            constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-            constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
-            auto           start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
+            auto const start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
-            {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {
+            {                
+                return VecType{
                     start,
                     BlockDim + start,
                     BlockDim * 2 + start,
@@ -1222,12 +1222,10 @@ namespace rocwmma
                     WAVE_SIZE + BlockDim * 2 + start,
                     WAVE_SIZE + BlockDim * 3 + start,
                 };
-                return v;
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {
+                return VecType{
                     start,
                     BlockDim + start,
                     BlockDim * 2 + start,
@@ -1245,13 +1243,11 @@ namespace rocwmma
                     WAVE_SIZE * 3 + BlockDim * 2 + start,
                     WAVE_SIZE * 3 + BlockDim * 3 + start,
                 };
-                return v;
             }
             else
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, VW * 2>;
                 return VecType();
             }
         }
@@ -1260,22 +1256,21 @@ namespace rocwmma
     template <typename DataT>
     struct SoaVec<DataT, 4, 256>
     {
+        static constexpr uint32_t VW       = 4;
+        static constexpr uint32_t BlockDim = 256;
+        static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+        static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
+        using VecType = VecT<DataT, VecSize>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 4;
-            constexpr uint32_t BlockDim = 256;
-
-            constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-            constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
-            auto           start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
+            auto const start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {
+                return VecType{
                     start,
                     BlockDim + start,
                     BlockDim * 2 + start,
@@ -1293,12 +1288,10 @@ namespace rocwmma
                     WAVE_SIZE * 3 + BlockDim * 2 + start,
                     WAVE_SIZE * 3 + BlockDim * 3 + start,
                 };
-                return v;
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {
+                return VecType{
                     start,
                     BlockDim + start,
                     BlockDim * 2 + start,
@@ -1332,13 +1325,11 @@ namespace rocwmma
                     WAVE_SIZE * 7 + BlockDim * 2 + start,
                     WAVE_SIZE * 7 + BlockDim * 3 + start,
                 };
-                return v;
             }
             else
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, VW * 4>;
                 return VecType();
             }
         }
@@ -1347,72 +1338,78 @@ namespace rocwmma
     template <typename DataT>
     struct SoaVec<DataT, 2, 16>
     {
+        static constexpr uint32_t VW       = 2;
+        static constexpr uint32_t BlockDim = 16;
+        using VecType = VecT<DataT, VW>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 2;
-            constexpr uint32_t BlockDim = 16;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / BlockDim * VW * BlockDim;
-            auto           start      = (threadId % BlockDim) % BlockDim + waveOffset;
-
-            using VecType = VecT<DataT, VW>;
-            VecType v     = {start, BlockDim + start};
-            return v;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = threadId / BlockDim * VW * BlockDim;
+            auto const start      = (threadId % BlockDim) % BlockDim + waveOffset;
+            
+            return VecType{
+                start,
+                 BlockDim + start,
+                 };
         }
     };
 
     template <typename DataT>
     struct SoaVec<DataT, 2, 32>
     {
+        static constexpr uint32_t VW       = 2;
+        static constexpr uint32_t BlockDim = 32;
+        using VecType = VecT<DataT, VW>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 2;
-            constexpr uint32_t BlockDim = 32;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / BlockDim * VW * BlockDim;
-            auto           start      = (threadId % BlockDim) % BlockDim + waveOffset;
-
-            using VecType = VecT<DataT, VW>;
-            VecType v     = {start, BlockDim + start};
-            return v;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = threadId / BlockDim * VW * BlockDim;
+            auto const start      = (threadId % BlockDim) % BlockDim + waveOffset;
+            
+            return VecType{
+                start,
+                BlockDim + start,
+                };
         }
     };
 
     template <typename DataT>
     struct SoaVec<DataT, 2, 64>
     {
+        static constexpr uint32_t VW       = 2;
+        static constexpr uint32_t BlockDim = 64;
+        static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+        static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
+        using VecType = VecT<DataT, VecSize>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 2;
-            constexpr uint32_t BlockDim = 64;
-
-            constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-            constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
-            auto           start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
+            auto const start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
-                using VecType = VecT<DataT, VW>;
-                VecType v     = {start, BlockDim + start};
-                return v;
+                return VecType{
+                    start,
+                    BlockDim + start,
+                     };
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
-            {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v
-                    = {start, BlockDim + start, WAVE_SIZE + start, WAVE_SIZE + BlockDim + start};
-                return v;
+            {                
+                return VecType{
+                    start,
+                    BlockDim + start,
+                    WAVE_SIZE + start,
+                    WAVE_SIZE + BlockDim + start,
+                    };
             }
             else
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, VW>;
                 return VecType();
             }
         }
@@ -1421,29 +1418,30 @@ namespace rocwmma
     template <typename DataT>
     struct SoaVec<DataT, 2, 128>
     {
+        static constexpr uint32_t VW       = 2;
+        static constexpr uint32_t BlockDim = 128;
+        static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+        static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
+        using VecType = VecT<DataT, VecSize>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 2;
-            constexpr uint32_t BlockDim = 128;
-
-            constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-            constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
-            auto           start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
+            auto const start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
-            {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v
-                    = {start, BlockDim + start, WAVE_SIZE + start, WAVE_SIZE + BlockDim + start};
-                return v;
+            {                
+                return VecType{
+                    start,
+                    BlockDim + start,
+                    WAVE_SIZE + start,
+                    WAVE_SIZE + BlockDim + start,
+                    };
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {
+                return VecType{
                     start,
                     BlockDim + start,
                     WAVE_SIZE + start,
@@ -1453,13 +1451,11 @@ namespace rocwmma
                     WAVE_SIZE * 3 + start,
                     WAVE_SIZE * 3 + BlockDim + start,
                 };
-                return v;
             }
             else
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, VW * 2>;
                 return VecType();
             }
         }
@@ -1468,35 +1464,36 @@ namespace rocwmma
     template <typename DataT>
     struct SoaVec<DataT, 2, 256>
     {
+        static constexpr uint32_t VW       = 2;
+        static constexpr uint32_t BlockDim = 256;
+        static constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
+        static constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
+        using VecType = VecT<DataT, VecSize>;
+
         ROCWMMA_DEVICE constexpr static inline auto genData()
         {
-            constexpr uint32_t VW       = 2;
-            constexpr uint32_t BlockDim = 256;
-
-            constexpr uint32_t WAVE_SIZE = Constants::AMDGCN_WAVE_SIZE;
-            constexpr uint32_t VecSize   = VW * BlockDim / WAVE_SIZE;
-
-            auto           threadId   = (uint8_t)detail::threadId();
-            const uint32_t waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
-            auto           start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
+            auto const threadId   = (uint8_t)detail::threadId();
+            auto const waveOffset = threadId / WAVE_SIZE * VW * BlockDim;
+            auto const start      = (threadId % WAVE_SIZE) % BlockDim + waveOffset;
 
             if constexpr(ROCWMMA_WAVE64_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {start,
+                
+                return VecType{
+                    start,
                                  BlockDim + start,
                                  WAVE_SIZE + start,
                                  WAVE_SIZE + BlockDim + start,
                                  WAVE_SIZE * 2 + start,
                                  WAVE_SIZE * 2 + BlockDim + start,
                                  WAVE_SIZE * 3 + start,
-                                 WAVE_SIZE * 3 + BlockDim + start};
-                return v;
+                                 WAVE_SIZE * 3 + BlockDim + start,
+                                 };
             }
             else if constexpr(ROCWMMA_WAVE32_MODE)
             {
-                using VecType = VecT<DataT, VecSize>;
-                VecType v     = {start,
+                return VecType{
+                    start,
                                  BlockDim + start,
                                  WAVE_SIZE + start,
                                  WAVE_SIZE + BlockDim + start,
@@ -1511,14 +1508,13 @@ namespace rocwmma
                                  WAVE_SIZE * 6 + start,
                                  WAVE_SIZE * 6 + BlockDim + start,
                                  WAVE_SIZE * 7 + start,
-                                 WAVE_SIZE * 7 + BlockDim + start};
-                return v;
+                                 WAVE_SIZE * 7 + BlockDim + start,
+                                 };
             }
             else
             {
                 // This host code should not be called since it is marked as ROCWMMA_DEVICE
                 // This code snippet exists since hipcc complains about the mismatched function
-                using VecType = VecT<DataT, VW * 4>;
                 return VecType();
             }
         }


### PR DESCRIPTION
- Adjusts the ColInlineVW load layout to have the same data coverage as ColOrthoVW.
- Meaning: Strides now match priority in VW -> BlockK -> BlockDim
- Removes extra shuffles of AOS<->SOA transforms for BlockDim > 64
- Now compatible with cooperative fragments (due to same data coverage)