### PR TITLE
Set CXX flags in debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,9 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-#Set Clang C++ Version
+#Set Clang C++ flags.
+set(CMAKE_CXX_FLAGS_DEBUG "-g -O2") # clang++ crashes without -O2
+set(CMAKE_CXX_FLAGS_MINSIZEREL "-O2 -DNDEBUG") # clang++ failed to build the project with the default -Os
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --driver-mode=g++ -Xclang -fallow-half-arguments-and-returns -D__HIP_HCC_COMPAT_MODE__=1 -Wno-format-nonliteral -parallel-jobs=4 -fclang-abi-compat=17")
 
 # Top level configs


### PR DESCRIPTION
clang++ crashes while building some hip code in debug and minsizerel mode.

Add -O2 as a workaround.

Hipcc does not have this issue since it adds -Ox implicitly.

