### PR TITLE
Use custom env with doxygen 1.9.8 for RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,4 +15,7 @@ python:
 build:
    os: ubuntu-22.04
    tools:
-      python: "3.8"
+      python: "mambaforge-22.9"
+
+conda:
+   environment: docs/environment.yml

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -1,0 +1,10 @@
+name: RTD
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.8
+  - pip
+  - doxygen=1.9.8
+  - pip:
+    - -r ./sphinx/requirements.txt


### PR DESCRIPTION
To eliminate faulty warnings in Doxygen 1.8 that cause the doc build to fail due to WARN_AS_ERROR=YES in the Doxyfile config