### PR TITLE
Use Dpp::Zip instead of blend-based zip to save registers

### DIFF
--- a/library/include/rocwmma/internal/blend.hpp
+++ b/library/include/rocwmma/internal/blend.hpp
@@ -195,8 +195,9 @@ namespace rocwmma
         // Because there is only one result from 2 sources, we must choose to blend either the low, or the
         // high elements per group of inputs.
         // E.g. src0 = [0, 1, 2, 3] src1 = [4, 5, 6, 7]
-        // UnpackLo = [0, 4, 1, 5]
-        // UnpackHi = [2, 6, 3, 7]
+        // UnpackLo   = [0, 4, 1, 5]
+        // UnpackHi   = [2, 6, 3, 7]
+        // UnpackLoHi = [0, 4, 2, 6]
 
         /*! \class UnpackByteLo
         *  \brief  Blend class that unpacks lo bytes from each 4B element of src0 and src1.
@@ -233,8 +234,10 @@ namespace rocwmma
         // Extract functions
         // These functions extract elements in order from src0 and src1 and concatenate their result together.
         // e.g. src0   = [0, 1, 2, 3] src1 = [4, 5, 6, 7]
-        //      extract_even = [0, 2, 4, 6]
-        //      extract_odd  = [1, 3, 5, 7]
+        // extract_even      = [0, 2, 4, 6]
+        // extract_odd       = [1, 3, 5, 7]
+        // extract_even_odd  = [0, 2, 5, 7]
+        // extract_odd_even  = [1, 3, 4, 6]
 
         /*! \class ExtractByteEven
         *  \brief  Blend class that extracts even ordered bytes from each 4B element of src0 and src1 and

--- a/library/include/rocwmma/internal/blend.hpp
+++ b/library/include/rocwmma/internal/blend.hpp
@@ -144,45 +144,144 @@ namespace rocwmma
         // Func::exec(src0, src1)
 
         // Zip functions
+        // Blend even thread elements from src0 with odd thread elements from src1,
+        // just like a zipper. We can reverse the order of the inputs if the opposite is desired.
+        // E.g. src0 = [0, 1, 2, 3] src1 = [4, 5, 6, 7]
+        // Zip1 = [0, 5, 2, 7]
+        // Zip2 = [0, 1, 6, 7]
+
+        /*! \class ZipByte
+        *  \brief  Blend class that alternates bytes from src0 and src1
+        */
         using ZipByte = Driver<BlendImpl::Ops::ZipByte>;
+
+        /*! \class ZipWord
+        *  \brief  Blend class that alternates words (2B) from src0 and src1
+        */
         using ZipWord = Driver<BlendImpl::Ops::ZipWord>;
-        using Zip1    = Driver<BlendImpl::Ops::Zip1>;
-        using Zip2    = Driver<BlendImpl::Ops::Zip2>;
-        using Zip4    = Driver<BlendImpl::Ops::Zip4>;
-        using Zip8    = Driver<BlendImpl::Ops::Zip8>;
-        using Zip16   = Driver<BlendImpl::Ops::Zip16>;
-        using Zip32   = Driver<BlendImpl::Ops::Zip32>;
+
+        /*! \class Zip1
+        *  \brief  Blend class that alternates thread elements (4B) from src0 and src1.
+        */
+        using Zip1 = Driver<BlendImpl::Ops::Zip1>;
+
+        /*! \class Zip2
+        *  \brief  Blend class that alternates groups of 2 thread elements (8B) from src0 and src1.
+        */
+        using Zip2 = Driver<BlendImpl::Ops::Zip2>;
+
+        /*! \class Zip4
+        *  \brief  Blend class that alternates groups of 4 thread elements (16B) from src0 and src1.
+        */
+        using Zip4 = Driver<BlendImpl::Ops::Zip4>;
+
+        /*! \class Zip8
+        *  \brief  Blend class that alternates groups of 8 thread elements (32B) from src0 and src1.
+        */
+        using Zip8 = Driver<BlendImpl::Ops::Zip8>;
+
+        /*! \class Zip16
+        *  \brief  Blend class that alternates groups of 16 thread elements (64B) from src0 and src1.
+        */
+        using Zip16 = Driver<BlendImpl::Ops::Zip16>;
+
+        /*! \class Zip32
+        *  \brief  Blend class that alternates groups of 32 thread elements (128B) from src0 and src1.
+        */
+        using Zip32 = Driver<BlendImpl::Ops::Zip32>;
 
         // Unpack functions
-        using UnpackByteLo     = Driver<BlendImpl::Ops::UnpackByteLo>;
-        using UnpackByteHi     = Driver<BlendImpl::Ops::UnpackByteHi>;
-        using UnpackWordLo     = Driver<BlendImpl::Ops::UnpackWordLo>;
-        using UnpackWordHi     = Driver<BlendImpl::Ops::UnpackWordHi>;
-        using UnpackByteLoHi   = Driver<BlendImpl::Ops::UnpackByteLoHi>;
+        // The unpack functionality blends elements from the same thread in src0 and src1.
+        // Because there is only one result from 2 sources, we must choose to blend either the low, or the
+        // high elements per group of inputs.
+        // E.g. src0 = [0, 1, 2, 3] src1 = [4, 5, 6, 7]
+        // UnpackLo = [0, 4, 1, 5]
+        // UnpackHi = [2, 6, 3, 7]
+
+        /*! \class UnpackByteLo
+        *  \brief  Blend class that unpacks lo bytes from each 4B element of src0 and src1.
+        */
+        using UnpackByteLo = Driver<BlendImpl::Ops::UnpackByteLo>;
+
+        /*! \class UnpackByteHi
+        *  \brief  Blend class that unpacks hi bytes from each 4B element of src0 and src1.
+        */
+        using UnpackByteHi = Driver<BlendImpl::Ops::UnpackByteHi>;
+
+        /*! \class UnpackWordLo
+        *  \brief  Blend class that unpacks lo words from each 4B element of src0 and src1.
+        */
+        using UnpackWordLo = Driver<BlendImpl::Ops::UnpackWordLo>;
+
+        /*! \class UnpackWordHi
+        *  \brief  Blend class that unpacks hi words from each 4B element of src0 and src1.
+        */
+        using UnpackWordHi = Driver<BlendImpl::Ops::UnpackWordHi>;
+
+        /*! \class UnpackByteLoHi
+        *  \brief  Blend class that unpacks two lo bytes followed by two hi bytes from each 4B element of src0 and src1.
+        */
+        using UnpackByteLoHi = Driver<BlendImpl::Ops::UnpackByteLoHi>;
+
+        /*! \class UnpackByte3BCast
+        *  \brief  Blend class that unpacks byte 3 from each 4B element of src0 and src1, which is broadcasted.
+        *  e.g. src0[0]   = [0, 1, 2, 3] src1[0] = [4, 5, 6, 7]
+        *       result[0] = [3, 7, 3, 7]
+        */
         using UnpackByte3BCast = Driver<BlendImpl::Ops::UnpackByte3BCast>;
 
         // Extract functions
-        using ExtractByteEven = Driver<BlendImpl::Ops::ExtractByteEven>;
-        using ExtractByteOdd  = Driver<BlendImpl::Ops::ExtractByteOdd>;
-        using ExtractWordEven = Driver<BlendImpl::Ops::ExtractWordEven>;
-        using ExtractWordOdd  = Driver<BlendImpl::Ops::ExtractWordOdd>;
+        // These functions extract elements in order from src0 and src1 and concatenate their result together.
+        // e.g. src0   = [0, 1, 2, 3] src1 = [4, 5, 6, 7]
+        //      extract_even = [0, 2, 4, 6]
+        //      extract_odd  = [1, 3, 5, 7]
 
+        /*! \class ExtractByteEven
+        *  \brief  Blend class that extracts even ordered bytes from each 4B element of src0 and src1 and
+        *  concatenates them together.
+        */
+        using ExtractByteEven = Driver<BlendImpl::Ops::ExtractByteEven>;
+
+        /*! \class ExtractByteOdd
+        *  \brief  Blend class that extracts odd ordered bytes from each 4B element of src0 and src1 and
+        *  concatenates them together.
+        */
+        using ExtractByteOdd = Driver<BlendImpl::Ops::ExtractByteOdd>;
+
+        /*! \class ExtractWordEven
+        *  \brief  Blend class that extracts even ordered words from each 4B element of src0 and src1 and
+        *  concatenates them together.
+        */
+        using ExtractWordEven = Driver<BlendImpl::Ops::ExtractWordEven>;
+
+        /*! \class ExtractWordOdd
+        *  \brief  Blend class that extracts odd ordered words from each 4B element of src0 and src1 and
+        *  concatenates them together.
+        */
+        using ExtractWordOdd = Driver<BlendImpl::Ops::ExtractWordOdd>;
+
+        /*! \class ExtractByteEvenOdd
+        *  \brief  Blend class that extracts even ordered bytes src0, odd ordered bytes from src1 and
+        *  concatenates them together.
+        */
         using ExtractByteEvenOdd = Driver<BlendImpl::Ops::ExtractByteEvenOdd>;
+
+        /*! \class ExtractWordEvenOdd
+        *  \brief  Blend class that extracts even ordered words src0, odd ordered words from src1 and
+        *  concatenates them together.
+        */
         using ExtractWordEvenOdd = Driver<BlendImpl::Ops::ExtractWordEvenOdd>;
 
+        /*! \class ExtractByteOddEven
+        *  \brief  Blend class that extracts odd ordered bytes src0, even ordered bytes from src1 and
+        *  concatenates them together.
+        */
         using ExtractByteOddEven = Driver<BlendImpl::Ops::ExtractByteOddEven>;
-        using ExtractWordOddEven = Driver<BlendImpl::Ops::ExtractWordOddEven>;
 
-        // Extract functions
-        using ExtractByteEven = Driver<BlendImpl::Ops::ExtractByteEven>;
-        using ExtractByteOdd  = Driver<BlendImpl::Ops::ExtractByteOdd>;
-        using ExtractWordEven = Driver<BlendImpl::Ops::ExtractWordEven>;
-        using ExtractWordOdd  = Driver<BlendImpl::Ops::ExtractWordOdd>;
-
-        using ExtractByteEvenOdd = Driver<BlendImpl::Ops::ExtractByteEvenOdd>;
-        using ExtractWordEvenOdd = Driver<BlendImpl::Ops::ExtractWordEvenOdd>;
-
-        using ExtractByteOddEven = Driver<BlendImpl::Ops::ExtractByteOddEven>;
+        /*! \class ExtractWordOddEven
+        *  \brief  Blend class that extracts odd ordered words src0, even ordered words from src1 and
+        *  concatenates them together.
+        */
         using ExtractWordOddEven = Driver<BlendImpl::Ops::ExtractWordOddEven>;
 
     } // namespace Blend

--- a/library/include/rocwmma/internal/dpp_impl.hpp
+++ b/library/include/rocwmma/internal/dpp_impl.hpp
@@ -43,6 +43,7 @@ namespace rocwmma
 
         // Functional
         using Properties::OP_ID_BCAST;
+        using Properties::OP_ID_BLEND;
         using Properties::OP_ID_MOVE;
         using Properties::OP_ID_REVERSE;
         using Properties::OP_ID_ROTATE;
@@ -695,6 +696,13 @@ namespace rocwmma
                 }
             };
 
+            /*! \class Shuffle2
+            *  \brief Shuffle\<N\> Perform localized shuffling within all sub-groups of \em N threads.
+            * \em N = group size.
+            *
+            * @tparam Select0 - index of element to shuffle to index 0
+            * @tparam Select1 - index of element to shuffle to index 1
+            */
             template <uint32_t Select0, uint32_t Select1>
             struct Shuffle2 : public Shuffle<OP_GROUP_SIZE_2,
                                              Ctrl::Shuffle4<Select0,
@@ -726,6 +734,15 @@ namespace rocwmma
                           public Backend::amdgcn_mov_dpp<SwapCtrl>
             {
             };
+
+            /*! \class Zip
+            *  \brief Perform blending of sub-groups of \p SubGroupSize threads between sources.
+            */
+            template <uint32_t SubGroupSize>
+            struct Zip : public DppOp<OP_ID_BLEND, SubGroupSize>,
+                         public Backend::amdgcn_mov_dpp<Ctrl::Move>
+            {
+            };
             /** @}*/
 
         } // namespace OpsBase
@@ -734,7 +751,7 @@ namespace rocwmma
         {
             // clang-format off
 
-            /// BCast variants
+            // BCast variants
             template <uint32_t ElementIdx>
             using BCast16 = OpsBase::BCast<ElementIdx, OP_GROUP_SIZE_16, Ctrl::RowBCast<ElementIdx>>;
 
@@ -753,7 +770,8 @@ namespace rocwmma
 
             using BCast32x31 = OpsBase::WFallBCast<OP_GROUP_SIZE_32, Ctrl::RowBCast31>;
 
-            /// Move variants
+            // Move variants
+
             using MaskMove = OpsBase::Move;
 
             /// Reversal variants
@@ -812,6 +830,15 @@ namespace rocwmma
 
             // Swap variants
             using Swap2 = OpsBase::Swap<OP_GROUP_SIZE_2, Ctrl::Shuffle4<0x02, 0x03, 0x00, 0x01>>;
+
+            // Zip variants
+            using Zip4 = OpsBase::Zip<OP_GROUP_SIZE_4>;
+
+            using Zip8 = OpsBase::Zip<OP_GROUP_SIZE_8>;
+
+            using Zip16 = OpsBase::Zip<OP_GROUP_SIZE_16>;
+
+            using Zip32 = OpsBase::Zip<OP_GROUP_SIZE_32>;
 
             // clang-format on
 

--- a/library/include/rocwmma/internal/permute.hpp
+++ b/library/include/rocwmma/internal/permute.hpp
@@ -76,11 +76,10 @@ namespace rocwmma
                 constexpr uint32_t B32VecSize = sizeof(DataT) / sizeof(uint32_t) * VecSize;
 
                 // Ensure that DataT is a multiple of B32
-                static_assert(B32VecSize >= 1,
-                              "DataT must be a multiple of B32");
+                static_assert(B32VecSize >= 1, "DataT must be a multiple of B32");
 
-                using B32VecT                 = VecT<uint32_t, B32VecSize>;
-                using InputVecT               = VecT<DataT, VecSize>;
+                using B32VecT   = VecT<uint32_t, B32VecSize>;
+                using InputVecT = VecT<DataT, VecSize>;
 
                 // Ensure that we can vectorize to B32
                 static_assert(sizeof(InputVecT) % sizeof(uint32_t) == 0,
@@ -106,42 +105,106 @@ namespace rocwmma
             }
         };
 
+        /*! \class BlockBCast32
+        *  \brief  Permute class that broadcasts one block of 32 threads to all other blocks
+        *  @tparam BlockIdx block index [0 - WaveSize/32]
+        */
         template <uint32_t BlockIdx>
         using BlockBCast32 = Driver<PermuteImpl::Ops::BlockBCast32<BlockIdx>>;
 
+        /*! \class BlockBCast16
+        *  \brief  Permute class that broadcasts one block of 16 threads to all other blocks
+        *  @tparam BlockIdx block index [0 - WaveSize/16]
+        */
         template <uint32_t BlockIdx>
         using BlockBCast16 = Driver<PermuteImpl::Ops::BlockBCast16<BlockIdx>>;
 
+        /*! \class BlockBCast8
+        *  \brief  Permute class that broadcasts one block of 8 threads to all other blocks
+        *  @tparam BlockIdx block index [0 - WaveSize/8]
+        */
         template <uint32_t BlockIdx>
         using BlockBCast8 = Driver<PermuteImpl::Ops::BlockBCast8<BlockIdx>>;
 
+        /*! \class BlockBCast4
+        *  \brief  Permute class that broadcasts one block of 4 threads to all other blocks
+        *  @tparam BlockIdx block index [0 - WaveSize/4]
+        */
         template <uint32_t BlockIdx>
         using BlockBCast4 = Driver<PermuteImpl::Ops::BlockBCast4<BlockIdx>>;
 
+        /*! \class BlockBCast2
+        *  \brief  Permute class that broadcasts one block of 2 threads to all other blocks
+        *  @tparam BlockIdx block index [0 - WaveSize/2]
+        */
         template <uint32_t BlockIdx>
         using BlockBCast2 = Driver<PermuteImpl::Ops::BlockBCast2<BlockIdx>>;
 
+        /*! \class GatherWave
+        *  \brief  Permute class that pulls interleaved values based on VW in each group size.
+        * Interleaved offsets are where each thread will read from.
+        *  @tparam VW vector width [1, 2, 4, 8, 16]
+        *  @tparam ElementShift rotation offset [0 - VW]
+        */
         template <uint32_t VW, uint32_t ElementShift>
         using GatherWave = Driver<PermuteImpl::Ops::GatherWave<VW, ElementShift>>;
 
+        /*! \class Gather32
+        *  \brief  Permute class that pulls interleaved values based on VW in each group size of 32.
+        * Interleaved offsets are where each thread will read from.
+        *  @tparam VW vector width [1, 2, 4, 8, 16]
+        *  @tparam ElementShift rotation offset [0 - VW]
+        */
         template <uint32_t VW, uint32_t ElementShift>
         using Gather32 = Driver<PermuteImpl::Ops::Gather32<VW, ElementShift>>;
 
+        /*! \class Gather16
+        *  \brief  Permute class that pulls interleaved values based on VW in each group size of 16.
+        * Interleaved offsets are where each thread will read from.
+        *  @tparam VW vector width [1, 2, 4, 8, 16]
+        *  @tparam ElementShift rotation offset [0 - VW]
+        */
         template <uint32_t VW, uint32_t ElementShift>
         using Gather16 = Driver<PermuteImpl::Ops::Gather16<VW, ElementShift>>;
 
+        /*! \class ScatterWave
+        *  \brief  Permute class that pushes interleaved values based on VW in each group size.
+        * Interleaved offsets are where each thread will write to.
+        *  @tparam VW vector width [1, 2, 4, 8, 16]
+        *  @tparam ElementShift rotation offset [0 - VW]
+        */
         template <uint32_t VW, uint32_t ElementShift>
         using ScatterWave = Driver<PermuteImpl::Ops::ScatterWave<VW, ElementShift>>;
 
+        /*! \class Scatter32
+        *  \brief  Permute class that pushes interleaved values based on VW in each group size of 32.
+        * Interleaved offsets are where each thread will write to.
+        *  @tparam VW vector width [1, 2, 4, 8, 16]
+        *  @tparam ElementShift rotation offset [0 - VW]
+        */
         template <uint32_t VW, uint32_t ElementShift>
         using Scatter32 = Driver<PermuteImpl::Ops::Scatter32<VW, ElementShift>>;
 
+        /*! \class Scatter16
+        *  \brief  Permute class that pushes interleaved values based on VW in each group size of 16.
+        * Interleaved offsets are where each thread will write to.
+        *  @tparam VW vector width [1, 2, 4, 8, 16]
+        *  @tparam ElementShift rotation offset [0 - VW]
+        */
         template <uint32_t VW, uint32_t ElementShift>
         using Scatter16 = Driver<PermuteImpl::Ops::Scatter16<VW, ElementShift>>;
 
+        /*! \class RotateWaveL
+        *  \brief  Swizzle class that rotates all threads to the left
+        *  @tparam RotateDistance thread index [0 - WaveSize-1]
+        */
         template <uint32_t RotateDistance>
         using RotateWaveL = Driver<PermuteImpl::Ops::RotateWaveL<RotateDistance>>;
 
+        /*! \class RotateWaveR
+        *  \brief  Swizzle class that rotates all threads to the right
+        *  @tparam RotateDistance thread index [0 - WaveSize-1]
+        */
         template <uint32_t RotateDistance>
         using RotateWaveR = Driver<PermuteImpl::Ops::RotateWaveR<RotateDistance>>;
 

--- a/library/include/rocwmma/internal/swizzle.hpp
+++ b/library/include/rocwmma/internal/swizzle.hpp
@@ -126,73 +126,191 @@ namespace rocwmma
         // Func::exec(src0)
 
         // BCast variants
+
+        /*! \class BCast32
+        *  \brief  Swizzle class that broadcasts one thread to all threads in each group of 32
+        *  @tparam ElementIdx thread index [0-31]
+        */
         template <uint32_t ElementIdx>
         using BCast32 = Driver<SwizzleImpl::Ops::BCast32<ElementIdx>>;
 
+        /*! \class BCast16
+        *  \brief  Swizzle class that broadcasts one thread to all threads in each group of 16
+        *  @tparam ElementIdx thread index [0-15]
+        */
         template <uint32_t ElementIdx>
         using BCast16 = Driver<SwizzleImpl::Ops::BCast16<ElementIdx>>;
 
+        /*! \class BCast8
+        *  \brief  Swizzle class that broadcasts one thread to all threads in each group of 8
+        *  @tparam ElementIdx thread index [0-7]
+        */
         template <uint32_t ElementIdx>
         using BCast8 = Driver<SwizzleImpl::Ops::BCast8<ElementIdx>>;
 
+        /*! \class BCast4
+        *  \brief  Swizzle class that broadcasts one thread to all threads in each group of 4
+        *  @tparam ElementIdx thread index [0-3]
+        */
         template <uint32_t ElementIdx>
         using BCast4 = Driver<SwizzleImpl::Ops::BCast4<ElementIdx>>;
 
+        /*! \class BCast2
+        *  \brief  Swizzle class that broadcasts one thread to all threads in each group of 2
+        *  @tparam ElementIdx thread index [0-1]
+        */
         template <uint32_t ElementIdx>
         using BCast2 = Driver<SwizzleImpl::Ops::BCast2<ElementIdx>>;
 
         // Reverse variants
+
+        /*! \class Reverse32
+        *  \brief  Swizzle class that mirrors all threads in each group of 32
+        */
         using Reverse32 = Driver<SwizzleImpl::Ops::Reverse32>;
+
+        /*! \class Reverse16
+        *  \brief  Swizzle class that mirrors all threads in each group of 16
+        */
         using Reverse16 = Driver<SwizzleImpl::Ops::Reverse16>;
-        using Reverse8  = Driver<SwizzleImpl::Ops::Reverse8>;
-        using Reverse4  = Driver<SwizzleImpl::Ops::Reverse4>;
-        using Reverse2  = Driver<SwizzleImpl::Ops::Reverse2>;
+
+        /*! \class Reverse8
+        *  \brief  Swizzle class that mirrors all threads in each group of 8
+        */
+        using Reverse8 = Driver<SwizzleImpl::Ops::Reverse8>;
+
+        /*! \class Reverse4
+        *  \brief  Swizzle class that mirrors all threads in each group of 4
+        */
+        using Reverse4 = Driver<SwizzleImpl::Ops::Reverse4>;
+
+        /*! \class Reverse2
+        *  \brief  Swizzle class that mirrors all threads in each group of 2
+        */
+        using Reverse2 = Driver<SwizzleImpl::Ops::Reverse2>;
 
         // Rotate variants
+
+        /*! \class RotateL32
+        *  \brief  Swizzle class that rotates all threads to the left in each group of 32
+        *  @tparam RotateDistance thread index [0-31]
+        */
         template <uint32_t RotateDistance>
         using RotateL32 = Driver<SwizzleImpl::Ops::RotateL32<RotateDistance>>;
 
+        /*! \class RotateL16
+        *  \brief  Swizzle class that rotates all threads to the left in each group of 16
+        *  @tparam RotateDistance thread index [0-15]
+        */
         template <uint32_t RotateDistance>
         using RotateL16 = Driver<SwizzleImpl::Ops::RotateL16<RotateDistance>>;
 
+        /*! \class RotateL8
+        *  \brief  Swizzle class that rotates all threads to the left in each group of 8
+        *  @tparam RotateDistance thread index [0-7]
+        */
         template <uint32_t RotateDistance>
         using RotateL8 = Driver<SwizzleImpl::Ops::RotateL8<RotateDistance>>;
 
+        /*! \class RotateL4
+        *  \brief  Swizzle class that rotates all threads to the left in each group of 4
+        *  @tparam RotateDistance thread index [0-3]
+        */
         template <uint32_t RotateDistance>
         using RotateL4 = Driver<SwizzleImpl::Ops::RotateL4<RotateDistance>>;
 
+        /*! \class RotateL2
+        *  \brief  Swizzle class that rotates all threads to the left in each group of 2
+        *  @tparam RotateDistance thread index [0-1]
+        */
         template <uint32_t RotateDistance>
         using RotateL2 = Driver<SwizzleImpl::Ops::RotateL2<RotateDistance>>;
 
+        /*! \class RotateR32
+        *  \brief  Swizzle class that rotates all threads to the right in each group of 32
+        *  @tparam RotateDistance thread index [0-31]
+        */
         template <uint32_t RotateDistance>
         using RotateR32 = Driver<SwizzleImpl::Ops::RotateR32<RotateDistance>>;
 
+        /*! \class RotateR16
+        *  \brief  Swizzle class that rotates all threads to the right in each group of 16
+        *  @tparam RotateDistance thread index [0-15]
+        */
         template <uint32_t RotateDistance>
         using RotateR16 = Driver<SwizzleImpl::Ops::RotateR16<RotateDistance>>;
 
+        /*! \class RotateR8
+        *  \brief  Swizzle class that rotates all threads to the right in each group of 8
+        *  @tparam RotateDistance thread index [0-7]
+        */
         template <uint32_t RotateDistance>
         using RotateR8 = Driver<SwizzleImpl::Ops::RotateR8<RotateDistance>>;
 
+        /*! \class RotateR4
+        *  \brief  Swizzle class that rotates all threads to the right in each group of 4
+        *  @tparam RotateDistance thread index [0-3]
+        */
         template <uint32_t RotateDistance>
         using RotateR4 = Driver<SwizzleImpl::Ops::RotateR4<RotateDistance>>;
 
+        /*! \class RotateR2
+        *  \brief  Swizzle class that rotates all threads to the right in each group of 2
+        *  @tparam RotateDistance thread index [0-1]
+        */
         template <uint32_t RotateDistance>
         using RotateR2 = Driver<SwizzleImpl::Ops::RotateR2<RotateDistance>>;
 
         // Shuffle variants
+
+        /*! \class Shuffle4
+        *  \brief  Swizzle class that shuffles elements in each group of 4
+        *  @tparam Select0 element index [0-3]
+        *  @tparam Select1 element index [0-3]
+        *  @tparam Select2 element index [0-3]
+        *  @tparam Select3 element index [0-3]
+        */
         template <uint32_t Select0, uint32_t Select1, uint32_t Select2, uint32_t Select3>
         using Shuffle4 = Driver<SwizzleImpl::Ops::Shuffle4<Select0, Select1, Select2, Select3>>;
 
+        /*! \class Shuffle2
+        *  \brief  Swizzle class that shuffles elements in each group of 2
+        *  @tparam Select0 element index [0-1]
+        *  @tparam Select1 element index [0-1]
+        */
         template <uint32_t Select0, uint32_t Select1>
         using Shuffle2 = Driver<SwizzleImpl::Ops::Shuffle2<Select0, Select1>>;
 
         // Swap variants
+
+        /*! \class Swap16
+        *  \brief  Swizzle class that swaps neighbouring groups in sizes of 16
+        */
         using Swap16 = Driver<SwizzleImpl::Ops::Swap16>;
-        using Swap8  = Driver<SwizzleImpl::Ops::Swap8>;
-        using Swap4  = Driver<SwizzleImpl::Ops::Swap4>;
-        using Swap2  = Driver<SwizzleImpl::Ops::Swap2>;
+
+        /*! \class Swap8
+        *  \brief  Swizzle class that swaps neighbouring groups in sizes of 8
+        */
+        using Swap8 = Driver<SwizzleImpl::Ops::Swap8>;
+
+        /*! \class Swap4
+        *  \brief  Swizzle class that swaps neighbouring groups in sizes of 4
+        */
+        using Swap4 = Driver<SwizzleImpl::Ops::Swap4>;
+
+        /*! \class Swap2
+        *  \brief  Swizzle class that swaps neighbouring groups in sizes of 2
+        */
+        using Swap2 = Driver<SwizzleImpl::Ops::Swap2>;
 
         // Fft variants
+
+        /*! \class Fft
+        *  \brief  Swizzle class that applies a specific fft transform given by control codes.
+        *  For a listing of these codes, consult the ISA documentation for ds_swizzle.
+        *  @tparam SubGroupSize affect size of sub-groups [0, 1, 2, 4, 8, 16, 32]
+        *  @tparam FftCtrl control code for ds_swizzle fft function (see ISA)
+        */
         template <uint32_t SubGroupSize, uint32_t FftCtrl>
         using Fft = Driver<SwizzleImpl::Ops::Fft<SubGroupSize, FftCtrl>>;
         /** @}*/


### PR DESCRIPTION
- Updates documentation of cross-lane operations
- Adds Zip4/8/16/32 functionality to DPP
- DPP doesn't require conditional mask, so we can save registers