### PR TITLE
Set number of compile threads to lesser of nproc or 12

### DIFF
--- a/.jenkins/common.groovy
+++ b/.jenkins/common.groovy
@@ -21,6 +21,9 @@ def runCompileCommand(platform, project, jobName, boolean debug=false)
     String compilerLauncher = project.defaults.ccache ? '-DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache' : ''
     String cmakeArgs = "-DCMAKE_C_COMPILER=/opt/rocm/bin/hipcc -DCMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc ${compilerLauncher} ${buildTypeArg} ${amdgpuTargets}"
     String hipccCompileFlags = "export HIPCC_COMPILE_FLAGS_APPEND='-O3 -Wno-format-nonliteral -parallel-jobs=1'"
+    // Set number of compile threads to lesser of nproc or 12
+    int nproc = Runtime.runtime.availableProcessors()
+    int numThreads = Math.min(nproc, 12)
 
     def command = """#!/usr/bin/env bash
                 set -x
@@ -31,7 +34,7 @@ def runCompileCommand(platform, project, jobName, boolean debug=false)
                 mkdir -p build/${buildTypeDir} && cd build/${buildTypeDir}
                 ${auxiliary.gfxTargetParser()}
                 ${cmake} ${cmakeArgs} -DROCWMMA_BUILD_BENCHMARK_TESTS=OFF ../..
-                make -j\$(nproc)
+                make -j ${numThreads}
                 """
 
     platform.runCommand(this, command)
@@ -62,4 +65,3 @@ def runPackageCommand(platform, project)
 }
 
 return this
-


### PR DESCRIPTION
http://math-ci.amd.com/blue/organizations/jenkins/main%2Fprecheckin%2FrocWMMA/detail/PR-363/1/pipeline/465

used 12 in compile stage

test stage failures should be unrelated to this change