### PR TITLE
Reduce count of cold and hot run

### DIFF
--- a/test/gemm/gemm_kernel_base_impl.hpp
+++ b/test/gemm/gemm_kernel_base_impl.hpp
@@ -392,8 +392,8 @@ namespace rocwmma
         mLda = mLdb = mLdc = mLdd = 0u;
         mAlpha = mBeta = static_cast<ComputeT>(0u);
 
-        mColdRuns = (bool)(ROCWMMA_VALIDATION_TESTS) ? 0u : 2u;
-        mHotRuns  = (bool)(ROCWMMA_VALIDATION_TESTS) ? 1u : 10u;
+        mColdRuns = (bool)(ROCWMMA_VALIDATION_TESTS) ? 0u : 1u;
+        mHotRuns  = (bool)(ROCWMMA_VALIDATION_TESTS) ? 1u : 5u;
 
         mRunFlag          = true;
         mValidationResult = false;


### PR DESCRIPTION
Reduce count of cold and hot run since it takes 5 hrs to run the bench test on navi3x

gemm test kernel used to run 5 times, but 12 times(2 cold + 10 hot) after 4daef2129da29a4a24eaaf6ca9075d2a12e198a6

Reduce the count of (cold + hot) run to make the execution time less than 3 hours on navi3x platforms