### PR TITLE
Refactor gemm kernel base

### DIFF
--- a/library/include/rocwmma/internal/config.hpp
+++ b/library/include/rocwmma/internal/config.hpp
@@ -26,9 +26,6 @@
 #ifndef ROCWMMA_CONFIG_HPP
 #define ROCWMMA_CONFIG_HPP
 
-namespace rocwmma
-{
-
 ///
 /// Architecture support
 /// Guaranteed symbols:
@@ -148,27 +145,21 @@ namespace rocwmma
 #define ROCWMMA_NO_HALF 0
 #endif // HIP_NO_HALF
 
-#if ROCWMMA_NO_HALF || (!ROCWMMA_NO_HALF && defined(__HIP_NO_HALF_CONVERSIONS__))
-#define ROCWMMA_TESTS_NO_HALF 1
-#else
-#define ROCWMMA_TESTS_NO_HALF 0
-#endif // !ROCWMMA_NO_HALF && defined(__HIP_NO_HALF_CONVERSIONS__)
-
 ///
 /// Sanity checks
 ///
 #if ROCWMMA_ARCH_GFX11
-    static_assert((bool)(ROCWMMA_WAVE32_MODE) && !(bool)(ROCWMMA_WAVE64_MODE),
-                  "rocWMMA supports only wave32 for gfx11 arch");
-    static_assert((bool)(ROCWMMA_BLOCK_DIM_16_SUPPORTED) && !(bool)(ROCWMMA_BLOCK_DIM_32_SUPPORTED),
-                  "rocWMMA supports only block size of 16 for gfx11 arch");
+static_assert((bool)(ROCWMMA_WAVE32_MODE) && !(bool)(ROCWMMA_WAVE64_MODE),
+              "rocWMMA supports only wave32 for gfx11 arch");
+static_assert((bool)(ROCWMMA_BLOCK_DIM_16_SUPPORTED) && !(bool)(ROCWMMA_BLOCK_DIM_32_SUPPORTED),
+              "rocWMMA supports only block size of 16 for gfx11 arch");
 #endif
 
 #if ROCWMMA_ARCH_GFX9
-    static_assert(!(bool)(ROCWMMA_WAVE32_MODE) && (bool)(ROCWMMA_WAVE64_MODE),
-                  "rocWMMA supports only wave64 for gfx9 arch");
-    static_assert((bool)(ROCWMMA_BLOCK_DIM_16_SUPPORTED) && (bool)(ROCWMMA_BLOCK_DIM_32_SUPPORTED),
-                  "rocWMMA requires block size of 16 and 32 for gfx9 arch");
+static_assert(!(bool)(ROCWMMA_WAVE32_MODE) && (bool)(ROCWMMA_WAVE64_MODE),
+              "rocWMMA supports only wave64 for gfx9 arch");
+static_assert((bool)(ROCWMMA_BLOCK_DIM_16_SUPPORTED) && (bool)(ROCWMMA_BLOCK_DIM_32_SUPPORTED),
+              "rocWMMA requires block size of 16 and 32 for gfx9 arch");
 #endif
 
 ///
@@ -181,7 +172,5 @@ namespace rocwmma
 #define ROCWMMA_HOST_DEVICE ROCWMMA_HOST ROCWMMA_DEVICE
 
 #define ROCWMMA_KERNEL __global__
-
-} // namespace rocwmma
 
 #endif // ROCWMMA_CONFIG_HPP

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -39,6 +39,8 @@
 
 #include <rocwmma/internal/types.hpp>
 
+#include "test_config.hpp"
+
 #include "device/common.hpp"
 
 #ifndef CHECK_HIP_ERROR

--- a/test/gemm/gemm_kernel_base.hpp
+++ b/test/gemm/gemm_kernel_base.hpp
@@ -169,14 +169,22 @@ namespace rocwmma
         ComputeT mAlpha, mBeta;
 
         // Execution flow control
-        uint32_t mRepeats;
+        uint32_t mColdRuns;
+        uint32_t mHotRuns;
         bool     mRunFlag          = true;
         bool     mValidationResult = false;
         double   mMaxRelativeError;
 
         // Performance
         float64_t mElapsedTimeMs, mTotalGFlops, mMeasuredTFlopsPerSec;
-        int32_t   mEfficiency, mReferenceEfficiency;
+        int32_t   mEfficiency;
+
+        // Reference
+        float64_t         mRefMeasuredTFlopsPerSec;
+        int32_t           mRefEfficiency;
+        static const bool mIsCpuRef;
+        static const bool mRunRefFlag;
+        static const bool mBenchRef;
     };
 
 } // namespace rocwmma

--- a/test/test_config.hpp
+++ b/test/test_config.hpp
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef ROCWMMA_TEST_CONFIG_HPP
+#define ROCWMMA_TEST_CONFIG_HPP
+
+#include <rocwmma/internal/config.hpp>
+
+///
+/// Testing symbols
+///
+#if defined(ROCWMMA_EXTENDED_TESTS)
+#define ROCWMMA_EXTENDED_TESTS 1
+#else
+#define ROCWMMA_EXTENDED_TESTS 0
+#endif
+
+#if defined(ROCWMMA_VALIDATION_TESTS)
+#define ROCWMMA_VALIDATION_TESTS 1
+#else
+#define ROCWMMA_VALIDATION_TESTS 0
+#endif
+
+#if defined(ROCWMMA_BENCHMARK_TESTS)
+#define ROCWMMA_BENCHMARK_TESTS 1
+#else
+#define ROCWMMA_BENCHMARK_TESTS 0
+#endif
+
+#if defined(ROCWMMA_BENCHMARK_WITH_ROCBLAS)
+#define ROCWMMA_BENCHMARK_WITH_ROCBLAS 1
+#else
+#define ROCWMMA_BENCHMARK_WITH_ROCBLAS 0
+#endif
+
+#if defined(ROCWMMA_VALIDATE_WITH_ROCBLAS)
+#define ROCWMMA_VALIDATE_WITH_ROCBLAS 1
+#else
+#define ROCWMMA_VALIDATE_WITH_ROCBLAS 0
+#endif
+
+#if ROCWMMA_BENCHMARK_WITH_ROCBLAS || ROCWMMA_VALIDATE_WITH_ROCBLAS
+#define ROCWMMA_ROCBLAS_INTEGRATION 1
+#else
+#define ROCWMMA_ROCBLAS_INTEGRATION 0
+#endif
+
+#if ROCWMMA_VALIDATION_TESTS && !ROCWMMA_VALIDATE_WITH_ROCBLAS
+#define ROCWMMA_VALIDATE_WITH_CPU 1
+#else
+#define ROCWMMA_VALIDATE_WITH_CPU 0
+#endif
+
+#if ROCWMMA_NO_HALF || (!ROCWMMA_NO_HALF && defined(__HIP_NO_HALF_CONVERSIONS__))
+#define ROCWMMA_TESTS_NO_HALF 1
+#else
+#define ROCWMMA_TESTS_NO_HALF 0
+#endif // !ROCWMMA_NO_HALF && defined(__HIP_NO_HALF_CONVERSIONS__)
+
+#endif // ROCWMMA_TEST_CONFIG_HPP


### PR DESCRIPTION
- Remove vast majority of #ifdefs code based on rocblas integration and validate / bench modes and simplify with static checks instead.
- Added cold iters to warm and to stabilize frequencies
- Added hot iters for actual benchmark timing
- Added rocBLAS throughput to display with efficiencies during benchmarks
- Fixed / prevent validation from running multiple times
- Removed redundant memory transfers to / from the host when they are not needed.
- For validation, re-used device C and D pointers to hold rocWMMA / reference data.
- Consolidate rocBLAS calls behind a dispatcher function
- Moved testing configuration out of library config into its own file
- Removed unnecessary namespace rocwmma scope from configs 