### PR TITLE
SWDEV-470979 - Remove apostrophe from the package description text (#406)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,7 @@ set(CPACK_RPM_PACKAGE_LICENSE "MIT")
 
 rocm_create_package(
   NAME rocwmma
-  DESCRIPTION "AMD's C++ library for facilitating GEMM, or GEMM-like 2D matrix multiplications on GPU leveraging MFMA instructions executing on matrix cores."
+  DESCRIPTION "AMD C++ library for facilitating GEMM, or GEMM-like 2D matrix multiplications on GPU leveraging MFMA instructions executing on matrix cores."
   MAINTAINER "rocWMMA Maintainer <rocwmma-maintainer@amd.com>"
   HEADER_ONLY
 )


### PR DESCRIPTION


While creating wheel package, the rpm tags are read from the rpm package. The apostrophe in the package description is causing syntax error while parsing the description tag.