### PR TITLE
Cherry pick changelog notes for ROCm 6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,25 @@
 Documentation for rocWMMA is available at
 [https://rocm.docs.amd.com/projects/rocWMMA/en/latest](https://rocm.docs.amd.com/projects/rocWMMA/en/latest).
 
-## (Unreleased) rocWMMA 1.3.0 for ROCm 6.0.0
+## (Unreleased) rocWMMA 1.4.0 for ROCm 6.1.0
+
+### Additions
+
+* Added bf16 support for hipRTC sample
+
+### Changes
+
+* Changed Clang C++ version to C++17
+* Updated rocwmma_coop API
+* Linked rocWMMA to hiprtc
+
+### Fixes
+
+* Fixed compile/runtime arch checks
+* Built all test in large code model
+* Removed inefficient branching in layout loop unrolling
+
+## rocWMMA 1.3.0 for ROCm 6.0.0
 
 ### Additions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Documentation for rocWMMA is available at
 [https://rocm.docs.amd.com/projects/rocWMMA/en/latest](https://rocm.docs.amd.com/projects/rocWMMA/en/latest).
 
-## (Unreleased) rocWMMA 1.4.0 for ROCm 6.1.0
+## rocWMMA 1.4.0 for ROCm 6.1.0
 
 ### Additions
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ include(ROCMCheckTargetIds)
 include(ROCMClients)
 
 # Versioning via rocm-cmake
-set ( VERSION_STRING "1.3.0" )
+set ( VERSION_STRING "1.4.0" )
 rocm_setup_version( VERSION ${VERSION_STRING} )
 
 # configure a header file to pass the CMake version settings to the source


### PR DESCRIPTION
Also removes the "Unreleased" text for 6.1.0, since it is to be synced into the docs/6.1.0 branch for ReadtheDocs