### PR TITLE
Circular include

### DIFF
--- a/library/include/rocwmma/internal/blend.hpp
+++ b/library/include/rocwmma/internal/blend.hpp
@@ -32,8 +32,6 @@
 #include "vector.hpp"
 // clang-format on
 
-#include "vector_util.hpp"
-
 namespace rocwmma
 {
     namespace Blend

--- a/library/include/rocwmma/internal/blend_impl.hpp
+++ b/library/include/rocwmma/internal/blend_impl.hpp
@@ -26,7 +26,7 @@
 #ifndef ROCWMMA_BLEND_IMPL_HPP
 #define ROCWMMA_BLEND_IMPL_HPP
 
-#include "blend.hpp"
+#include "utility/vector.hpp"
 #include "utils.hpp"
 
 namespace rocwmma

--- a/library/include/rocwmma/internal/vector.hpp
+++ b/library/include/rocwmma/internal/vector.hpp
@@ -28,14 +28,6 @@
 #define ROCWMMA_VECTOR_HPP
 
 #include "types.hpp"
-// #include "types_ext.hpp"
-#if !defined(__HIPCC_RTC__)
-
-#include <hip/hip_fp16.h>
-#include <hip/hip_vector_types.h>
-
-#endif
-
 #include "utility/forward.hpp"
 #include "utility/type_traits.hpp"
 
@@ -400,7 +392,6 @@ ROCWMMA_REGISTER_HIP_NON_NATIVE_VECTOR_TYPE_WITH_INC_DEC_OPS_AS_FLOAT(rocwmma::b
 ROCWMMA_REGISTER_HIP_NON_NATIVE_VECTOR_TYPE_WITH_INC_DEC_OPS_AS_FLOAT(rocwmma::bfloat16_t, 512);
 
 #include "type_traits.hpp"
-#include "utility/get.hpp"
 
 namespace rocwmma
 {
@@ -518,7 +509,4 @@ namespace rocwmma
     using Coord2d      = non_native_vector_base<Coord2dDataT, 2>;
 
 } // namespace rocwmma
-
-#include "utility/vector.hpp"
-
 #endif // ROCWMMA_VECTOR_HPP

--- a/library/include/rocwmma/internal/vector_impl.hpp
+++ b/library/include/rocwmma/internal/vector_impl.hpp
@@ -28,7 +28,6 @@
 #define ROCWMMA_VECTOR_IMPL_HPP
 
 #include "utility/sequence.hpp"
-#include "vector.hpp"
 
 namespace rocwmma
 {

--- a/library/include/rocwmma/internal/vector_util_impl.hpp
+++ b/library/include/rocwmma/internal/vector_util_impl.hpp
@@ -29,7 +29,7 @@
 
 #include "blend.hpp"
 #include "types.hpp"
-#include "vector.hpp"
+#include "utility/vector.hpp"
 
 namespace rocwmma
 {


### PR DESCRIPTION
Break the circular include

    - Break the circular include
    - Solved the warning "use of function template name with no prior
    declaration in function call with explicit template arguments is a C++20
    extension"