### PR TITLE
Fix CP_BLK tests

### DIFF
--- a/test/gemm/gemm_local_mapping.hpp
+++ b/test/gemm/gemm_local_mapping.hpp
@@ -413,18 +413,22 @@ namespace rocwmma
             __device__ constexpr static inline auto
                 formatLWFragA(typename GlobalMapping::GRFragA const& grFragA)
             {
-                return applyDataLayout<LayoutLds, 1>(
-                    reinterpret_cast<ApplyRegisterFile_t<typename GlobalMapping::GRFragA> const&>(
-                        grFragA));
+                // When interpreting as a register block (e.g. BlockDim 64 on CDNA), avoid transforming
+                // direct register layouts because we want the register contents as they currently are.
+                return reinterpret_cast<
+                    ApplyDataLayout_t<ApplyRegisterFile_t<typename GlobalMapping::GRFragA>,
+                                      LayoutLds> const&>(grFragA);
             }
 
             template <uint32_t WaveCount = 1>
             __device__ constexpr static inline auto
                 formatLWFragB(typename GlobalMapping::GRFragB const& grFragB)
             {
-                return applyDataLayout<LayoutLds, 1>(
-                    reinterpret_cast<ApplyRegisterFile_t<typename GlobalMapping::GRFragB> const&>(
-                        grFragB));
+                // When interpreting as a register block (e.g. BlockDim 64 on CDNA), avoid transforming
+                // direct register layouts because we want the register contents as they currently are.
+                return reinterpret_cast<
+                    ApplyDataLayout_t<ApplyRegisterFile_t<typename GlobalMapping::GRFragB>,
+                                      LayoutLds> const&>(grFragB);
             }
         };
 


### PR DESCRIPTION
- When getting register file, keep contents as-is instead of transforming