### PR TITLE
Refactor cross lane test

### DIFF
--- a/library/include/rocwmma/internal/blend_impl.hpp
+++ b/library/include/rocwmma/internal/blend_impl.hpp
@@ -290,17 +290,6 @@ namespace rocwmma
             using ExtractByteOddEven = PermByte<1u, 3u, 4u, 6u>;
             using ExtractWordEvenOdd = PermWord<0u, 3u>;
             using ExtractWordOddEven = PermWord<1u, 2u>;
-
-            using ExtractByteEven = PermByte<0u, 2u, 4u, 6u>;
-            using ExtractByteOdd  = PermByte<1u, 3u, 5u, 7u>;
-            using ExtractWordEven = UnpackWordLo;
-            using ExtractWordOdd  = UnpackWordHi;
-
-            using ExtractByteEvenOdd = PermByte<0u, 2u, 5u, 7u>;
-            using ExtractByteOddEven = PermByte<1u, 3u, 4u, 6u>;
-            using ExtractWordEvenOdd = PermWord<0u, 3u>;
-            using ExtractWordOddEven = PermWord<1u, 2u>;
-
         } // namespace Ops
 
     } // namespace BlendImpl

--- a/library/include/rocwmma/internal/permute_impl.hpp
+++ b/library/include/rocwmma/internal/permute_impl.hpp
@@ -237,6 +237,14 @@ namespace rocwmma
                 : public BPermuteOp<OP_ID_GATHER, SubGroupSize>,
                   public Backend::amdgcn_ds_bpermute<Ctrl::Interleave<SubGroupSize, VW, Shift>>
             {
+                constexpr static uint32_t vw()
+                {
+                    return VW;
+                }
+                constexpr static uint32_t shift()
+                {
+                    return Shift;
+                }
             };
 
             template <uint32_t SubGroupSize, uint32_t VW, uint32_t Shift>
@@ -244,6 +252,14 @@ namespace rocwmma
                 : public PermuteOp<OP_ID_SCATTER, SubGroupSize>,
                   public Backend::amdgcn_ds_permute<Ctrl::Interleave<SubGroupSize, VW, Shift>>
             {
+                constexpr static uint32_t vw()
+                {
+                    return VW;
+                }
+                constexpr static uint32_t shift()
+                {
+                    return Shift;
+                }
             };
 
             /*! \class Rotate

--- a/library/include/rocwmma/internal/utils.hpp
+++ b/library/include/rocwmma/internal/utils.hpp
@@ -293,6 +293,12 @@ namespace rocwmma
     }
 
     template <>
+    constexpr const char* dataTypeToString<uint64_t>()
+    {
+        return "u64";
+    }
+
+    template <>
     constexpr const char* dataTypeToString<row_major>()
     {
         return "T";

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -72,6 +72,8 @@
 
 namespace rocwmma
 {
+    static constexpr uint32_t ERROR_VALUE   = 0u;
+    static constexpr uint32_t SUCCESS_VALUE = 1u;
 
     template <uint32_t N>
     using I = std::integral_constant<uint32_t, N>;

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -72,8 +72,8 @@
 
 namespace rocwmma
 {
-    static constexpr uint32_t ERROR_VALUE   = 0u;
-    static constexpr uint32_t SUCCESS_VALUE = 1u;
+    static constexpr uint32_t ERROR_VALUE   = 7u;
+    static constexpr uint32_t SUCCESS_VALUE = 0u;
 
     template <uint32_t N>
     using I = std::integral_constant<uint32_t, N>;

--- a/test/unit/cross_lane_ops_test/CMakeLists.txt
+++ b/test/unit/cross_lane_ops_test/CMakeLists.txt
@@ -99,6 +99,8 @@ set(CrossLaneOpsTestSources ${UnitCommonSources}
                            ${CMAKE_CURRENT_SOURCE_DIR}/test/permute_block_bcast_8.cpp
                            ${CMAKE_CURRENT_SOURCE_DIR}/test/permute_block_bcast_16.cpp
                            ${CMAKE_CURRENT_SOURCE_DIR}/test/permute_block_bcast_32.cpp
+                           ${CMAKE_CURRENT_SOURCE_DIR}/test/permute_rotate.cpp
+                           # ${CMAKE_CURRENT_SOURCE_DIR}/test/permute_gather_scatter.cpp
 
                            # Blend
                            ${CMAKE_CURRENT_SOURCE_DIR}/test/blend_unpack_byte_hi_lo.cpp
@@ -108,6 +110,7 @@ set(CrossLaneOpsTestSources ${UnitCommonSources}
                            ${CMAKE_CURRENT_SOURCE_DIR}/test/blend_unpack_word_lo.cpp
                            ${CMAKE_CURRENT_SOURCE_DIR}/test/blend_zip_byte.cpp
                            ${CMAKE_CURRENT_SOURCE_DIR}/test/blend_zip_word.cpp
+                           ${CMAKE_CURRENT_SOURCE_DIR}/test/blend_zip.cpp
 
 )
 

--- a/test/unit/cross_lane_ops_test/CMakeLists.txt
+++ b/test/unit/cross_lane_ops_test/CMakeLists.txt
@@ -100,7 +100,7 @@ set(CrossLaneOpsTestSources ${UnitCommonSources}
                            ${CMAKE_CURRENT_SOURCE_DIR}/test/permute_block_bcast_16.cpp
                            ${CMAKE_CURRENT_SOURCE_DIR}/test/permute_block_bcast_32.cpp
                            ${CMAKE_CURRENT_SOURCE_DIR}/test/permute_rotate.cpp
-                           # ${CMAKE_CURRENT_SOURCE_DIR}/test/permute_gather_scatter.cpp
+                           ${CMAKE_CURRENT_SOURCE_DIR}/test/permute_gather_scatter.cpp
 
                            # Blend
                            ${CMAKE_CURRENT_SOURCE_DIR}/test/blend_unpack_byte_hi_lo.cpp

--- a/test/unit/cross_lane_ops_test/CMakeLists.txt
+++ b/test/unit/cross_lane_ops_test/CMakeLists.txt
@@ -100,7 +100,7 @@ set(CrossLaneOpsTestSources ${UnitCommonSources}
                            ${CMAKE_CURRENT_SOURCE_DIR}/test/permute_block_bcast_16.cpp
                            ${CMAKE_CURRENT_SOURCE_DIR}/test/permute_block_bcast_32.cpp
                            ${CMAKE_CURRENT_SOURCE_DIR}/test/permute_rotate.cpp
-                           ${CMAKE_CURRENT_SOURCE_DIR}/test/permute_gather_scatter.cpp
+                           # ${CMAKE_CURRENT_SOURCE_DIR}/test/permute_gather_scatter.cpp
 
                            # Blend
                            ${CMAKE_CURRENT_SOURCE_DIR}/test/blend_unpack_byte_hi_lo.cpp
@@ -111,6 +111,10 @@ set(CrossLaneOpsTestSources ${UnitCommonSources}
                            ${CMAKE_CURRENT_SOURCE_DIR}/test/blend_zip_byte.cpp
                            ${CMAKE_CURRENT_SOURCE_DIR}/test/blend_zip_word.cpp
                            ${CMAKE_CURRENT_SOURCE_DIR}/test/blend_zip.cpp
+                           ${CMAKE_CURRENT_SOURCE_DIR}/test/blend_extract_byte_even.cpp
+                           ${CMAKE_CURRENT_SOURCE_DIR}/test/blend_extract_byte_odd.cpp
+                           ${CMAKE_CURRENT_SOURCE_DIR}/test/blend_extract_word_even.cpp
+                           ${CMAKE_CURRENT_SOURCE_DIR}/test/blend_extract_word_odd.cpp
 
 )
 

--- a/test/unit/cross_lane_ops_test/detail/cross_lane_ops.hpp
+++ b/test/unit/cross_lane_ops_test/detail/cross_lane_ops.hpp
@@ -99,13 +99,10 @@ namespace rocwmma
 
             bool permuteWaveRotateCheck
                 = !((isGfx11 || isGfx12)
-                    && (CrossLaneOp::opImpl() == CrossLaneOps::Properties::OP_IMPL_PERMUTE ||
-                        CrossLaneOp::opImpl() == CrossLaneOps::Properties::OP_IMPL_BPERMUTE
-                        )
+                    && (CrossLaneOp::opImpl() == CrossLaneOps::Properties::OP_IMPL_PERMUTE
+                        || CrossLaneOp::opImpl() == CrossLaneOps::Properties::OP_IMPL_BPERMUTE)
                     && (CrossLaneOp::opId() == CrossLaneOps::Properties::OP_ID_ROTATE)
                     && (CrossLaneOp::groupSize() == CrossLaneOps::Properties::OP_GROUP_SIZE_WARP));
-
-            printf("permuteWaveRotateCheck %d\n", permuteWaveRotateCheck);
 
             return Base::checkDevice() && dppBCast16Check && dppWaveShiftCheck && dppWaveRotateCheck
                    && dppWaterfallBCastCheck && permuteWaveRotateCheck;

--- a/test/unit/cross_lane_ops_test/detail/cross_lane_ops.hpp
+++ b/test/unit/cross_lane_ops_test/detail/cross_lane_ops.hpp
@@ -54,22 +54,6 @@ namespace rocwmma
         CrossLaneOpsKernelBase()          = default;
         virtual ~CrossLaneOpsKernelBase() = default;
 
-        dim3 gridDim() const final
-        {
-            // Need to address the input array as 32b elements per thread.
-            auto x = dim3(static_cast<uint32_t>(
-                              roundf(static_cast<float32_t>(Base::mM * Base::mN)
-                                     / static_cast<float32_t>(PackTraits<DataT>::PackRatio)))
-                          / Base::mTBlockX);
-
-            return x;
-        }
-
-        dim3 blockDim() const final
-        {
-            return dim3(Base::mTBlockX);
-        }
-
         bool checkSizes() const final
         {
             return (Base::mTBlockY == 1);

--- a/test/unit/cross_lane_ops_test/detail/cross_lane_ops.hpp
+++ b/test/unit/cross_lane_ops_test/detail/cross_lane_ops.hpp
@@ -97,8 +97,18 @@ namespace rocwmma
                     && (CrossLaneOp::opImpl() == CrossLaneOps::Properties::OP_IMPL_DPP)
                     && (CrossLaneOp::opId() == CrossLaneOps::Properties::OP_ID_WFALL_BCAST));
 
+            bool permuteWaveRotateCheck
+                = !((isGfx11 || isGfx12)
+                    && (CrossLaneOp::opImpl() == CrossLaneOps::Properties::OP_IMPL_PERMUTE ||
+                        CrossLaneOp::opImpl() == CrossLaneOps::Properties::OP_IMPL_BPERMUTE
+                        )
+                    && (CrossLaneOp::opId() == CrossLaneOps::Properties::OP_ID_ROTATE)
+                    && (CrossLaneOp::groupSize() == CrossLaneOps::Properties::OP_GROUP_SIZE_WARP));
+
+            printf("permuteWaveRotateCheck %d\n", permuteWaveRotateCheck);
+
             return Base::checkDevice() && dppBCast16Check && dppWaveShiftCheck && dppWaveRotateCheck
-                   && dppWaterfallBCastCheck;
+                   && dppWaterfallBCastCheck && permuteWaveRotateCheck;
         }
 
         std::ostream& printHeader(std::ostream& stream = std::cout) const final

--- a/test/unit/cross_lane_ops_test/detail/cross_lane_ops.hpp
+++ b/test/unit/cross_lane_ops_test/detail/cross_lane_ops.hpp
@@ -97,15 +97,8 @@ namespace rocwmma
                     && (CrossLaneOp::opImpl() == CrossLaneOps::Properties::OP_IMPL_DPP)
                     && (CrossLaneOp::opId() == CrossLaneOps::Properties::OP_ID_WFALL_BCAST));
 
-            bool permuteWaveRotateCheck
-                = !((isGfx11 || isGfx12)
-                    && (CrossLaneOp::opImpl() == CrossLaneOps::Properties::OP_IMPL_PERMUTE
-                        || CrossLaneOp::opImpl() == CrossLaneOps::Properties::OP_IMPL_BPERMUTE)
-                    && (CrossLaneOp::opId() == CrossLaneOps::Properties::OP_ID_ROTATE)
-                    && (CrossLaneOp::groupSize() == CrossLaneOps::Properties::OP_GROUP_SIZE_WARP));
-
             return Base::checkDevice() && dppBCast16Check && dppWaveShiftCheck && dppWaveRotateCheck
-                   && dppWaterfallBCastCheck && permuteWaveRotateCheck;
+                   && dppWaterfallBCastCheck;
         }
 
         std::ostream& printHeader(std::ostream& stream = std::cout) const final

--- a/test/unit/cross_lane_ops_test/detail/cross_lane_ops.hpp
+++ b/test/unit/cross_lane_ops_test/detail/cross_lane_ops.hpp
@@ -187,6 +187,8 @@ namespace rocwmma
     struct DppOpsKernel final
         : public CrossLaneOpsKernelBase<DataT, CrossLaneOp, WriteRowMask, WriteBankMask, BoundCtrl>
     {
+        static_assert((CrossLaneOp::GROUP_SIZE & (CrossLaneOp::GROUP_SIZE - 1)) == 0,
+                      "SubGroupSize must be power of 2.");
         using Base = UnitKernelBase<1, 1, DataT, col_major>;
 
     public:

--- a/test/unit/cross_lane_ops_test/device/blend_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/blend_ops.hpp
@@ -34,7 +34,7 @@ namespace rocwmma
     template <typename DataT, typename CrossLaneOp>
     ROCWMMA_DEVICE bool blendOpsTestCase()
     {
-        return false;
+        return true;
     }
 
 } // namespace rocwmma

--- a/test/unit/cross_lane_ops_test/device/blend_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/blend_ops.hpp
@@ -31,6 +31,10 @@
 
 namespace rocwmma
 {
+    /**
+	 * @addtogroup cross_lane_op_gen_ref_value_funcs
+	 * @{
+	 */
     ROCWMMA_DEVICE inline uint32_t
         getBlendPermByte(uint32_t input0, uint32_t input1, uint32_t select)
     {
@@ -61,6 +65,7 @@ namespace rocwmma
     {
         return (idx / SubGroupSize) & 0x1 ? input1 : input0;
     }
+    /** @} */
 
     template <typename DataT, typename CrossLaneOp>
     ROCWMMA_DEVICE std::enable_if_t<CrossLaneOp::opId() == CrossLaneOps::OP_ID_PERM_BYTE

--- a/test/unit/cross_lane_ops_test/device/blend_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/blend_ops.hpp
@@ -32,34 +32,34 @@
 namespace rocwmma
 {
     ROCWMMA_DEVICE inline uint32_t
-        getBlendPermByte(uint32_t input1, uint32_t input2, uint32_t select)
+        getBlendPermByte(uint32_t input0, uint32_t input1, uint32_t select)
     {
         // check the invokation of __builtin_amdgcn_perm in blend_impl.hpp
         // "src0 and src1 are flipped". So do same here.
-        uint64_t inputRegs = input2;
-        inputRegs          = inputRegs << 32 | input1;
+        uint64_t inputRegs = input1;
+        inputRegs          = inputRegs << 32 | input0;
 
         return (inputRegs >> (select * 8)) & 0xFF;
     }
 
     template <uint32_t Select0, uint32_t Select1, uint32_t Select2, uint32_t Select3>
-    ROCWMMA_DEVICE inline int getBlendPermByteExpect(int input1, int input2)
+    ROCWMMA_DEVICE inline uint32_t getBlendPermByteExpect(uint32_t input0, uint32_t input1)
     {
         uint32_t output = 0;
-        output |= getBlendPermByte(input1, input2, Select3);
+        output |= getBlendPermByte(input0, input1, Select3);
         output <<= 8;
-        output |= getBlendPermByte(input1, input2, Select2);
+        output |= getBlendPermByte(input0, input1, Select2);
         output <<= 8;
-        output |= getBlendPermByte(input1, input2, Select1);
+        output |= getBlendPermByte(input0, input1, Select1);
         output <<= 8;
-        output |= getBlendPermByte(input1, input2, Select0);
+        output |= getBlendPermByte(input0, input1, Select0);
         return output;
     }
 
     template <uint32_t SubGroupSize>
-    ROCWMMA_DEVICE inline int getBlendZipExpect(int input1, int input2)
+    ROCWMMA_DEVICE inline uint32_t getBlendZipExpect(uint32_t input0, uint32_t input1, uint32_t idx)
     {
-        return 0;
+        return (idx / SubGroupSize) & 0x1 ? input1 : input0;
     }
 
     template <typename DataT, typename CrossLaneOp>
@@ -68,23 +68,15 @@ namespace rocwmma
                                     bool>
                    blendOpsTestCase()
     {
-        int input1 = 0x05060708;
-        int input2 = 0x01020304;
-        int expect = getBlendPermByteExpect<CrossLaneOp::select0(),
-                                            CrossLaneOp::select1(),
-                                            CrossLaneOp::select2(),
-                                            CrossLaneOp::select3()>(input1, input2);
-        int output = rocwmma::Blend::Driver<CrossLaneOp>::exec(input1, input2);
+        uint32_t input0 = 0x05060708;
+        uint32_t input1 = 0x01020304;
+        uint32_t expect = getBlendPermByteExpect<CrossLaneOp::select0(),
+                                                 CrossLaneOp::select1(),
+                                                 CrossLaneOp::select2(),
+                                                 CrossLaneOp::select3()>(input0, input1);
+        uint32_t output = rocwmma::Blend::Driver<CrossLaneOp>::exec(input0, input1);
 
-        printf("op perm byte (%d, %d, %d, %d), input1 %x, input2 %x, expect %x, output %x\n",
-               CrossLaneOp::select0(),
-               CrossLaneOp::select1(),
-               CrossLaneOp::select2(),
-               CrossLaneOp::select3(),
-               input1,
-               input2,
-               expect,
-               output);
+        // printf("op perm byte (%d, %d, %d, %d), input0 %x, input1 %x, expect %x, output %x\n", CrossLaneOp::select0(), CrossLaneOp::select1(), CrossLaneOp::select2(), CrossLaneOp::select3(), input0, input1, expect, output);
         return output != expect;
     }
 
@@ -94,12 +86,12 @@ namespace rocwmma
                                     bool>
                    blendOpsTestCase()
     {
-        int input1 = threadIdx.x;
-        int input2 = threadIdx.x;
-        int expect = getBlendZipExpect<CrossLaneOp::groupSize()>(input1, input2);
-        int output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input1, input2);
+        uint32_t input0 = 0;
+        uint32_t input1 = 1;
+        uint32_t expect = getBlendZipExpect<CrossLaneOp::groupSize()>(input0, input1, threadIdx.x);
+        uint32_t output = rocwmma::Blend::Driver<CrossLaneOp>::exec(input0, input1);
 
-        // printf("op zip (%d), input1 %d, input2 %d, expect %d, output %d\n", CrossLaneOp::groupSize(), input1, input2, expect , output );
+        // printf("op zip (%d), input0 %d, input1 %d, expect %d, output %d\n", CrossLaneOp::groupSize(), input0, input1, expect , output );
         return output != expect;
     }
 

--- a/test/unit/cross_lane_ops_test/device/blend_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/blend_ops.hpp
@@ -27,7 +27,7 @@
 #ifndef ROCWMMA_DEVICE_BLEND_OPS_HPP
 #define ROCWMMA_DEVICE_BLEND_OPS_HPP
 
-#include <rocwmma/rocwmma.hpp>
+#include "cross_lane_ops_util.hpp"
 
 namespace rocwmma
 {
@@ -68,15 +68,16 @@ namespace rocwmma
                                     bool>
                    blendOpsTestCase()
     {
-        uint32_t input0 = 0x05060708;
-        uint32_t input1 = 0x01020304;
-        uint32_t expect = getBlendPermByteExpect<CrossLaneOp::select0(),
-                                                 CrossLaneOp::select1(),
-                                                 CrossLaneOp::select2(),
-                                                 CrossLaneOp::select3()>(input0, input1);
-        uint32_t output = rocwmma::Blend::Driver<CrossLaneOp>::exec(input0, input1);
+        DataT input0 = makeValueFromU32<DataT>(0x05060708);
+        DataT input1 = makeValueFromU32<DataT>(0x01020304);
+        DataT expect = makeValueFromU32<DataT>(
+            getBlendPermByteExpect<CrossLaneOp::select0(),
+                                   CrossLaneOp::select1(),
+                                   CrossLaneOp::select2(),
+                                   CrossLaneOp::select3()>(input0, input1));
+        DataT output = rocwmma::Blend::Driver<CrossLaneOp>::exec(input0, input1);
 
-        // printf("op perm byte (%d, %d, %d, %d), input0 %x, input1 %x, expect %x, output %x\n", CrossLaneOp::select0(), CrossLaneOp::select1(), CrossLaneOp::select2(), CrossLaneOp::select3(), input0, input1, expect, output);
+        // printf("op perm byte (%d, %d, %d, %d), input0 %lx, input1 %lx, expect %lx, output %lx\n", CrossLaneOp::select0(), CrossLaneOp::select1(), CrossLaneOp::select2(), CrossLaneOp::select3(), (uint64_t)input0, (uint64_t)input1, (uint64_t)expect, (uint64_t)output);
         return output != expect;
     }
 
@@ -86,10 +87,11 @@ namespace rocwmma
                                     bool>
                    blendOpsTestCase()
     {
-        uint32_t input0 = 0;
-        uint32_t input1 = 1;
-        uint32_t expect = getBlendZipExpect<CrossLaneOp::groupSize()>(input0, input1, threadIdx.x);
-        uint32_t output = rocwmma::Blend::Driver<CrossLaneOp>::exec(input0, input1);
+        DataT input0 = makeValueFromU32<DataT>(1);
+        DataT input1 = makeValueFromU32<DataT>(2);
+        DataT expect = makeValueFromU32<DataT>(
+            getBlendZipExpect<CrossLaneOp::groupSize()>(input0, input1, threadIdx.x));
+        DataT output = rocwmma::Blend::Driver<CrossLaneOp>::exec(input0, input1);
 
         // printf("op zip (%d), input0 %d, input1 %d, expect %d, output %d\n", CrossLaneOp::groupSize(), input0, input1, expect , output );
         return output != expect;

--- a/test/unit/cross_lane_ops_test/device/blend_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/blend_ops.hpp
@@ -82,7 +82,6 @@ namespace rocwmma
                                    CrossLaneOp::select3()>(input0, input1));
         DataT output = rocwmma::Blend::Driver<CrossLaneOp>::exec(input0, input1);
 
-        // printf("op perm byte (%d, %d, %d, %d), input0 %lx, input1 %lx, expect %lx, output %lx\n", CrossLaneOp::select0(), CrossLaneOp::select1(), CrossLaneOp::select2(), CrossLaneOp::select3(), (uint64_t)input0, (uint64_t)input1, (uint64_t)expect, (uint64_t)output);
         return output != expect;
     }
 
@@ -98,7 +97,6 @@ namespace rocwmma
             getBlendZipExpect<CrossLaneOp::groupSize()>(input0, input1, threadIdx.x));
         DataT output = rocwmma::Blend::Driver<CrossLaneOp>::exec(input0, input1);
 
-        // printf("op zip (%d), input0 %d, input1 %d, expect %d, output %d\n", CrossLaneOp::groupSize(), input0, input1, expect , output );
         return output != expect;
     }
 

--- a/test/unit/cross_lane_ops_test/device/blend_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/blend_ops.hpp
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#ifndef ROCWMMA_DEVICE_BLEND_OPS_HPP
+#define ROCWMMA_DEVICE_BLEND_OPS_HPP
+
+#include <rocwmma/rocwmma.hpp>
+
+namespace rocwmma
+{
+    template <typename DataT, typename CrossLaneOp>
+    ROCWMMA_DEVICE bool blendOpsTestCase()
+    {
+        return false;
+    }
+
+} // namespace rocwmma
+
+#endif // ROCWMMA_DEVICE_BLEND_OPS_HPP

--- a/test/unit/cross_lane_ops_test/device/cross_lane_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/cross_lane_ops.hpp
@@ -118,8 +118,17 @@ namespace rocwmma
                                        DataT        param1,
                                        DataT        param2)
     {
+        __shared__ uint32_t sharedSrcValues[Constants::AMDGCN_WAVE_SIZE];
+        uint32_t*           srcValues = sharedSrcValues;
         crossLaneOpsTest<DataT>(
-            permuteOpsTestCase<DataT, CrossLaneOp>, m, n, in, out, ld, param1, param2);
+            [srcValues]() { return permuteOpsTestCase<DataT, CrossLaneOp>(srcValues); },
+            m,
+            n,
+            in,
+            out,
+            ld,
+            param1,
+            param2);
     }
 
     template <typename DataT, typename CrossLaneOp>

--- a/test/unit/cross_lane_ops_test/device/cross_lane_ops_util.hpp
+++ b/test/unit/cross_lane_ops_test/device/cross_lane_ops_util.hpp
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#ifndef ROCWMMA_DEVICE_CROSS_LANE_OPS_UTIL_HPP
+#define ROCWMMA_DEVICE_CROSS_LANE_OPS_UTIL_HPP
+
+#include <rocwmma/rocwmma.hpp>
+
+namespace rocwmma
+{
+    constexpr uint32_t VALUE_OUT_OF_RANGE = 100; // 100 is out of [0, SubGroupSize]
+
+    template <typename DataT>
+    ROCWMMA_DEVICE inline DataT makeValueFromU32(uint32_t input)
+    {
+        static_assert(std::is_same_v<uint32_t, DataT> || std::is_same_v<uint64_t, DataT>,
+                      "DataT must be uint32_t or uint64_t. We only test these 2 types");
+        if constexpr(std::is_same_v<uint64_t, DataT>)
+        {
+            uint64_t output = input;
+            output          = output << 32 | input;
+            return output;
+        }
+        else
+        {
+            return input;
+        }
+    }
+
+} // namespace rocwmma
+
+#endif // ROCWMMA_DEVICE_CROSS_LANE_OPS_UTIL_HPP

--- a/test/unit/cross_lane_ops_test/device/cross_lane_ops_util.hpp
+++ b/test/unit/cross_lane_ops_test/device/cross_lane_ops_util.hpp
@@ -33,6 +33,14 @@ namespace rocwmma
 {
     constexpr uint32_t VALUE_OUT_OF_RANGE = 100; // 100 is out of [0, SubGroupSize]
 
+    /**
+	 * @defgroup cross_lane_op_gen_ref_value_funcs Reference values generators of cross-lane ops
+	 *
+	 * This group contains functions related to generate reference values of cross-lane ops.
+	 *
+	 * All functions in this group share the following properties:
+	 * - The parameter input is set to threadIdx.x
+	 */
     template <typename DataT>
     ROCWMMA_DEVICE inline DataT makeValueFromU32(uint32_t input)
     {

--- a/test/unit/cross_lane_ops_test/device/dpp_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/dpp_ops.hpp
@@ -138,7 +138,6 @@ namespace rocwmma
             = rocwmma::Dpp::Driver<CrossLaneOp, WriteRowMask, WriteBankMask, BoundCtrl>::exec(
                 input, makeValueFromU32<DataT>(prev));
 
-        // printf("op 0, input %d, WriteRowMask %x, WriteBankMask %x, BoundCtrl %d, expect %d, output %d\n",  input , WriteRowMask , WriteBankMask , BoundCtrl, expect , output );
         return output != expect;
     }
 
@@ -162,7 +161,6 @@ namespace rocwmma
             = rocwmma::Dpp::Driver<CrossLaneOp, WriteRowMask, WriteBankMask, BoundCtrl>::exec(
                 input, makeValueFromU32<DataT>(prev));
 
-        // printf("op 0, input %lx, WriteRowMask %x, WriteBankMask %x, BoundCtrl %d, expect %lx, output %lx\n",  (uint64_t)input , WriteRowMask , WriteBankMask , BoundCtrl, (uint64_t)expect , (uint64_t)output );
         return output != expect;
     }
 
@@ -189,7 +187,6 @@ namespace rocwmma
             = rocwmma::Dpp::Driver<CrossLaneOp, WriteRowMask, WriteBankMask, BoundCtrl>::exec(
                 input, makeValueFromU32<DataT>(prev));
 
-        // printf("op (%d, %d, %d), input %d, WriteRowMask %x, WriteBankMask %x, BoundCtrl %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::OP_DIR, CrossLaneOp::OP_DIST, input , WriteRowMask , WriteBankMask , BoundCtrl, expect , output );
         return output != expect;
     }
 
@@ -216,7 +213,6 @@ namespace rocwmma
             = rocwmma::Dpp::Driver<CrossLaneOp, WriteRowMask, WriteBankMask, BoundCtrl>::exec(
                 input, makeValueFromU32<DataT>(prev));
 
-        // printf("op (%d, %d, %d), input %d, WriteRowMask %x, WriteBankMask %x, BoundCtrl %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::OP_DIR, CrossLaneOp::OP_DIST, input , WriteRowMask , WriteBankMask , BoundCtrl, expect , output );
         return output != expect;
     }
 
@@ -254,7 +250,6 @@ namespace rocwmma
             = rocwmma::Dpp::Driver<CrossLaneOp, WriteRowMask, WriteBankMask, BoundCtrl>::exec(
                 input, makeValueFromU32<DataT>(prev));
 
-        // printf("op (%d, %d), input %d, WriteRowMask %x, WriteBankMask %x, BoundCtrl %d, expect %d, output %d\n", CrossLaneOp::SELECT_0, CrossLaneOp::SELECT_1, input , WriteRowMask , WriteBankMask , BoundCtrl, expect , output );
         return output != expect;
     }
 
@@ -278,7 +273,6 @@ namespace rocwmma
             = rocwmma::Dpp::Driver<CrossLaneOp, WriteRowMask, WriteBankMask, BoundCtrl>::exec(
                 input, makeValueFromU32<DataT>(prev));
 
-        // printf("op (%d, %d), input %d, WriteRowMask %x, WriteBankMask %x, BoundCtrl %d, expect %d, output %d\n", CrossLaneOp::SELECT_0, CrossLaneOp::SELECT_1, input , WriteRowMask , WriteBankMask , BoundCtrl, expect , output );
         return output != expect;
     }
 
@@ -302,7 +296,6 @@ namespace rocwmma
             = rocwmma::Dpp::Driver<CrossLaneOp, WriteRowMask, WriteBankMask, BoundCtrl>::exec(
                 input, makeValueFromU32<DataT>(prev));
 
-        // printf("op (%d, %d), input %d, WriteRowMask %x, WriteBankMask %x, BoundCtrl %d, expect %d, output %d\n", CrossLaneOp::SELECT_0, CrossLaneOp::SELECT_1, input , WriteRowMask , WriteBankMask , BoundCtrl, expect , output );
         return output != expect;
     }
 } // namespace rocwmma

--- a/test/unit/cross_lane_ops_test/device/dpp_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/dpp_ops.hpp
@@ -28,7 +28,6 @@
 #define ROCWMMA_DEVICE_DPP_OPS_HPP
 
 #include "cross_lane_ops_util.hpp"
-#include <rocwmma/rocwmma.hpp>
 
 namespace rocwmma
 {
@@ -154,7 +153,7 @@ namespace rocwmma
         DataT    input    = makeValueFromU32<DataT>(id);
         bool     isMasked = isDppMasked(id, WriteRowMask, WriteBankMask);
         DataT    expect   = makeValueFromU32<DataT>(
-            isMasked ? getDppReverseExpect<CrossLaneOp::GROUP_SIZE>(input) : prev);
+            isMasked ? getDppReverseExpect<CrossLaneOp::GROUP_SIZE>(id) : prev);
         DataT output
             = rocwmma::Dpp::Driver<CrossLaneOp, WriteRowMask, WriteBankMask, BoundCtrl>::exec(
                 input, makeValueFromU32<DataT>(prev));
@@ -180,7 +179,7 @@ namespace rocwmma
         DataT    expect
             = makeValueFromU32<DataT>(isMasked ? getDppRotateExpect<CrossLaneOp::GROUP_SIZE,
                                                                     CrossLaneOp::OP_DIR,
-                                                                    CrossLaneOp::OP_DIST>(input)
+                                                                    CrossLaneOp::OP_DIST>(id)
                                                : prev);
         DataT output
             = rocwmma::Dpp::Driver<CrossLaneOp, WriteRowMask, WriteBankMask, BoundCtrl>::exec(
@@ -235,17 +234,17 @@ namespace rocwmma
         if constexpr(CrossLaneOp::groupSize() == 2)
         {
             expect = makeValueFromU32<DataT>(
-                isMasked ? getDppShuffle2Expect<CrossLaneOp::SELECT_0, CrossLaneOp::SELECT_1>(input)
+                isMasked ? getDppShuffle2Expect<CrossLaneOp::SELECT_0, CrossLaneOp::SELECT_1>(id)
                          : prev);
         }
         else if constexpr(CrossLaneOp::groupSize() == 4)
         {
-            expect = makeValueFromU32<DataT>(
-                isMasked ? getDppShuffle4Expect<CrossLaneOp::SELECT_0,
-                                                CrossLaneOp::SELECT_1,
-                                                CrossLaneOp::SELECT_2,
-                                                CrossLaneOp::SELECT_3>(input)
-                         : prev);
+            expect
+                = makeValueFromU32<DataT>(isMasked ? getDppShuffle4Expect<CrossLaneOp::SELECT_0,
+                                                                          CrossLaneOp::SELECT_1,
+                                                                          CrossLaneOp::SELECT_2,
+                                                                          CrossLaneOp::SELECT_3>(id)
+                                                   : prev);
         }
         DataT output
             = rocwmma::Dpp::Driver<CrossLaneOp, WriteRowMask, WriteBankMask, BoundCtrl>::exec(
@@ -270,7 +269,7 @@ namespace rocwmma
         DataT    input    = makeValueFromU32<DataT>(id);
         bool     isMasked = isDppMasked(id, WriteRowMask, WriteBankMask);
         DataT    expect   = makeValueFromU32<DataT>(
-            isMasked ? getDppSwapExpect<CrossLaneOp::GROUP_SIZE>(input) : prev);
+            isMasked ? getDppSwapExpect<CrossLaneOp::GROUP_SIZE>(id) : prev);
         DataT output
             = rocwmma::Dpp::Driver<CrossLaneOp, WriteRowMask, WriteBankMask, BoundCtrl>::exec(
                 input, makeValueFromU32<DataT>(prev));
@@ -294,7 +293,7 @@ namespace rocwmma
         DataT    input    = makeValueFromU32<DataT>(id);
         bool     isMasked = isDppMasked(id, WriteRowMask, WriteBankMask);
         DataT    expect   = makeValueFromU32<DataT>(
-            isMasked ? getDppWFallBCastExpect<CrossLaneOp::GROUP_SIZE>(input) : prev);
+            isMasked ? getDppWFallBCastExpect<CrossLaneOp::GROUP_SIZE>(id) : prev);
         DataT output
             = rocwmma::Dpp::Driver<CrossLaneOp, WriteRowMask, WriteBankMask, BoundCtrl>::exec(
                 input, makeValueFromU32<DataT>(prev));

--- a/test/unit/cross_lane_ops_test/device/dpp_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/dpp_ops.hpp
@@ -40,7 +40,6 @@ namespace rocwmma
     {
         return true;
     }
-
 } // namespace rocwmma
 
 #endif // ROCWMMA_DEVICE_DPP_OPS_HPP

--- a/test/unit/cross_lane_ops_test/device/dpp_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/dpp_ops.hpp
@@ -27,29 +27,11 @@
 #ifndef ROCWMMA_DEVICE_DPP_OPS_HPP
 #define ROCWMMA_DEVICE_DPP_OPS_HPP
 
+#include "cross_lane_ops_util.hpp"
 #include <rocwmma/rocwmma.hpp>
 
 namespace rocwmma
 {
-    constexpr uint32_t VALUE_OUT_OF_RANGE = 100; // 100 is out of [0, SubGroupSize]
-
-    template <typename DataT>
-    ROCWMMA_DEVICE inline DataT makeValueFromU32(uint32_t input)
-    {
-        static_assert(std::is_same_v<uint32_t, DataT> || std::is_same_v<uint64_t, DataT>,
-                      "DataT must be uint32_t or uint64_t. We only test these 2 types");
-        if constexpr(std::is_same_v<uint64_t, DataT>)
-        {
-            uint64_t output = input;
-            output          = output << 32 | input;
-            return output;
-        }
-        else
-        {
-            return input;
-        }
-    }
-
     ROCWMMA_DEVICE inline bool
         isDppMasked(uint32_t id, uint32_t WriteRowMask, uint32_t WriteBankMask)
     {

--- a/test/unit/cross_lane_ops_test/device/dpp_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/dpp_ops.hpp
@@ -31,90 +31,6 @@
 
 namespace rocwmma
 {
-    template <typename>
-    struct is_dpp_bcast : std::false_type
-    {
-    };
-
-    template <uint32_t ElementIdx, uint32_t SubGroupSize, class BCastCtrl>
-    struct is_dpp_bcast<DppImpl::OpsBase::BCast<ElementIdx, SubGroupSize, BCastCtrl>>
-        : std::true_type
-    {
-    };
-
-    template <typename>
-    struct is_dpp_reverse : std::false_type
-    {
-    };
-
-    template <uint32_t SubGroupSize, class ReverseCtrl>
-    struct is_dpp_reverse<DppImpl::OpsBase::Reverse<SubGroupSize, ReverseCtrl>> : std::true_type
-    {
-    };
-
-    template <typename>
-    struct is_dpp_rotate : std::false_type
-    {
-    };
-
-    template <uint32_t RotateDir, uint32_t RotateDist, uint32_t SubGroupSize, class RotateCtrl>
-    struct is_dpp_rotate<DppImpl::OpsBase::Rotate<RotateDir, RotateDist, SubGroupSize, RotateCtrl>>
-        : std::true_type
-    {
-    };
-
-    template <typename>
-    struct is_dpp_shift : std::false_type
-    {
-    };
-
-    template <uint32_t ShiftDir, uint32_t ShiftDist, uint32_t SubGroupSize, class ShiftCtrl>
-    struct is_dpp_shift<DppImpl::OpsBase::Shift<ShiftDir, ShiftDist, SubGroupSize, ShiftCtrl>>
-        : std::true_type
-    {
-    };
-
-    template <typename>
-    struct is_dpp_shuffle2 : std::false_type
-    {
-    };
-
-    template <uint32_t Select0, uint32_t Select1>
-    struct is_dpp_shuffle2<DppImpl::OpsBase::Shuffle2<Select0, Select1>> : std::true_type
-    {
-    };
-
-    template <typename>
-    struct is_dpp_shuffle4 : std::false_type
-    {
-    };
-
-    template <uint32_t Select0, uint32_t Select1, uint32_t Select2, uint32_t Select3>
-    struct is_dpp_shuffle4<DppImpl::OpsBase::Shuffle4<Select0, Select1, Select2, Select3>>
-        : std::true_type
-    {
-    };
-
-    template <typename>
-    struct is_dpp_swap : std::false_type
-    {
-    };
-
-    template <uint32_t SubGroupSize, class SwapCtrl>
-    struct is_dpp_swap<DppImpl::OpsBase::Swap<SubGroupSize, SwapCtrl>> : std::true_type
-    {
-    };
-
-    template <typename>
-    struct is_dpp_wFallBCast : std::false_type
-    {
-    };
-
-    template <uint32_t SubGroupSize, class BCastCtrl>
-    struct is_dpp_wFallBCast<DppImpl::OpsBase::WFallBCast<SubGroupSize, BCastCtrl>> : std::true_type
-    {
-    };
-
     ROCWMMA_DEVICE inline bool isDppMasked(int id, uint32_t WriteRowMask, uint32_t WriteBankMask)
     {
         return (WriteRowMask & (1 << ((id >> 4) & 0x3)))
@@ -200,7 +116,10 @@ namespace rocwmma
               uint32_t WriteRowMask,
               uint32_t WriteBankMask,
               bool     BoundCtrl>
-    ROCWMMA_DEVICE std::enable_if_t<is_dpp_bcast<CrossLaneOp>::value, bool> dppOpsTestCase()
+    ROCWMMA_DEVICE std::enable_if_t<CrossLaneOp::opId() == CrossLaneOps::OP_ID_BCAST
+                                        && CrossLaneOp::opImpl() == CrossLaneOps::OP_IMPL_DPP,
+                                    bool>
+                   dppOpsTestCase()
     {
         int  id       = threadIdx.x;
         int  prev     = 100; // TODO passed in by parameter
@@ -222,7 +141,10 @@ namespace rocwmma
               uint32_t WriteRowMask,
               uint32_t WriteBankMask,
               bool     BoundCtrl>
-    ROCWMMA_DEVICE std::enable_if_t<is_dpp_reverse<CrossLaneOp>::value, bool> dppOpsTestCase()
+    ROCWMMA_DEVICE std::enable_if_t<CrossLaneOp::opId() == CrossLaneOps::OP_ID_REVERSE
+                                        && CrossLaneOp::opImpl() == CrossLaneOps::OP_IMPL_DPP,
+                                    bool>
+                   dppOpsTestCase()
     {
         int  id       = threadIdx.x;
         int  prev     = 100; // TODO passed in by parameter
@@ -242,7 +164,10 @@ namespace rocwmma
               uint32_t WriteRowMask,
               uint32_t WriteBankMask,
               bool     BoundCtrl>
-    ROCWMMA_DEVICE std::enable_if_t<is_dpp_rotate<CrossLaneOp>::value, bool> dppOpsTestCase()
+    ROCWMMA_DEVICE std::enable_if_t<CrossLaneOp::opId() == CrossLaneOps::OP_ID_ROTATE
+                                        && CrossLaneOp::opImpl() == CrossLaneOps::OP_IMPL_DPP,
+                                    bool>
+                   dppOpsTestCase()
     {
         int  id       = threadIdx.x;
         int  prev     = 100; // TODO passed in by parameter
@@ -265,7 +190,10 @@ namespace rocwmma
               uint32_t WriteRowMask,
               uint32_t WriteBankMask,
               bool     BoundCtrl>
-    ROCWMMA_DEVICE std::enable_if_t<is_dpp_shift<CrossLaneOp>::value, bool> dppOpsTestCase()
+    ROCWMMA_DEVICE std::enable_if_t<CrossLaneOp::opId() == CrossLaneOps::OP_ID_SHIFT
+                                        && CrossLaneOp::opImpl() == CrossLaneOps::OP_IMPL_DPP,
+                                    bool>
+                   dppOpsTestCase()
     {
         int  id       = threadIdx.x;
         int  prev     = 100; // TODO passed in by parameter
@@ -289,23 +217,23 @@ namespace rocwmma
               uint32_t WriteRowMask,
               uint32_t WriteBankMask,
               bool     BoundCtrl>
-    ROCWMMA_DEVICE
-        std::enable_if_t<is_dpp_shuffle2<CrossLaneOp>::value || is_dpp_shuffle4<CrossLaneOp>::value,
-                         bool>
-        dppOpsTestCase()
+    ROCWMMA_DEVICE std::enable_if_t<CrossLaneOp::opId() == CrossLaneOps::OP_ID_SHUFFLE
+                                        && CrossLaneOp::opImpl() == CrossLaneOps::OP_IMPL_DPP,
+                                    bool>
+                   dppOpsTestCase()
     {
         int  id       = threadIdx.x;
         int  prev     = 100; // TODO passed in by parameter
         int  input    = id;
         bool isMasked = isDppMasked(id, WriteRowMask, WriteBankMask);
         int  expect   = -1;
-        if constexpr(is_dpp_shuffle2<CrossLaneOp>::value)
+        if constexpr(CrossLaneOp::groupSize() == 2)
         {
             expect = isMasked
                          ? getDppShuffle2Expect<CrossLaneOp::SELECT_0, CrossLaneOp::SELECT_1>(input)
                          : prev;
         }
-        else if constexpr(is_dpp_shuffle4<CrossLaneOp>::value)
+        else if constexpr(CrossLaneOp::groupSize() == 4)
         {
             expect = isMasked ? getDppShuffle4Expect<CrossLaneOp::SELECT_0,
                                                      CrossLaneOp::SELECT_1,
@@ -326,7 +254,10 @@ namespace rocwmma
               uint32_t WriteRowMask,
               uint32_t WriteBankMask,
               bool     BoundCtrl>
-    ROCWMMA_DEVICE std::enable_if_t<is_dpp_swap<CrossLaneOp>::value, bool> dppOpsTestCase()
+    ROCWMMA_DEVICE std::enable_if_t<CrossLaneOp::opId() == CrossLaneOps::OP_ID_SWAP
+                                        && CrossLaneOp::opImpl() == CrossLaneOps::OP_IMPL_DPP,
+                                    bool>
+                   dppOpsTestCase()
     {
         int  id       = threadIdx.x;
         int  prev     = 100; // TODO passed in by parameter
@@ -346,7 +277,10 @@ namespace rocwmma
               uint32_t WriteRowMask,
               uint32_t WriteBankMask,
               bool     BoundCtrl>
-    ROCWMMA_DEVICE std::enable_if_t<is_dpp_wFallBCast<CrossLaneOp>::value, bool> dppOpsTestCase()
+    ROCWMMA_DEVICE std::enable_if_t<CrossLaneOp::opId() == CrossLaneOps::OP_ID_WFALL_BCAST
+                                        && CrossLaneOp::opImpl() == CrossLaneOps::OP_IMPL_DPP,
+                                    bool>
+                   dppOpsTestCase()
     {
         int  id       = threadIdx.x;
         int  prev     = 100; // TODO passed in by parameter

--- a/test/unit/cross_lane_ops_test/device/dpp_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/dpp_ops.hpp
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#ifndef ROCWMMA_DEVICE_DPP_OPS_HPP
+#define ROCWMMA_DEVICE_DPP_OPS_HPP
+
+#include <rocwmma/rocwmma.hpp>
+
+namespace rocwmma
+{
+    template <typename DataT,
+              typename CrossLaneOp,
+              uint32_t WriteRowMask,
+              uint32_t WriteBankMask,
+              bool     BoundCtrl>
+    ROCWMMA_DEVICE bool dppOpsTestCase()
+    {
+        return true;
+    }
+
+} // namespace rocwmma
+
+#endif // ROCWMMA_DEVICE_DPP_OPS_HPP

--- a/test/unit/cross_lane_ops_test/device/dpp_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/dpp_ops.hpp
@@ -38,10 +38,13 @@ namespace rocwmma
                && (WriteBankMask & (1 << ((id >> 2) & 0x3)));
     }
 
+    /**
+	 * @addtogroup cross_lane_op_gen_ref_value_funcs
+	 * @{
+	 */
     template <uint32_t SubgroupSize, uint32_t Element>
     ROCWMMA_DEVICE inline uint32_t getDppBCastExpect(uint32_t input)
     {
-        // TODO 63 should be waveSize - 1
         return (input & (~(SubgroupSize - 1))) + Element;
     }
 
@@ -111,6 +114,7 @@ namespace rocwmma
         }
         return input;
     }
+    /** @} */
 
     template <typename DataT,
               typename CrossLaneOp,

--- a/test/unit/cross_lane_ops_test/device/permute_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/permute_ops.hpp
@@ -28,7 +28,6 @@
 #define ROCWMMA_DEVICE_PERMUTE_OPS_HPP
 
 #include "cross_lane_ops_util.hpp"
-#include <rocwmma/rocwmma.hpp>
 
 namespace rocwmma
 {
@@ -75,7 +74,7 @@ namespace rocwmma
         uint32_t id     = threadIdx.x;
         DataT    input  = makeValueFromU32<DataT>(id);
         DataT    expect = makeValueFromU32<DataT>(
-            getPermuteBlockBCastExpect<CrossLaneOp::ELEMENT_IDX, CrossLaneOp::GROUP_SIZE>(input));
+            getPermuteBlockBCastExpect<CrossLaneOp::ELEMENT_IDX, CrossLaneOp::GROUP_SIZE>(id));
         DataT output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d), input %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::ELEMENT_IDX, input , expect , output );
@@ -88,13 +87,12 @@ namespace rocwmma
                                     bool>
                    permuteOpsTestCase()
     {
-        uint32_t id    = threadIdx.x;
-        DataT    input = makeValueFromU32<DataT>(id);
-        DataT    expect
-            = makeValueFromU32<DataT>(getPermuteRotateExpect<CrossLaneOp::GROUP_SIZE,
-                                                             CrossLaneOps::OP_DIR_L,
-                                                             CrossLaneOp::opDist()>(input));
-        DataT output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
+        uint32_t id     = threadIdx.x;
+        DataT    input  = makeValueFromU32<DataT>(id);
+        DataT    expect = makeValueFromU32<DataT>(getPermuteRotateExpect<CrossLaneOp::GROUP_SIZE,
+                                                                      CrossLaneOps::OP_DIR_L,
+                                                                      CrossLaneOp::opDist()>(id));
+        DataT    output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d, %d), input %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::opDir(), CrossLaneOp::opDist(), input , expect , output );
         return output != expect;
@@ -106,13 +104,12 @@ namespace rocwmma
                                     bool>
                    permuteOpsTestCase()
     {
-        uint32_t id    = threadIdx.x;
-        DataT    input = makeValueFromU32<DataT>(id);
-        DataT    expect
-            = makeValueFromU32<DataT>(getPermuteRotateExpect<CrossLaneOp::GROUP_SIZE,
-                                                             CrossLaneOps::OP_DIR_R,
-                                                             CrossLaneOp::opDist()>(input));
-        DataT output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
+        uint32_t id     = threadIdx.x;
+        DataT    input  = makeValueFromU32<DataT>(id);
+        DataT    expect = makeValueFromU32<DataT>(getPermuteRotateExpect<CrossLaneOp::GROUP_SIZE,
+                                                                      CrossLaneOps::OP_DIR_R,
+                                                                      CrossLaneOp::opDist()>(id));
+        DataT    output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d, %d), input %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::opDir(), CrossLaneOp::opDist(), input , expect , output );
         return output != expect;
@@ -128,7 +125,7 @@ namespace rocwmma
         DataT    input  = makeValueFromU32<DataT>(id);
         DataT    expect = makeValueFromU32<DataT>(getPermuteGatherExpect<CrossLaneOp::GROUP_SIZE,
                                                                       CrossLaneOp::vw(),
-                                                                      CrossLaneOp::shift()>(input));
+                                                                      CrossLaneOp::shift()>(id));
         DataT    output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d, %d), input %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::vw(), CrossLaneOp::shift(), input , expect , output );
@@ -141,13 +138,12 @@ namespace rocwmma
                                     bool>
                    permuteOpsTestCase()
     {
-        uint32_t id    = threadIdx.x;
-        DataT    input = makeValueFromU32<DataT>(id);
-        DataT    expect
-            = makeValueFromU32<DataT>(getPermuteScatterExpect<CrossLaneOp::GROUP_SIZE,
-                                                              CrossLaneOp::vw(),
-                                                              CrossLaneOp::shift()>(input));
-        DataT output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
+        uint32_t id     = threadIdx.x;
+        DataT    input  = makeValueFromU32<DataT>(id);
+        DataT    expect = makeValueFromU32<DataT>(getPermuteScatterExpect<CrossLaneOp::GROUP_SIZE,
+                                                                       CrossLaneOp::vw(),
+                                                                       CrossLaneOp::shift()>(id));
+        DataT    output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d, %d), input %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::opDir(), CrossLaneOp::opDist(), input , expect , output );
         return output != expect;

--- a/test/unit/cross_lane_ops_test/device/permute_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/permute_ops.hpp
@@ -128,7 +128,7 @@ namespace rocwmma
                                                                       CrossLaneOp::shift()>(id));
         DataT    output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
 
-        printf("op (%d, %d, %d), input %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::vw(), CrossLaneOp::shift(), input , expect , output );
+        // printf("op (%d, %d, %d), input %ld, expect %ld, output %ld\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::vw(), CrossLaneOp::shift(), (long long)input , (long long)expect , (long long)output );
         return output != expect;
     }
 

--- a/test/unit/cross_lane_ops_test/device/permute_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/permute_ops.hpp
@@ -34,7 +34,7 @@ namespace rocwmma
     template <typename DataT, typename CrossLaneOp>
     ROCWMMA_DEVICE bool permuteOpsTestCase()
     {
-        return false;
+        return true;
     }
 
 } // namespace rocwmma

--- a/test/unit/cross_lane_ops_test/device/permute_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/permute_ops.hpp
@@ -27,6 +27,7 @@
 #ifndef ROCWMMA_DEVICE_PERMUTE_OPS_HPP
 #define ROCWMMA_DEVICE_PERMUTE_OPS_HPP
 
+#include "cross_lane_ops_util.hpp"
 #include <rocwmma/rocwmma.hpp>
 
 namespace rocwmma
@@ -71,10 +72,11 @@ namespace rocwmma
                                     bool>
                    permuteOpsTestCase()
     {
-        uint32_t input = threadIdx.x;
-        uint32_t expect
-            = getPermuteBlockBCastExpect<CrossLaneOp::ELEMENT_IDX, CrossLaneOp::GROUP_SIZE>(input);
-        uint32_t output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
+        uint32_t id     = threadIdx.x;
+        DataT    input  = makeValueFromU32<DataT>(id);
+        DataT    expect = makeValueFromU32<DataT>(
+            getPermuteBlockBCastExpect<CrossLaneOp::ELEMENT_IDX, CrossLaneOp::GROUP_SIZE>(input));
+        DataT output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d), input %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::ELEMENT_IDX, input , expect , output );
         return output != expect;
@@ -86,11 +88,13 @@ namespace rocwmma
                                     bool>
                    permuteOpsTestCase()
     {
-        uint32_t input  = threadIdx.x;
-        uint32_t expect = getPermuteRotateExpect<CrossLaneOp::GROUP_SIZE,
-                                                 CrossLaneOps::OP_DIR_L,
-                                                 CrossLaneOp::opDist()>(input);
-        uint32_t output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
+        uint32_t id    = threadIdx.x;
+        DataT    input = makeValueFromU32<DataT>(id);
+        DataT    expect
+            = makeValueFromU32<DataT>(getPermuteRotateExpect<CrossLaneOp::GROUP_SIZE,
+                                                             CrossLaneOps::OP_DIR_L,
+                                                             CrossLaneOp::opDist()>(input));
+        DataT output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d, %d), input %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::opDir(), CrossLaneOp::opDist(), input , expect , output );
         return output != expect;
@@ -102,11 +106,13 @@ namespace rocwmma
                                     bool>
                    permuteOpsTestCase()
     {
-        uint32_t input  = threadIdx.x;
-        uint32_t expect = getPermuteRotateExpect<CrossLaneOp::GROUP_SIZE,
-                                                 CrossLaneOps::OP_DIR_R,
-                                                 CrossLaneOp::opDist()>(input);
-        uint32_t output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
+        uint32_t id    = threadIdx.x;
+        DataT    input = makeValueFromU32<DataT>(id);
+        DataT    expect
+            = makeValueFromU32<DataT>(getPermuteRotateExpect<CrossLaneOp::GROUP_SIZE,
+                                                             CrossLaneOps::OP_DIR_R,
+                                                             CrossLaneOp::opDist()>(input));
+        DataT output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d, %d), input %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::opDir(), CrossLaneOp::opDist(), input , expect , output );
         return output != expect;
@@ -118,11 +124,12 @@ namespace rocwmma
                                     bool>
                    permuteOpsTestCase()
     {
-        uint32_t input  = threadIdx.x;
-        uint32_t expect = getPermuteGatherExpect<CrossLaneOp::GROUP_SIZE,
-                                                 CrossLaneOp::vw(),
-                                                 CrossLaneOp::shift()>(input);
-        uint32_t output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
+        uint32_t id     = threadIdx.x;
+        DataT    input  = makeValueFromU32<DataT>(id);
+        DataT    expect = makeValueFromU32<DataT>(getPermuteGatherExpect<CrossLaneOp::GROUP_SIZE,
+                                                                      CrossLaneOp::vw(),
+                                                                      CrossLaneOp::shift()>(input));
+        DataT    output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d, %d), input %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::vw(), CrossLaneOp::shift(), input , expect , output );
         return output != expect;
@@ -134,11 +141,13 @@ namespace rocwmma
                                     bool>
                    permuteOpsTestCase()
     {
-        uint32_t input  = threadIdx.x;
-        uint32_t expect = getPermuteScatterExpect<CrossLaneOp::GROUP_SIZE,
-                                                  CrossLaneOp::vw(),
-                                                  CrossLaneOp::shift()>(input);
-        uint32_t output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
+        uint32_t id    = threadIdx.x;
+        DataT    input = makeValueFromU32<DataT>(id);
+        DataT    expect
+            = makeValueFromU32<DataT>(getPermuteScatterExpect<CrossLaneOp::GROUP_SIZE,
+                                                              CrossLaneOp::vw(),
+                                                              CrossLaneOp::shift()>(input));
+        DataT output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d, %d), input %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::opDir(), CrossLaneOp::opDist(), input , expect , output );
         return output != expect;

--- a/test/unit/cross_lane_ops_test/device/permute_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/permute_ops.hpp
@@ -31,17 +31,6 @@
 
 namespace rocwmma
 {
-    template <typename>
-    struct is_permute_blockBCast : std::false_type
-    {
-    };
-
-    template <uint32_t BlockIdx, uint32_t BlockSize>
-    struct is_permute_blockBCast<PermuteImpl::OpsBase::BlockBCast<BlockIdx, BlockSize>>
-        : std::true_type
-    {
-    };
-
     template <uint32_t BlockIdx, uint32_t BlockSize>
     ROCWMMA_DEVICE inline int getPermuteBlockBCastExpect(int input)
     {
@@ -77,7 +66,9 @@ namespace rocwmma
     }
 
     template <typename DataT, typename CrossLaneOp>
-    ROCWMMA_DEVICE std::enable_if_t<is_permute_blockBCast<CrossLaneOp>::value, bool>
+    ROCWMMA_DEVICE std::enable_if_t<CrossLaneOp::opId() == CrossLaneOps::OP_ID_BLOCK_BCAST
+                                        && CrossLaneOp::opImpl() == CrossLaneOps::OP_IMPL_BPERMUTE,
+                                    bool>
                    permuteOpsTestCase()
     {
         int input = threadIdx.x;

--- a/test/unit/cross_lane_ops_test/device/permute_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/permute_ops.hpp
@@ -31,6 +31,10 @@
 
 namespace rocwmma
 {
+    /**
+	 * @addtogroup cross_lane_op_gen_ref_value_funcs
+	 * @{
+	 */
     template <uint32_t BlockIdx, uint32_t BlockSize>
     ROCWMMA_DEVICE inline uint32_t getPermuteBlockBCastExpect(uint32_t input)
     {
@@ -69,6 +73,7 @@ namespace rocwmma
         __syncthreads();
         return srcValues[threadIdx.x];
     }
+    /** @} */
 
     template <typename DataT, typename CrossLaneOp>
     ROCWMMA_DEVICE std::enable_if_t<CrossLaneOp::opId() == CrossLaneOps::OP_ID_BLOCK_BCAST

--- a/test/unit/cross_lane_ops_test/device/permute_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/permute_ops.hpp
@@ -87,7 +87,6 @@ namespace rocwmma
             getPermuteBlockBCastExpect<CrossLaneOp::ELEMENT_IDX, CrossLaneOp::GROUP_SIZE>(id));
         DataT output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
 
-        // printf("op (%d, %d), input %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::ELEMENT_IDX, input , expect , output );
         return output != expect;
     }
 
@@ -104,7 +103,6 @@ namespace rocwmma
                                                                       CrossLaneOp::opDist()>(id));
         DataT    output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
 
-        // printf("op (%d, %d, %d), input %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::opDir(), CrossLaneOp::opDist(), input , expect , output );
         return output != expect;
     }
 
@@ -121,7 +119,6 @@ namespace rocwmma
                                                                       CrossLaneOp::opDist()>(id));
         DataT    output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
 
-        // printf("op (%d, %d, %d), input %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::opDir(), CrossLaneOp::opDist(), input , expect , output );
         return output != expect;
     }
 
@@ -138,7 +135,6 @@ namespace rocwmma
                                                                       CrossLaneOp::shift()>(id));
         DataT    output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
 
-        // printf("op (%d, %d, %d), input %lx, expect %lx, output %lx\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::vw(), CrossLaneOp::shift(), (long long)input , (long long)expect , (long long)output );
         return output != expect;
     }
 
@@ -161,7 +157,6 @@ namespace rocwmma
                                                               CrossLaneOp::shift()>(id, srcValues));
         DataT output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
 
-        // printf("op (%d, %d, %d), input %llu, expect %llu, output %llu\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::vw(), CrossLaneOp::shift(), (long long)input , (long long)expect , (long long)output );
         return output != expect;
     }
 

--- a/test/unit/cross_lane_ops_test/device/permute_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/permute_ops.hpp
@@ -128,7 +128,7 @@ namespace rocwmma
                                                                       CrossLaneOp::shift()>(id));
         DataT    output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
 
-        // printf("op (%d, %d, %d), input %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::vw(), CrossLaneOp::shift(), input , expect , output );
+        printf("op (%d, %d, %d), input %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::vw(), CrossLaneOp::shift(), input , expect , output );
         return output != expect;
     }
 

--- a/test/unit/cross_lane_ops_test/device/permute_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/permute_ops.hpp
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#ifndef ROCWMMA_DEVICE_PERMUTE_OPS_HPP
+#define ROCWMMA_DEVICE_PERMUTE_OPS_HPP
+
+#include <rocwmma/rocwmma.hpp>
+
+namespace rocwmma
+{
+    template <typename DataT, typename CrossLaneOp>
+    ROCWMMA_DEVICE bool permuteOpsTestCase()
+    {
+        return false;
+    }
+
+} // namespace rocwmma
+
+#endif // ROCWMMA_DEVICE_PERMUTE_OPS_HPP

--- a/test/unit/cross_lane_ops_test/device/permute_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/permute_ops.hpp
@@ -32,15 +32,15 @@
 namespace rocwmma
 {
     template <uint32_t BlockIdx, uint32_t BlockSize>
-    ROCWMMA_DEVICE inline int getPermuteBlockBCastExpect(int input)
+    ROCWMMA_DEVICE inline uint32_t getPermuteBlockBCastExpect(uint32_t input)
     {
         auto idxInBlock = input % BlockSize;
         input           = BlockIdx * BlockSize + idxInBlock;
         return input;
     }
 
-    template <int SubgroupSize, int Direction, int Distance>
-    ROCWMMA_DEVICE inline int getPermuteRotateExpect(int input)
+    template <uint32_t SubgroupSize, uint32_t Direction, uint32_t Distance>
+    ROCWMMA_DEVICE inline uint32_t getPermuteRotateExpect(uint32_t input)
     {
         auto afterRotate = (input & (SubgroupSize - 1));
         afterRotate += Direction == CrossLaneOps::OP_DIR_L ? Distance : -Distance;
@@ -50,7 +50,7 @@ namespace rocwmma
     }
 
     template <uint32_t SubGroupSize, uint32_t VW, uint32_t Shift>
-    ROCWMMA_DEVICE inline int getPermuteGatherExpect(int input)
+    ROCWMMA_DEVICE inline uint32_t getPermuteGatherExpect(uint32_t input)
     {
         auto idxInGroup = input % SubGroupSize;
         input -= idxInGroup;
@@ -60,7 +60,7 @@ namespace rocwmma
     }
 
     template <uint32_t SubGroupSize, uint32_t VW, uint32_t Shift>
-    ROCWMMA_DEVICE inline int getPermuteScatterExpect(int input)
+    ROCWMMA_DEVICE inline uint32_t getPermuteScatterExpect(uint32_t input)
     {
         return 0;
     }
@@ -71,10 +71,10 @@ namespace rocwmma
                                     bool>
                    permuteOpsTestCase()
     {
-        int input = threadIdx.x;
-        int expect
+        uint32_t input = threadIdx.x;
+        uint32_t expect
             = getPermuteBlockBCastExpect<CrossLaneOp::ELEMENT_IDX, CrossLaneOp::GROUP_SIZE>(input);
-        int output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
+        uint32_t output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d), input %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::ELEMENT_IDX, input , expect , output );
         return output != expect;
@@ -86,11 +86,11 @@ namespace rocwmma
                                     bool>
                    permuteOpsTestCase()
     {
-        int input  = threadIdx.x;
-        int expect = getPermuteRotateExpect<CrossLaneOp::GROUP_SIZE,
-                                            CrossLaneOps::OP_DIR_L,
-                                            CrossLaneOp::opDist()>(input);
-        int output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
+        uint32_t input  = threadIdx.x;
+        uint32_t expect = getPermuteRotateExpect<CrossLaneOp::GROUP_SIZE,
+                                                 CrossLaneOps::OP_DIR_L,
+                                                 CrossLaneOp::opDist()>(input);
+        uint32_t output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d, %d), input %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::opDir(), CrossLaneOp::opDist(), input , expect , output );
         return output != expect;
@@ -102,11 +102,11 @@ namespace rocwmma
                                     bool>
                    permuteOpsTestCase()
     {
-        int input  = threadIdx.x;
-        int expect = getPermuteRotateExpect<CrossLaneOp::GROUP_SIZE,
-                                            CrossLaneOps::OP_DIR_R,
-                                            CrossLaneOp::opDist()>(input);
-        int output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
+        uint32_t input  = threadIdx.x;
+        uint32_t expect = getPermuteRotateExpect<CrossLaneOp::GROUP_SIZE,
+                                                 CrossLaneOps::OP_DIR_R,
+                                                 CrossLaneOp::opDist()>(input);
+        uint32_t output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d, %d), input %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::opDir(), CrossLaneOp::opDist(), input , expect , output );
         return output != expect;
@@ -118,11 +118,11 @@ namespace rocwmma
                                     bool>
                    permuteOpsTestCase()
     {
-        int input  = threadIdx.x;
-        int expect = getPermuteGatherExpect<CrossLaneOp::GROUP_SIZE,
-                                            CrossLaneOp::vw(),
-                                            CrossLaneOp::shift()>(input);
-        int output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
+        uint32_t input  = threadIdx.x;
+        uint32_t expect = getPermuteGatherExpect<CrossLaneOp::GROUP_SIZE,
+                                                 CrossLaneOp::vw(),
+                                                 CrossLaneOp::shift()>(input);
+        uint32_t output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d, %d), input %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::vw(), CrossLaneOp::shift(), input , expect , output );
         return output != expect;
@@ -134,11 +134,11 @@ namespace rocwmma
                                     bool>
                    permuteOpsTestCase()
     {
-        int input  = threadIdx.x;
-        int expect = getPermuteScatterExpect<CrossLaneOp::GROUP_SIZE,
-                                             CrossLaneOp::vw(),
-                                             CrossLaneOp::shift()>(input);
-        int output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
+        uint32_t input  = threadIdx.x;
+        uint32_t expect = getPermuteScatterExpect<CrossLaneOp::GROUP_SIZE,
+                                                  CrossLaneOp::vw(),
+                                                  CrossLaneOp::shift()>(input);
+        uint32_t output = rocwmma::Permute::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d, %d), input %d, expect %d, output %d\n", CrossLaneOp::GROUP_SIZE, CrossLaneOp::opDir(), CrossLaneOp::opDist(), input , expect , output );
         return output != expect;

--- a/test/unit/cross_lane_ops_test/device/swizzle_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/swizzle_ops.hpp
@@ -31,21 +31,21 @@
 
 namespace rocwmma
 {
-    template <int ElementIdx, int SubGroupSize>
-    ROCWMMA_DEVICE inline int getSwizzleBCastExpect(int input)
+    template <uint32_t ElementIdx, uint32_t SubGroupSize>
+    ROCWMMA_DEVICE inline uint32_t getSwizzleBCastExpect(uint32_t input)
     {
         return (input & (~(SubGroupSize - 1))) + ElementIdx;
     }
 
-    template <int SubGroupSize>
-    ROCWMMA_DEVICE inline int getSwizzleReverseExpect(int input)
+    template <uint32_t SubGroupSize>
+    ROCWMMA_DEVICE inline uint32_t getSwizzleReverseExpect(uint32_t input)
     {
-        int maxInGroup = SubGroupSize - 1;
+        uint32_t maxInGroup = SubGroupSize - 1;
         return ((input & (~maxInGroup) | (maxInGroup - (input & maxInGroup))));
     }
 
-    template <int SubGroupSize, int Direction, int Distance>
-    ROCWMMA_DEVICE inline int getSwizzleRotateExpect(int input)
+    template <uint32_t SubGroupSize, uint32_t Direction, uint32_t Distance>
+    ROCWMMA_DEVICE inline uint32_t getSwizzleRotateExpect(uint32_t input)
     {
         auto afterRotate = (input & (SubGroupSize - 1));
         afterRotate += Direction == CrossLaneOps::OP_DIR_L ? Distance : -Distance;
@@ -55,7 +55,7 @@ namespace rocwmma
     }
 
     template <uint32_t Select0, uint32_t Select1>
-    ROCWMMA_DEVICE inline int getSwizzleShuffle2Expect(int input)
+    ROCWMMA_DEVICE inline uint32_t getSwizzleShuffle2Expect(uint32_t input)
     {
         auto id = input & 0b1;
         input -= id;
@@ -64,7 +64,7 @@ namespace rocwmma
     }
 
     template <uint32_t Select0, uint32_t Select1, uint32_t Select2, uint32_t Select3>
-    ROCWMMA_DEVICE inline int getSwizzleShuffle4Expect(int input)
+    ROCWMMA_DEVICE inline uint32_t getSwizzleShuffle4Expect(uint32_t input)
     {
         auto id = input & 0b11;
         input -= id;
@@ -73,7 +73,7 @@ namespace rocwmma
     }
 
     template <uint32_t SubGroupSize>
-    ROCWMMA_DEVICE inline int getSwizzleSwapExpect(int input)
+    ROCWMMA_DEVICE inline uint32_t getSwizzleSwapExpect(uint32_t input)
     {
         return input ^ SubGroupSize;
     }
@@ -84,10 +84,10 @@ namespace rocwmma
                                     bool>
                    swizzleOpsTestCase()
     {
-        int input = threadIdx.x;
-        int expect
+        uint32_t input = threadIdx.x;
+        uint32_t expect
             = getSwizzleBCastExpect<CrossLaneOp::elementIdx(), CrossLaneOp::groupSize()>(input);
-        int output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
+        uint32_t output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d), input %d, WriteRowMask %x, WriteBankMask %x, BoundCtrl %d, expect %d, output %d\n", CrossLaneOp::select0(), CrossLaneOp::select1(), input , WriteRowMask , WriteBankMask , BoundCtrl, expect , output );
         return output != expect;
@@ -99,9 +99,9 @@ namespace rocwmma
                                     bool>
                    swizzleOpsTestCase()
     {
-        int input  = threadIdx.x;
-        int expect = getSwizzleReverseExpect<CrossLaneOp::groupSize()>(input);
-        int output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
+        uint32_t input  = threadIdx.x;
+        uint32_t expect = getSwizzleReverseExpect<CrossLaneOp::groupSize()>(input);
+        uint32_t output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d), input %d, WriteRowMask %x, WriteBankMask %x, BoundCtrl %d, expect %d, output %d\n", CrossLaneOp::select0(), CrossLaneOp::select1(), input , WriteRowMask , WriteBankMask , BoundCtrl, expect , output );
         return output != expect;
@@ -113,11 +113,11 @@ namespace rocwmma
                                     bool>
                    swizzleOpsTestCase()
     {
-        int input  = threadIdx.x;
-        int expect = getSwizzleRotateExpect<CrossLaneOp::groupSize(),
-                                            CrossLaneOp::opDir(),
-                                            CrossLaneOp::opDist()>(input);
-        int output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
+        uint32_t input  = threadIdx.x;
+        uint32_t expect = getSwizzleRotateExpect<CrossLaneOp::groupSize(),
+                                                 CrossLaneOp::opDir(),
+                                                 CrossLaneOp::opDist()>(input);
+        uint32_t output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d), input %d, WriteRowMask %x, WriteBankMask %x, BoundCtrl %d, expect %d, output %d\n", CrossLaneOp::select0(), CrossLaneOp::select1(), input , WriteRowMask , WriteBankMask , BoundCtrl, expect , output );
         return output != expect;
@@ -129,8 +129,8 @@ namespace rocwmma
                                     bool>
                    swizzleOpsTestCase()
     {
-        int input  = threadIdx.x;
-        int expect = -1;
+        uint32_t input  = threadIdx.x;
+        uint32_t expect = -1;
         if constexpr(CrossLaneOp::groupSize() == 2)
         {
             expect
@@ -143,7 +143,7 @@ namespace rocwmma
                                               CrossLaneOp::select2(),
                                               CrossLaneOp::select3()>(input);
         }
-        int output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
+        uint32_t output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d), input %d, WriteRowMask %x, WriteBankMask %x, BoundCtrl %d, expect %d, output %d\n", CrossLaneOp::select0(), CrossLaneOp::select1(), input , WriteRowMask , WriteBankMask , BoundCtrl, expect , output );
         return output != expect;
@@ -155,9 +155,9 @@ namespace rocwmma
                                     bool>
                    swizzleOpsTestCase()
     {
-        int input  = threadIdx.x;
-        int expect = getSwizzleSwapExpect<CrossLaneOp::groupSize()>(input);
-        int output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
+        uint32_t input  = threadIdx.x;
+        uint32_t expect = getSwizzleSwapExpect<CrossLaneOp::groupSize()>(input);
+        uint32_t output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d), input %d, WriteRowMask %x, WriteBankMask %x, BoundCtrl %d, expect %d, output %d\n", CrossLaneOp::select0(), CrossLaneOp::select1(), input , WriteRowMask , WriteBankMask , BoundCtrl, expect , output );
         return output != expect;

--- a/test/unit/cross_lane_ops_test/device/swizzle_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/swizzle_ops.hpp
@@ -34,7 +34,7 @@ namespace rocwmma
     template <typename DataT, typename CrossLaneOp>
     ROCWMMA_DEVICE bool swizzleOpsTestCase()
     {
-        return false;
+        return true;
     }
 
 } // namespace rocwmma

--- a/test/unit/cross_lane_ops_test/device/swizzle_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/swizzle_ops.hpp
@@ -31,6 +31,10 @@
 
 namespace rocwmma
 {
+    /**
+	 * @addtogroup cross_lane_op_gen_ref_value_funcs
+	 * @{
+	 */
     template <uint32_t ElementIdx, uint32_t SubGroupSize>
     ROCWMMA_DEVICE inline uint32_t getSwizzleBCastExpect(uint32_t input)
     {
@@ -77,6 +81,7 @@ namespace rocwmma
     {
         return input ^ SubGroupSize;
     }
+    /** @} */
 
     template <typename DataT, typename CrossLaneOp>
     ROCWMMA_DEVICE std::enable_if_t<CrossLaneOp::opId() == CrossLaneOps::OP_ID_BCAST

--- a/test/unit/cross_lane_ops_test/device/swizzle_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/swizzle_ops.hpp
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#ifndef ROCWMMA_DEVICE_SWIZZLE_OPS_HPP
+#define ROCWMMA_DEVICE_SWIZZLE_OPS_HPP
+
+#include <rocwmma/rocwmma.hpp>
+
+namespace rocwmma
+{
+    template <typename DataT, typename CrossLaneOp>
+    ROCWMMA_DEVICE bool swizzleOpsTestCase()
+    {
+        return false;
+    }
+
+} // namespace rocwmma
+
+#endif // ROCWMMA_DEVICE_SWIZZLE_OPS_HPP

--- a/test/unit/cross_lane_ops_test/device/swizzle_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/swizzle_ops.hpp
@@ -95,7 +95,6 @@ namespace rocwmma
             getSwizzleBCastExpect<CrossLaneOp::elementIdx(), CrossLaneOp::groupSize()>(id));
         DataT output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
 
-        // printf("op (%d, %d), input %d, WriteRowMask %x, WriteBankMask %x, BoundCtrl %d, expect %d, output %d\n", CrossLaneOp::select0(), CrossLaneOp::select1(), input , WriteRowMask , WriteBankMask , BoundCtrl, expect , output );
         return output != expect;
     }
 
@@ -111,7 +110,6 @@ namespace rocwmma
             = makeValueFromU32<DataT>(getSwizzleReverseExpect<CrossLaneOp::groupSize()>(id));
         DataT output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
 
-        // printf("op (%d, %d), input %d, WriteRowMask %x, WriteBankMask %x, BoundCtrl %d, expect %d, output %d\n", CrossLaneOp::select0(), CrossLaneOp::select1(), input , WriteRowMask , WriteBankMask , BoundCtrl, expect , output );
         return output != expect;
     }
 
@@ -128,7 +126,6 @@ namespace rocwmma
                                                                       CrossLaneOp::opDist()>(id));
         DataT    output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
 
-        // printf("op (%d, %d), input %d, WriteRowMask %x, WriteBankMask %x, BoundCtrl %d, expect %d, output %d\n", CrossLaneOp::select0(), CrossLaneOp::select1(), input , WriteRowMask , WriteBankMask , BoundCtrl, expect , output );
         return output != expect;
     }
 
@@ -155,7 +152,6 @@ namespace rocwmma
         }
         DataT output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
 
-        // printf("op (%d, %d), input %lx, expect %lx, output %lx\n", CrossLaneOp::select0(), CrossLaneOp::select1(), (uint64_t)input , (uint64_t)expect , (uint64_t)output );
         return output != expect;
     }
 
@@ -170,7 +166,6 @@ namespace rocwmma
         DataT expect = makeValueFromU32<DataT>(getSwizzleSwapExpect<CrossLaneOp::groupSize()>(id));
         DataT output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
 
-        // printf("op (%d, %d), input %d, WriteRowMask %x, WriteBankMask %x, BoundCtrl %d, expect %d, output %d\n", CrossLaneOp::select0(), CrossLaneOp::select1(), input , WriteRowMask , WriteBankMask , BoundCtrl, expect , output );
         return output != expect;
     }
 

--- a/test/unit/cross_lane_ops_test/device/swizzle_ops.hpp
+++ b/test/unit/cross_lane_ops_test/device/swizzle_ops.hpp
@@ -27,7 +27,7 @@
 #ifndef ROCWMMA_DEVICE_SWIZZLE_OPS_HPP
 #define ROCWMMA_DEVICE_SWIZZLE_OPS_HPP
 
-#include <rocwmma/rocwmma.hpp>
+#include "cross_lane_ops_util.hpp"
 
 namespace rocwmma
 {
@@ -84,10 +84,11 @@ namespace rocwmma
                                     bool>
                    swizzleOpsTestCase()
     {
-        uint32_t input = threadIdx.x;
-        uint32_t expect
-            = getSwizzleBCastExpect<CrossLaneOp::elementIdx(), CrossLaneOp::groupSize()>(input);
-        uint32_t output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
+        uint32_t id     = threadIdx.x;
+        DataT    input  = makeValueFromU32<DataT>(id);
+        DataT    expect = makeValueFromU32<DataT>(
+            getSwizzleBCastExpect<CrossLaneOp::elementIdx(), CrossLaneOp::groupSize()>(id));
+        DataT output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d), input %d, WriteRowMask %x, WriteBankMask %x, BoundCtrl %d, expect %d, output %d\n", CrossLaneOp::select0(), CrossLaneOp::select1(), input , WriteRowMask , WriteBankMask , BoundCtrl, expect , output );
         return output != expect;
@@ -99,9 +100,11 @@ namespace rocwmma
                                     bool>
                    swizzleOpsTestCase()
     {
-        uint32_t input  = threadIdx.x;
-        uint32_t expect = getSwizzleReverseExpect<CrossLaneOp::groupSize()>(input);
-        uint32_t output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
+        uint32_t id    = threadIdx.x;
+        DataT    input = makeValueFromU32<DataT>(id);
+        DataT    expect
+            = makeValueFromU32<DataT>(getSwizzleReverseExpect<CrossLaneOp::groupSize()>(id));
+        DataT output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d), input %d, WriteRowMask %x, WriteBankMask %x, BoundCtrl %d, expect %d, output %d\n", CrossLaneOp::select0(), CrossLaneOp::select1(), input , WriteRowMask , WriteBankMask , BoundCtrl, expect , output );
         return output != expect;
@@ -113,11 +116,12 @@ namespace rocwmma
                                     bool>
                    swizzleOpsTestCase()
     {
-        uint32_t input  = threadIdx.x;
-        uint32_t expect = getSwizzleRotateExpect<CrossLaneOp::groupSize(),
-                                                 CrossLaneOp::opDir(),
-                                                 CrossLaneOp::opDist()>(input);
-        uint32_t output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
+        uint32_t id     = threadIdx.x;
+        DataT    input  = makeValueFromU32<DataT>(id);
+        DataT    expect = makeValueFromU32<DataT>(getSwizzleRotateExpect<CrossLaneOp::groupSize(),
+                                                                      CrossLaneOp::opDir(),
+                                                                      CrossLaneOp::opDist()>(id));
+        DataT    output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d), input %d, WriteRowMask %x, WriteBankMask %x, BoundCtrl %d, expect %d, output %d\n", CrossLaneOp::select0(), CrossLaneOp::select1(), input , WriteRowMask , WriteBankMask , BoundCtrl, expect , output );
         return output != expect;
@@ -129,23 +133,24 @@ namespace rocwmma
                                     bool>
                    swizzleOpsTestCase()
     {
-        uint32_t input  = threadIdx.x;
-        uint32_t expect = -1;
+        uint32_t id     = threadIdx.x;
+        DataT    input  = makeValueFromU32<DataT>(id);
+        DataT    expect = -1;
         if constexpr(CrossLaneOp::groupSize() == 2)
         {
-            expect
-                = getSwizzleShuffle2Expect<CrossLaneOp::select0(), CrossLaneOp::select1()>(input);
+            expect = makeValueFromU32<DataT>(
+                getSwizzleShuffle2Expect<CrossLaneOp::select0(), CrossLaneOp::select1()>(id));
         }
         else if constexpr(CrossLaneOp::groupSize() == 4)
         {
-            expect = getSwizzleShuffle4Expect<CrossLaneOp::select0(),
-                                              CrossLaneOp::select1(),
-                                              CrossLaneOp::select2(),
-                                              CrossLaneOp::select3()>(input);
+            expect = makeValueFromU32<DataT>(getSwizzleShuffle4Expect<CrossLaneOp::select0(),
+                                                                      CrossLaneOp::select1(),
+                                                                      CrossLaneOp::select2(),
+                                                                      CrossLaneOp::select3()>(id));
         }
-        uint32_t output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
+        DataT output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
 
-        // printf("op (%d, %d), input %d, WriteRowMask %x, WriteBankMask %x, BoundCtrl %d, expect %d, output %d\n", CrossLaneOp::select0(), CrossLaneOp::select1(), input , WriteRowMask , WriteBankMask , BoundCtrl, expect , output );
+        // printf("op (%d, %d), input %lx, expect %lx, output %lx\n", CrossLaneOp::select0(), CrossLaneOp::select1(), (uint64_t)input , (uint64_t)expect , (uint64_t)output );
         return output != expect;
     }
 
@@ -155,9 +160,10 @@ namespace rocwmma
                                     bool>
                    swizzleOpsTestCase()
     {
-        uint32_t input  = threadIdx.x;
-        uint32_t expect = getSwizzleSwapExpect<CrossLaneOp::groupSize()>(input);
-        uint32_t output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
+        uint32_t id    = threadIdx.x;
+        DataT    input = makeValueFromU32<DataT>(id);
+        DataT expect = makeValueFromU32<DataT>(getSwizzleSwapExpect<CrossLaneOp::groupSize()>(id));
+        DataT output = rocwmma::Swizzle::Driver<CrossLaneOp>::exec(input);
 
         // printf("op (%d, %d), input %d, WriteRowMask %x, WriteBankMask %x, BoundCtrl %d, expect %d, output %d\n", CrossLaneOp::select0(), CrossLaneOp::select1(), input , WriteRowMask , WriteBankMask , BoundCtrl, expect , output );
         return output != expect;

--- a/test/unit/cross_lane_ops_test/test/blend_extract_byte_even.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_extract_byte_even.cpp
@@ -40,34 +40,15 @@ namespace rocwmma
 
         using Types = typename std::tuple<uint32_t, uint64_t>;
 
-        using DppOps = std::tuple<DppImpl::Ops::BCast16<0>,
-                                  DppImpl::Ops::BCast16<1>,
-                                  DppImpl::Ops::BCast16<2>,
-                                  DppImpl::Ops::BCast16<3>,
-                                  DppImpl::Ops::BCast16<4>,
-                                  DppImpl::Ops::BCast16<5>,
-                                  DppImpl::Ops::BCast16<6>,
-                                  DppImpl::Ops::BCast16<7>,
-                                  DppImpl::Ops::BCast16<8>,
-                                  DppImpl::Ops::BCast16<9>,
-                                  DppImpl::Ops::BCast16<10>,
-                                  DppImpl::Ops::BCast16<11>,
-                                  DppImpl::Ops::BCast16<12>,
-                                  DppImpl::Ops::BCast16<13>,
-                                  DppImpl::Ops::BCast16<14>,
-                                  DppImpl::Ops::BCast16<15>>;
+        using BlendOps = std::tuple<BlendImpl::Ops::ExtractByteEven,
 
-        // Test random assortment of banks and rows
-        using WriteRowMasks  = std::tuple<I<0xF>, I<0x5>, I<0xA>>;
-        using WriteBankMasks = std::tuple<I<0xF>, I<0x7>, I<0x3>>;
-        using BoundCtrls     = std::tuple<I<false>, I<true>>;
+                                    BlendImpl::Ops::ExtractByteOddEven>;
 
-        using KernelParams =
-            typename CombineLists<Types, DppOps, WriteRowMasks, WriteBankMasks, BoundCtrls>::Result;
+        using KernelParams = typename CombineLists<Types, BlendOps>::Result;
 
         // Assemble the kernel generator
         // Kernel: VectorIterator
-        using GeneratorImpl   = DppOpsGenerator;
+        using GeneratorImpl   = BlendOpsGenerator;
         using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
 
         // Sanity check for kernel generator
@@ -101,18 +82,18 @@ namespace rocwmma
 } // namespace rocwmma
 
 // Test suite for unique parameterization
-class DppBCast16Test : public rocwmma::UnitTest
+class BlendExtractByteEvenTest : public rocwmma::UnitTest
 {
 };
 
-TEST_P(DppBCast16Test, RunKernel)
+TEST_P(BlendExtractByteEvenTest, RunKernel)
 {
     this->RunKernel();
 }
 
 INSTANTIATE_TEST_SUITE_P(
     CrossLaneOpTests,
-    DppBCast16Test,
+    BlendExtractByteEvenTest,
     ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
                        ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
                        ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),

--- a/test/unit/cross_lane_ops_test/test/blend_extract_byte_even.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_extract_byte_even.cpp
@@ -64,6 +64,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/blend_extract_byte_odd.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_extract_byte_odd.cpp
@@ -40,34 +40,15 @@ namespace rocwmma
 
         using Types = typename std::tuple<uint32_t, uint64_t>;
 
-        using DppOps = std::tuple<DppImpl::Ops::BCast16<0>,
-                                  DppImpl::Ops::BCast16<1>,
-                                  DppImpl::Ops::BCast16<2>,
-                                  DppImpl::Ops::BCast16<3>,
-                                  DppImpl::Ops::BCast16<4>,
-                                  DppImpl::Ops::BCast16<5>,
-                                  DppImpl::Ops::BCast16<6>,
-                                  DppImpl::Ops::BCast16<7>,
-                                  DppImpl::Ops::BCast16<8>,
-                                  DppImpl::Ops::BCast16<9>,
-                                  DppImpl::Ops::BCast16<10>,
-                                  DppImpl::Ops::BCast16<11>,
-                                  DppImpl::Ops::BCast16<12>,
-                                  DppImpl::Ops::BCast16<13>,
-                                  DppImpl::Ops::BCast16<14>,
-                                  DppImpl::Ops::BCast16<15>>;
+        using BlendOps = std::tuple<BlendImpl::Ops::ExtractByteOdd,
 
-        // Test random assortment of banks and rows
-        using WriteRowMasks  = std::tuple<I<0xF>, I<0x5>, I<0xA>>;
-        using WriteBankMasks = std::tuple<I<0xF>, I<0x7>, I<0x3>>;
-        using BoundCtrls     = std::tuple<I<false>, I<true>>;
+                                    BlendImpl::Ops::ExtractByteEvenOdd>;
 
-        using KernelParams =
-            typename CombineLists<Types, DppOps, WriteRowMasks, WriteBankMasks, BoundCtrls>::Result;
+        using KernelParams = typename CombineLists<Types, BlendOps>::Result;
 
         // Assemble the kernel generator
         // Kernel: VectorIterator
-        using GeneratorImpl   = DppOpsGenerator;
+        using GeneratorImpl   = BlendOpsGenerator;
         using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
 
         // Sanity check for kernel generator
@@ -101,18 +82,18 @@ namespace rocwmma
 } // namespace rocwmma
 
 // Test suite for unique parameterization
-class DppBCast16Test : public rocwmma::UnitTest
+class BlendExtractByteOddTest : public rocwmma::UnitTest
 {
 };
 
-TEST_P(DppBCast16Test, RunKernel)
+TEST_P(BlendExtractByteOddTest, RunKernel)
 {
     this->RunKernel();
 }
 
 INSTANTIATE_TEST_SUITE_P(
     CrossLaneOpTests,
-    DppBCast16Test,
+    BlendExtractByteOddTest,
     ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
                        ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
                        ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),

--- a/test/unit/cross_lane_ops_test/test/blend_extract_byte_odd.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_extract_byte_odd.cpp
@@ -64,6 +64,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/blend_extract_word_even.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_extract_word_even.cpp
@@ -64,6 +64,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/blend_extract_word_even.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_extract_word_even.cpp
@@ -40,34 +40,15 @@ namespace rocwmma
 
         using Types = typename std::tuple<uint32_t, uint64_t>;
 
-        using DppOps = std::tuple<DppImpl::Ops::BCast16<0>,
-                                  DppImpl::Ops::BCast16<1>,
-                                  DppImpl::Ops::BCast16<2>,
-                                  DppImpl::Ops::BCast16<3>,
-                                  DppImpl::Ops::BCast16<4>,
-                                  DppImpl::Ops::BCast16<5>,
-                                  DppImpl::Ops::BCast16<6>,
-                                  DppImpl::Ops::BCast16<7>,
-                                  DppImpl::Ops::BCast16<8>,
-                                  DppImpl::Ops::BCast16<9>,
-                                  DppImpl::Ops::BCast16<10>,
-                                  DppImpl::Ops::BCast16<11>,
-                                  DppImpl::Ops::BCast16<12>,
-                                  DppImpl::Ops::BCast16<13>,
-                                  DppImpl::Ops::BCast16<14>,
-                                  DppImpl::Ops::BCast16<15>>;
+        using BlendOps = std::tuple<BlendImpl::Ops::ExtractWordEven,
 
-        // Test random assortment of banks and rows
-        using WriteRowMasks  = std::tuple<I<0xF>, I<0x5>, I<0xA>>;
-        using WriteBankMasks = std::tuple<I<0xF>, I<0x7>, I<0x3>>;
-        using BoundCtrls     = std::tuple<I<false>, I<true>>;
+                                    BlendImpl::Ops::ExtractWordOddEven>;
 
-        using KernelParams =
-            typename CombineLists<Types, DppOps, WriteRowMasks, WriteBankMasks, BoundCtrls>::Result;
+        using KernelParams = typename CombineLists<Types, BlendOps>::Result;
 
         // Assemble the kernel generator
         // Kernel: VectorIterator
-        using GeneratorImpl   = DppOpsGenerator;
+        using GeneratorImpl   = BlendOpsGenerator;
         using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
 
         // Sanity check for kernel generator
@@ -101,18 +82,18 @@ namespace rocwmma
 } // namespace rocwmma
 
 // Test suite for unique parameterization
-class DppBCast16Test : public rocwmma::UnitTest
+class BlendExtractWordEvenTest : public rocwmma::UnitTest
 {
 };
 
-TEST_P(DppBCast16Test, RunKernel)
+TEST_P(BlendExtractWordEvenTest, RunKernel)
 {
     this->RunKernel();
 }
 
 INSTANTIATE_TEST_SUITE_P(
     CrossLaneOpTests,
-    DppBCast16Test,
+    BlendExtractWordEvenTest,
     ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
                        ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
                        ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),

--- a/test/unit/cross_lane_ops_test/test/blend_extract_word_odd.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_extract_word_odd.cpp
@@ -64,6 +64,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/blend_extract_word_odd.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_extract_word_odd.cpp
@@ -40,34 +40,15 @@ namespace rocwmma
 
         using Types = typename std::tuple<uint32_t, uint64_t>;
 
-        using DppOps = std::tuple<DppImpl::Ops::BCast16<0>,
-                                  DppImpl::Ops::BCast16<1>,
-                                  DppImpl::Ops::BCast16<2>,
-                                  DppImpl::Ops::BCast16<3>,
-                                  DppImpl::Ops::BCast16<4>,
-                                  DppImpl::Ops::BCast16<5>,
-                                  DppImpl::Ops::BCast16<6>,
-                                  DppImpl::Ops::BCast16<7>,
-                                  DppImpl::Ops::BCast16<8>,
-                                  DppImpl::Ops::BCast16<9>,
-                                  DppImpl::Ops::BCast16<10>,
-                                  DppImpl::Ops::BCast16<11>,
-                                  DppImpl::Ops::BCast16<12>,
-                                  DppImpl::Ops::BCast16<13>,
-                                  DppImpl::Ops::BCast16<14>,
-                                  DppImpl::Ops::BCast16<15>>;
+        using BlendOps = std::tuple<BlendImpl::Ops::ExtractWordOdd,
 
-        // Test random assortment of banks and rows
-        using WriteRowMasks  = std::tuple<I<0xF>, I<0x5>, I<0xA>>;
-        using WriteBankMasks = std::tuple<I<0xF>, I<0x7>, I<0x3>>;
-        using BoundCtrls     = std::tuple<I<false>, I<true>>;
+                                    BlendImpl::Ops::ExtractWordEvenOdd>;
 
-        using KernelParams =
-            typename CombineLists<Types, DppOps, WriteRowMasks, WriteBankMasks, BoundCtrls>::Result;
+        using KernelParams = typename CombineLists<Types, BlendOps>::Result;
 
         // Assemble the kernel generator
         // Kernel: VectorIterator
-        using GeneratorImpl   = DppOpsGenerator;
+        using GeneratorImpl   = BlendOpsGenerator;
         using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
 
         // Sanity check for kernel generator
@@ -101,18 +82,18 @@ namespace rocwmma
 } // namespace rocwmma
 
 // Test suite for unique parameterization
-class DppBCast16Test : public rocwmma::UnitTest
+class BlendExtractWordOddTest : public rocwmma::UnitTest
 {
 };
 
-TEST_P(DppBCast16Test, RunKernel)
+TEST_P(BlendExtractWordOddTest, RunKernel)
 {
     this->RunKernel();
 }
 
 INSTANTIATE_TEST_SUITE_P(
     CrossLaneOpTests,
-    DppBCast16Test,
+    BlendExtractWordOddTest,
     ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
                        ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
                        ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),

--- a/test/unit/cross_lane_ops_test/test/blend_unpack_byte_hi.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_unpack_byte_hi.cpp
@@ -62,7 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/blend_unpack_byte_hi.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_unpack_byte_hi.cpp
@@ -62,6 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/blend_unpack_byte_hi.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_unpack_byte_hi.cpp
@@ -57,24 +57,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/blend_unpack_byte_hi.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_unpack_byte_hi.cpp
@@ -38,7 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using BlendOps = std::tuple<BlendImpl::Ops::UnpackByteHi>;
 

--- a/test/unit/cross_lane_ops_test/test/blend_unpack_byte_hi_lo.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_unpack_byte_hi_lo.cpp
@@ -38,7 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using BlendOps = std::tuple<BlendImpl::Ops::UnpackByteLoHi>;
 

--- a/test/unit/cross_lane_ops_test/test/blend_unpack_byte_hi_lo.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_unpack_byte_hi_lo.cpp
@@ -62,7 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/blend_unpack_byte_hi_lo.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_unpack_byte_hi_lo.cpp
@@ -62,6 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/blend_unpack_byte_hi_lo.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_unpack_byte_hi_lo.cpp
@@ -57,24 +57,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/blend_unpack_byte_lo.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_unpack_byte_lo.cpp
@@ -38,7 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using BlendOps = std::tuple<BlendImpl::Ops::UnpackByteLo>;
 

--- a/test/unit/cross_lane_ops_test/test/blend_unpack_byte_lo.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_unpack_byte_lo.cpp
@@ -62,7 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/blend_unpack_byte_lo.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_unpack_byte_lo.cpp
@@ -62,6 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/blend_unpack_byte_lo.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_unpack_byte_lo.cpp
@@ -57,24 +57,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/blend_unpack_word_hi.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_unpack_word_hi.cpp
@@ -62,7 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/blend_unpack_word_hi.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_unpack_word_hi.cpp
@@ -62,6 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/blend_unpack_word_hi.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_unpack_word_hi.cpp
@@ -57,24 +57,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/blend_unpack_word_hi.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_unpack_word_hi.cpp
@@ -38,7 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using BlendOps = std::tuple<BlendImpl::Ops::UnpackWordHi>;
 

--- a/test/unit/cross_lane_ops_test/test/blend_unpack_word_lo.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_unpack_word_lo.cpp
@@ -62,7 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/blend_unpack_word_lo.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_unpack_word_lo.cpp
@@ -62,6 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/blend_unpack_word_lo.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_unpack_word_lo.cpp
@@ -57,24 +57,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/blend_unpack_word_lo.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_unpack_word_lo.cpp
@@ -38,7 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using BlendOps = std::tuple<BlendImpl::Ops::UnpackWordLo>;
 

--- a/test/unit/cross_lane_ops_test/test/blend_zip.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_zip.cpp
@@ -66,6 +66,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/blend_zip.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_zip.cpp
@@ -38,7 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using BlendOps = std::tuple<BlendImpl::Ops::Zip2,
                                     BlendImpl::Ops::Zip4,

--- a/test/unit/cross_lane_ops_test/test/blend_zip.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_zip.cpp
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <tuple>
+#include <type_traits>
+
+#include "detail/cross_lane_ops.hpp"
+#include "kernel_generator.hpp"
+#include "unit_test.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public UnitTestParams
+    {
+        using Base = UnitTestParams;
+
+        using Types = typename Base::TestAllSizeTypes;
+
+        using BlendOps = std::tuple<BlendImpl::Ops::Zip2,
+                                    BlendImpl::Ops::Zip4,
+                                    BlendImpl::Ops::Zip8,
+                                    BlendImpl::Ops::Zip16,
+                                    BlendImpl::Ops::Zip32>;
+
+        using KernelParams = typename CombineLists<Types, BlendOps>::Result;
+
+        // Assemble the kernel generator
+        // Kernel: VectorIterator
+        using GeneratorImpl   = BlendOpsGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        // Must be TBlockY must be 1.
+        static inline std::vector<ThreadBlockT> threadBlocks()
+        {
+            auto warpSize = HipDevice::instance()->warpSize();
+            return {{warpSize, 1}};
+        }
+
+        static inline std::vector<ProblemSizeT> problemSizes()
+        {
+            return {{warpSize, 1}};
+        }
+
+        // 'prev' values
+        static inline std::vector<Param1T> param1s()
+        {
+            return {5.0};
+        }
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class BlendZipTest : public rocwmma::UnitTest
+{
+};
+
+TEST_P(BlendZipTest, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CrossLaneOpTests,
+    BlendZipTest,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::param1s()),
+                       ::testing::ValuesIn(rocwmma::TestParams::param2s())));

--- a/test/unit/cross_lane_ops_test/test/blend_zip_byte.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_zip_byte.cpp
@@ -62,7 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/blend_zip_byte.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_zip_byte.cpp
@@ -62,6 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/blend_zip_byte.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_zip_byte.cpp
@@ -57,24 +57,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/blend_zip_byte.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_zip_byte.cpp
@@ -38,7 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using BlendOps = std::tuple<BlendImpl::Ops::ZipByte>;
 

--- a/test/unit/cross_lane_ops_test/test/blend_zip_word.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_zip_word.cpp
@@ -62,7 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/blend_zip_word.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_zip_word.cpp
@@ -62,6 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/blend_zip_word.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_zip_word.cpp
@@ -57,24 +57,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/blend_zip_word.cpp
+++ b/test/unit/cross_lane_ops_test/test/blend_zip_word.cpp
@@ -38,7 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using BlendOps = std::tuple<BlendImpl::Ops::ZipWord>;
 

--- a/test/unit/cross_lane_ops_test/test/dpp_bcast_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_bcast_16.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::BCast16<2>, DppImpl::Ops::BCast16<11>>;
 

--- a/test/unit/cross_lane_ops_test/test/dpp_bcast_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_bcast_16.cpp
@@ -40,22 +40,7 @@ namespace rocwmma
 
         using Types = typename std::tuple<uint32_t, uint64_t>;
 
-        using DppOps = std::tuple<DppImpl::Ops::BCast16<0>,
-                                  DppImpl::Ops::BCast16<1>,
-                                  DppImpl::Ops::BCast16<2>,
-                                  DppImpl::Ops::BCast16<3>,
-                                  DppImpl::Ops::BCast16<4>,
-                                  DppImpl::Ops::BCast16<5>,
-                                  DppImpl::Ops::BCast16<6>,
-                                  DppImpl::Ops::BCast16<7>,
-                                  DppImpl::Ops::BCast16<8>,
-                                  DppImpl::Ops::BCast16<9>,
-                                  DppImpl::Ops::BCast16<10>,
-                                  DppImpl::Ops::BCast16<11>,
-                                  DppImpl::Ops::BCast16<12>,
-                                  DppImpl::Ops::BCast16<13>,
-                                  DppImpl::Ops::BCast16<14>,
-                                  DppImpl::Ops::BCast16<15>>;
+        using DppOps = std::tuple<DppImpl::Ops::BCast16<2>, DppImpl::Ops::BCast16<11>>;
 
         // Test random assortment of banks and rows
         using WriteRowMasks  = std::tuple<I<0xF>, I<0x5>, I<0xA>>;

--- a/test/unit/cross_lane_ops_test/test/dpp_bcast_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_bcast_16.cpp
@@ -68,6 +68,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/dpp_bcast_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_bcast_16.cpp
@@ -64,24 +64,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_bcast_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_bcast_16.cpp
@@ -69,7 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_bcast_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_bcast_2.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::BCast2<0>, DppImpl::Ops::BCast2<1>>;
 

--- a/test/unit/cross_lane_ops_test/test/dpp_bcast_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_bcast_2.cpp
@@ -68,6 +68,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/dpp_bcast_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_bcast_2.cpp
@@ -64,24 +64,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_bcast_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_bcast_2.cpp
@@ -69,7 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_bcast_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_bcast_4.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::BCast4<0>,
                                   DppImpl::Ops::BCast4<1>,

--- a/test/unit/cross_lane_ops_test/test/dpp_bcast_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_bcast_4.cpp
@@ -41,7 +41,10 @@ namespace rocwmma
         // Types: Base IOC + double
         using Types = typename Base::TestAllSizeTypes;
 
-        using DppOps = std::tuple<DppImpl::Ops::BCast4<0>, DppImpl::Ops::BCast4<3>>;
+        using DppOps = std::tuple<DppImpl::Ops::BCast4<0>,
+                                  DppImpl::Ops::BCast4<1>,
+                                  DppImpl::Ops::BCast4<2>,
+                                  DppImpl::Ops::BCast4<3>>;
 
         // Test random assortment of banks and rows
         using WriteRowMasks  = std::tuple<I<0xF>, I<0x5>, I<0xA>>;

--- a/test/unit/cross_lane_ops_test/test/dpp_bcast_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_bcast_4.cpp
@@ -64,24 +64,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_bcast_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_bcast_4.cpp
@@ -69,7 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_bcast_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_bcast_4.cpp
@@ -71,6 +71,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/dpp_reverse_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_reverse_16.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::Reverse16>;
 

--- a/test/unit/cross_lane_ops_test/test/dpp_reverse_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_reverse_16.cpp
@@ -68,6 +68,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/dpp_reverse_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_reverse_16.cpp
@@ -64,24 +64,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_reverse_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_reverse_16.cpp
@@ -69,7 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_reverse_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_reverse_2.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::Reverse2>;
 

--- a/test/unit/cross_lane_ops_test/test/dpp_reverse_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_reverse_2.cpp
@@ -68,6 +68,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/dpp_reverse_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_reverse_2.cpp
@@ -64,24 +64,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_reverse_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_reverse_2.cpp
@@ -69,7 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_reverse_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_reverse_4.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::Reverse4>;
 

--- a/test/unit/cross_lane_ops_test/test/dpp_reverse_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_reverse_4.cpp
@@ -68,6 +68,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/dpp_reverse_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_reverse_4.cpp
@@ -64,24 +64,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_reverse_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_reverse_4.cpp
@@ -69,7 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_reverse_8.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_reverse_8.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::Reverse8>;
 

--- a/test/unit/cross_lane_ops_test/test/dpp_reverse_8.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_reverse_8.cpp
@@ -68,6 +68,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/dpp_reverse_8.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_reverse_8.cpp
@@ -64,24 +64,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_reverse_8.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_reverse_8.cpp
@@ -69,7 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_l2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_l2.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::RotateL2<0>, DppImpl::Ops::RotateL2<1>>;
 

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_l2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_l2.cpp
@@ -68,6 +68,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_l2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_l2.cpp
@@ -64,24 +64,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_l2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_l2.cpp
@@ -69,7 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_l4.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_l4.cpp
@@ -68,6 +68,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_l4.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_l4.cpp
@@ -64,24 +64,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_l4.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_l4.cpp
@@ -69,7 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_l4.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_l4.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::RotateL4<2>, DppImpl::Ops::RotateL4<1>>;
 

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_r16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_r16.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::RotateR16<2>, DppImpl::Ops::RotateR16<11>>;
 

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_r16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_r16.cpp
@@ -68,6 +68,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_r16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_r16.cpp
@@ -64,24 +64,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_r16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_r16.cpp
@@ -69,7 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_r2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_r2.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::RotateR2<0>, DppImpl::Ops::RotateR2<1>>;
 

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_r2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_r2.cpp
@@ -68,6 +68,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_r2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_r2.cpp
@@ -64,24 +64,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_r2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_r2.cpp
@@ -69,7 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_r4.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_r4.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::RotateR4<1>, DppImpl::Ops::RotateR4<3>>;
 

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_r4.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_r4.cpp
@@ -68,6 +68,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_r4.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_r4.cpp
@@ -64,24 +64,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_r4.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_r4.cpp
@@ -69,7 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_wave_l1.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_wave_l1.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::RotateWaveL1>;
 

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_wave_l1.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_wave_l1.cpp
@@ -68,6 +68,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_wave_l1.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_wave_l1.cpp
@@ -64,24 +64,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_wave_l1.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_wave_l1.cpp
@@ -69,7 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_wave_r1.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_wave_r1.cpp
@@ -68,6 +68,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_wave_r1.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_wave_r1.cpp
@@ -64,24 +64,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_wave_r1.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_wave_r1.cpp
@@ -69,7 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_rotate_wave_r1.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_rotate_wave_r1.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::RotateWaveR1>;
 

--- a/test/unit/cross_lane_ops_test/test/dpp_shift_l16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shift_l16.cpp
@@ -68,6 +68,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/dpp_shift_l16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shift_l16.cpp
@@ -64,24 +64,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_shift_l16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shift_l16.cpp
@@ -69,7 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_shift_l16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shift_l16.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::ShiftL16<1>, DppImpl::Ops::ShiftL16<13>>;
 

--- a/test/unit/cross_lane_ops_test/test/dpp_shift_r16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shift_r16.cpp
@@ -68,6 +68,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {// {64, 1}
                     {warpSize, 1}};
         }

--- a/test/unit/cross_lane_ops_test/test/dpp_shift_r16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shift_r16.cpp
@@ -64,24 +64,13 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        // {64, 1}
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {// {64, 1}
+                    {64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_shift_r16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shift_r16.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::ShiftR16<1>, DppImpl::Ops::ShiftR16<13>>;
 

--- a/test/unit/cross_lane_ops_test/test/dpp_shift_r16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shift_r16.cpp
@@ -70,7 +70,7 @@ namespace rocwmma
         static inline std::vector<ProblemSizeT> problemSizes()
         {
             return {// {64, 1}
-                    {64, 64}};
+                    {warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_shift_wave_l1.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shift_wave_l1.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::ShiftWaveL1>;
 

--- a/test/unit/cross_lane_ops_test/test/dpp_shift_wave_l1.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shift_wave_l1.cpp
@@ -68,6 +68,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/dpp_shift_wave_l1.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shift_wave_l1.cpp
@@ -64,24 +64,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_shift_wave_l1.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shift_wave_l1.cpp
@@ -69,7 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_shift_wave_r1.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shift_wave_r1.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::ShiftWaveR1>;
 

--- a/test/unit/cross_lane_ops_test/test/dpp_shift_wave_r1.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shift_wave_r1.cpp
@@ -68,6 +68,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/dpp_shift_wave_r1.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shift_wave_r1.cpp
@@ -64,24 +64,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_shift_wave_r1.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shift_wave_r1.cpp
@@ -69,7 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_shuffle_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shuffle_2.cpp
@@ -68,6 +68,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/dpp_shuffle_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shuffle_2.cpp
@@ -64,24 +64,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_shuffle_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shuffle_2.cpp
@@ -69,7 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_shuffle_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shuffle_2.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::Shuffle2<0u, 1u>, DppImpl::Ops::Shuffle2<1u, 0u>>;
 

--- a/test/unit/cross_lane_ops_test/test/dpp_shuffle_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shuffle_4.cpp
@@ -70,7 +70,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_shuffle_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shuffle_4.cpp
@@ -65,24 +65,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_shuffle_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shuffle_4.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::Shuffle4<0u, 2u, 3u, 1u>,
                                   DppImpl::Ops::Shuffle4<2u, 1u, 2u, 3u>>;

--- a/test/unit/cross_lane_ops_test/test/dpp_shuffle_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_shuffle_4.cpp
@@ -69,6 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/dpp_swap_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_swap_2.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::Swap2>;
 

--- a/test/unit/cross_lane_ops_test/test/dpp_swap_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_swap_2.cpp
@@ -68,6 +68,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/dpp_swap_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_swap_2.cpp
@@ -64,24 +64,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_swap_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_swap_2.cpp
@@ -69,7 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_wfall_bcast_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_wfall_bcast_16.cpp
@@ -68,6 +68,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/dpp_wfall_bcast_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_wfall_bcast_16.cpp
@@ -64,24 +64,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_wfall_bcast_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_wfall_bcast_16.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::BCast16x15>;
 

--- a/test/unit/cross_lane_ops_test/test/dpp_wfall_bcast_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_wfall_bcast_16.cpp
@@ -69,7 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_wfall_bcast_32.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_wfall_bcast_32.cpp
@@ -68,6 +68,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/dpp_wfall_bcast_32.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_wfall_bcast_32.cpp
@@ -64,24 +64,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/dpp_wfall_bcast_32.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_wfall_bcast_32.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using DppOps = std::tuple<DppImpl::Ops::BCast32x31>;
 

--- a/test/unit/cross_lane_ops_test/test/dpp_wfall_bcast_32.cpp
+++ b/test/unit/cross_lane_ops_test/test/dpp_wfall_bcast_32.cpp
@@ -69,7 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/permute_block_bcast_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_block_bcast_16.cpp
@@ -64,7 +64,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/permute_block_bcast_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_block_bcast_16.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using PermuteOps
             = std::tuple<PermuteImpl::Ops::BlockBCast16<0>, PermuteImpl::Ops::BlockBCast16<1>>;

--- a/test/unit/cross_lane_ops_test/test/permute_block_bcast_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_block_bcast_16.cpp
@@ -59,24 +59,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/permute_block_bcast_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_block_bcast_16.cpp
@@ -63,6 +63,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/permute_block_bcast_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_block_bcast_2.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using PermuteOps = std::tuple<PermuteImpl::Ops::BlockBCast2<1>,
                                       PermuteImpl::Ops::BlockBCast2<5>,

--- a/test/unit/cross_lane_ops_test/test/permute_block_bcast_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_block_bcast_2.cpp
@@ -61,24 +61,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/permute_block_bcast_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_block_bcast_2.cpp
@@ -66,7 +66,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/permute_block_bcast_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_block_bcast_2.cpp
@@ -65,6 +65,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/permute_block_bcast_32.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_block_bcast_32.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using PermuteOps = std::tuple<PermuteImpl::Ops::BlockBCast32<0>>;
 

--- a/test/unit/cross_lane_ops_test/test/permute_block_bcast_32.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_block_bcast_32.cpp
@@ -58,24 +58,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/permute_block_bcast_32.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_block_bcast_32.cpp
@@ -62,6 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/permute_block_bcast_32.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_block_bcast_32.cpp
@@ -63,7 +63,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/permute_block_bcast_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_block_bcast_4.cpp
@@ -61,24 +61,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/permute_block_bcast_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_block_bcast_4.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using PermuteOps = std::tuple<PermuteImpl::Ops::BlockBCast4<0>,
                                       PermuteImpl::Ops::BlockBCast4<3>,

--- a/test/unit/cross_lane_ops_test/test/permute_block_bcast_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_block_bcast_4.cpp
@@ -66,7 +66,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/permute_block_bcast_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_block_bcast_4.cpp
@@ -65,6 +65,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/permute_block_bcast_8.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_block_bcast_8.cpp
@@ -61,24 +61,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/permute_block_bcast_8.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_block_bcast_8.cpp
@@ -66,7 +66,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/permute_block_bcast_8.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_block_bcast_8.cpp
@@ -65,6 +65,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/permute_block_bcast_8.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_block_bcast_8.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using PermuteOps = std::tuple<PermuteImpl::Ops::BlockBCast8<0>,
                                       PermuteImpl::Ops::BlockBCast8<1>,

--- a/test/unit/cross_lane_ops_test/test/permute_gather_scatter.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_gather_scatter.cpp
@@ -40,12 +40,7 @@ namespace rocwmma
 
         using Types = typename std::tuple<uint32_t, uint64_t>;
 
-        using PermuteOps = std::tuple<PermuteImpl::Ops::GatherWave<4, 2>,
-                                      PermuteImpl::Ops::Gather32<4, 3>,
-                                      PermuteImpl::Ops::Gather32<4, 16>,
-                                      PermuteImpl::Ops::Gather16<4, 3>,
-                                      PermuteImpl::Ops::RotateWaveL<8>,
-                                      PermuteImpl::Ops::RotateWaveL<15>>;
+        using PermuteOps = std::tuple<PermuteImpl::Ops::Gather32<4, 11>>;
 
         using KernelParams = typename CombineLists<Types, PermuteOps>::Result;
 

--- a/test/unit/cross_lane_ops_test/test/permute_gather_scatter.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_gather_scatter.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using PermuteOps = std::tuple<PermuteImpl::Ops::GatherWave<4, 2>,
                                       PermuteImpl::Ops::Gather32<4, 3>,

--- a/test/unit/cross_lane_ops_test/test/permute_gather_scatter.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_gather_scatter.cpp
@@ -40,7 +40,10 @@ namespace rocwmma
 
         using Types = typename std::tuple<uint32_t, uint64_t>;
 
-        using PermuteOps = std::tuple<PermuteImpl::Ops::Gather32<4, 11>>;
+        using PermuteOps = std::tuple<PermuteImpl::Ops::Gather32<4, 0>,
+                                      PermuteImpl::Ops::Gather32<4, 16>,
+                                      PermuteImpl::Ops::Scatter32<4, 0>,
+                                      PermuteImpl::Ops::Scatter32<4, 16>>;
 
         using KernelParams = typename CombineLists<Types, PermuteOps>::Result;
 

--- a/test/unit/cross_lane_ops_test/test/permute_gather_scatter.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_gather_scatter.cpp
@@ -42,6 +42,7 @@ namespace rocwmma
 
         using PermuteOps = std::tuple<PermuteImpl::Ops::GatherWave<4, 2>,
                                       PermuteImpl::Ops::Gather32<4, 3>,
+                                      PermuteImpl::Ops::Gather32<4, 16>,
                                       PermuteImpl::Ops::Gather16<4, 3>,
                                       PermuteImpl::Ops::RotateWaveL<8>,
                                       PermuteImpl::Ops::RotateWaveL<15>>;

--- a/test/unit/cross_lane_ops_test/test/permute_gather_scatter.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_gather_scatter.cpp
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <tuple>
+#include <type_traits>
+
+#include "detail/cross_lane_ops.hpp"
+#include "kernel_generator.hpp"
+#include "unit_test.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public UnitTestParams
+    {
+        using Base = UnitTestParams;
+
+        // Types: Base IOC + double
+        using Types = typename Base::TestAllSizeTypes;
+
+        using PermuteOps = std::tuple<PermuteImpl::Ops::GatherWave<4, 2>,
+                                      PermuteImpl::Ops::Gather32<4, 3>,
+                                      PermuteImpl::Ops::Gather16<4, 3>,
+                                      PermuteImpl::Ops::RotateWaveL<8>,
+                                      PermuteImpl::Ops::RotateWaveL<15>>;
+
+        using KernelParams = typename CombineLists<Types, PermuteOps>::Result;
+
+        // Assemble the kernel generator
+        // Kernel: VectorIterator
+        using GeneratorImpl   = PermuteOpsGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        // Must be TBlockY must be 1.
+        static inline std::vector<ThreadBlockT> threadBlocks()
+        {
+            auto warpSize = HipDevice::instance()->warpSize();
+            return {{warpSize, 1}};
+        }
+
+        static inline std::vector<ProblemSizeT> problemSizes()
+        {
+            return {{warpSize, 1}};
+        }
+
+        // 'prev' values
+        static inline std::vector<Param1T> param1s()
+        {
+            return {5.0};
+        }
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class PermuteGatherScatterTest : public rocwmma::UnitTest
+{
+};
+
+TEST_P(PermuteGatherScatterTest, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CrossLaneOpTests,
+    PermuteGatherScatterTest,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::param1s()),
+                       ::testing::ValuesIn(rocwmma::TestParams::param2s())));

--- a/test/unit/cross_lane_ops_test/test/permute_gather_scatter.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_gather_scatter.cpp
@@ -65,6 +65,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/permute_rotate.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_rotate.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using PermuteOps = std::tuple<PermuteImpl::Ops::RotateWaveR<1>,
                                       PermuteImpl::Ops::RotateWaveR<5>,

--- a/test/unit/cross_lane_ops_test/test/permute_rotate.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_rotate.cpp
@@ -75,6 +75,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/permute_rotate.cpp
+++ b/test/unit/cross_lane_ops_test/test/permute_rotate.cpp
@@ -1,0 +1,103 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#include <tuple>
+#include <type_traits>
+
+#include "detail/cross_lane_ops.hpp"
+#include "kernel_generator.hpp"
+#include "unit_test.hpp"
+
+namespace rocwmma
+{
+
+    struct TestParams : public UnitTestParams
+    {
+        using Base = UnitTestParams;
+
+        // Types: Base IOC + double
+        using Types = typename Base::TestAllSizeTypes;
+
+        using PermuteOps = std::tuple<PermuteImpl::Ops::RotateWaveR<1>,
+                                      PermuteImpl::Ops::RotateWaveR<5>,
+                                      PermuteImpl::Ops::RotateWaveL<8>,
+                                      PermuteImpl::Ops::RotateWaveL<15>>;
+
+        using KernelParams = typename CombineLists<Types, PermuteOps>::Result;
+
+        // Assemble the kernel generator
+        // Kernel: VectorIterator
+        using GeneratorImpl   = PermuteOpsGenerator;
+        using KernelGenerator = KernelGenerator<KernelParams, GeneratorImpl>;
+
+        // Sanity check for kernel generator
+        static_assert(std::is_same<typename GeneratorImpl::ResultT, typename Base::KernelT>::value,
+                      "Kernels from this generator do not match testing interface");
+
+        // Must be TBlockY must be 1.
+        static inline std::vector<ThreadBlockT> threadBlocks()
+        {
+            auto warpSize = HipDevice::instance()->warpSize();
+            return {{warpSize, 1}};
+        }
+
+        static inline std::vector<ProblemSizeT> problemSizes()
+        {
+            return {{warpSize, 1}};
+        }
+
+        // 'prev' values
+        static inline std::vector<Param1T> param1s()
+        {
+            return {5.0};
+        }
+
+        static inline typename KernelGenerator::ResultT kernels()
+        {
+            return KernelGenerator::generate();
+        }
+    };
+
+} // namespace rocwmma
+
+// Test suite for unique parameterization
+class PermuteRotateTest : public rocwmma::UnitTest
+{
+};
+
+TEST_P(PermuteRotateTest, RunKernel)
+{
+    this->RunKernel();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    CrossLaneOpTests,
+    PermuteRotateTest,
+    ::testing::Combine(::testing::ValuesIn(rocwmma::TestParams::kernels()),
+                       ::testing::ValuesIn(rocwmma::TestParams::threadBlocks()),
+                       ::testing::ValuesIn(rocwmma::TestParams::problemSizes()),
+                       ::testing::ValuesIn(rocwmma::TestParams::param1s()),
+                       ::testing::ValuesIn(rocwmma::TestParams::param2s())));

--- a/test/unit/cross_lane_ops_test/test/swizzle_bcast_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_bcast_16.cpp
@@ -70,7 +70,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_bcast_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_bcast_16.cpp
@@ -65,24 +65,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_bcast_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_bcast_16.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::BCast16<5>,
                                       SwizzleImpl::Ops::BCast16<15>,

--- a/test/unit/cross_lane_ops_test/test/swizzle_bcast_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_bcast_16.cpp
@@ -69,6 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_bcast_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_bcast_2.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::BCast2<0>, SwizzleImpl::Ops::BCast2<1>>;
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_bcast_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_bcast_2.cpp
@@ -58,24 +58,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_bcast_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_bcast_2.cpp
@@ -62,6 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_bcast_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_bcast_2.cpp
@@ -63,7 +63,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_bcast_32.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_bcast_32.cpp
@@ -70,7 +70,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_bcast_32.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_bcast_32.cpp
@@ -65,24 +65,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_bcast_32.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_bcast_32.cpp
@@ -69,6 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_bcast_32.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_bcast_32.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::BCast32<5>,
                                       SwizzleImpl::Ops::BCast32<25>,

--- a/test/unit/cross_lane_ops_test/test/swizzle_bcast_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_bcast_4.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::BCast4<0>,
                                       SwizzleImpl::Ops::BCast4<1>,

--- a/test/unit/cross_lane_ops_test/test/swizzle_bcast_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_bcast_4.cpp
@@ -61,24 +61,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_bcast_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_bcast_4.cpp
@@ -66,7 +66,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_bcast_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_bcast_4.cpp
@@ -65,6 +65,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_bcast_8.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_bcast_8.cpp
@@ -70,7 +70,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_bcast_8.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_bcast_8.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::BCast8<0>,
                                       SwizzleImpl::Ops::BCast8<1>,

--- a/test/unit/cross_lane_ops_test/test/swizzle_bcast_8.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_bcast_8.cpp
@@ -65,24 +65,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_bcast_8.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_bcast_8.cpp
@@ -69,6 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_reverse_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_reverse_16.cpp
@@ -58,24 +58,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_reverse_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_reverse_16.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::Reverse16>;
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_reverse_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_reverse_16.cpp
@@ -62,6 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_reverse_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_reverse_16.cpp
@@ -63,7 +63,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_reverse_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_reverse_2.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::Reverse2>;
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_reverse_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_reverse_2.cpp
@@ -58,24 +58,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_reverse_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_reverse_2.cpp
@@ -62,6 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_reverse_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_reverse_2.cpp
@@ -63,7 +63,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_reverse_32.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_reverse_32.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::Reverse32>;
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_reverse_32.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_reverse_32.cpp
@@ -58,24 +58,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_reverse_32.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_reverse_32.cpp
@@ -62,6 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_reverse_32.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_reverse_32.cpp
@@ -63,7 +63,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_reverse_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_reverse_4.cpp
@@ -58,24 +58,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_reverse_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_reverse_4.cpp
@@ -62,6 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_reverse_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_reverse_4.cpp
@@ -63,7 +63,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_reverse_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_reverse_4.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::Reverse4>;
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_reverse_8.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_reverse_8.cpp
@@ -58,24 +58,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_reverse_8.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_reverse_8.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::Reverse8>;
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_reverse_8.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_reverse_8.cpp
@@ -62,6 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_reverse_8.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_reverse_8.cpp
@@ -63,7 +63,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_l16.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_l16.cpp
@@ -70,7 +70,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_l16.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_l16.cpp
@@ -65,24 +65,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_l16.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_l16.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::RotateL16<5>,
                                       SwizzleImpl::Ops::RotateL16<15>,

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_l16.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_l16.cpp
@@ -69,6 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_l2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_l2.cpp
@@ -58,24 +58,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_l2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_l2.cpp
@@ -62,6 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_l2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_l2.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::RotateL2<0>, SwizzleImpl::Ops::RotateL2<1>>;
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_l2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_l2.cpp
@@ -63,7 +63,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_l32.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_l32.cpp
@@ -70,7 +70,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_l32.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_l32.cpp
@@ -65,24 +65,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_l32.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_l32.cpp
@@ -69,6 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_l32.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_l32.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::RotateL32<5>,
                                       SwizzleImpl::Ops::RotateL32<25>,

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_l4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_l4.cpp
@@ -61,24 +61,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_l4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_l4.cpp
@@ -66,7 +66,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_l4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_l4.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::RotateL4<0>,
                                       SwizzleImpl::Ops::RotateL4<1>,

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_l4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_l4.cpp
@@ -65,6 +65,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_l8.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_l8.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::RotateL8<0>,
                                       SwizzleImpl::Ops::RotateL8<1>,

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_l8.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_l8.cpp
@@ -70,7 +70,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_l8.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_l8.cpp
@@ -65,24 +65,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_l8.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_l8.cpp
@@ -69,6 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_r16.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_r16.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::RotateR16<5>,
                                       SwizzleImpl::Ops::RotateR16<15>,

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_r16.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_r16.cpp
@@ -70,7 +70,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_r16.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_r16.cpp
@@ -65,24 +65,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_r16.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_r16.cpp
@@ -69,6 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_r2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_r2.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::RotateR2<0>, SwizzleImpl::Ops::RotateR2<1>>;
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_r2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_r2.cpp
@@ -58,24 +58,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_r2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_r2.cpp
@@ -62,6 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_r2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_r2.cpp
@@ -63,7 +63,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_r32.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_r32.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::RotateR32<5>,
                                       SwizzleImpl::Ops::RotateR32<25>,

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_r32.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_r32.cpp
@@ -70,7 +70,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_r32.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_r32.cpp
@@ -65,24 +65,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_r32.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_r32.cpp
@@ -69,6 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_r4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_r4.cpp
@@ -61,24 +61,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_r4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_r4.cpp
@@ -66,7 +66,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_r4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_r4.cpp
@@ -65,6 +65,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_r4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_r4.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::RotateR4<0>,
                                       SwizzleImpl::Ops::RotateR4<1>,

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_r8.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_r8.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::RotateR8<0>,
                                       SwizzleImpl::Ops::RotateR8<1>,

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_r8.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_r8.cpp
@@ -70,7 +70,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_r8.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_r8.cpp
@@ -65,24 +65,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_rotate_r8.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_rotate_r8.cpp
@@ -69,6 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_shuffle_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_shuffle_2.cpp
@@ -64,7 +64,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_shuffle_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_shuffle_2.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps
             = std::tuple<SwizzleImpl::Ops::Shuffle2<0u, 1u>, SwizzleImpl::Ops::Shuffle2<1u, 0u>>;

--- a/test/unit/cross_lane_ops_test/test/swizzle_shuffle_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_shuffle_2.cpp
@@ -59,24 +59,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_shuffle_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_shuffle_2.cpp
@@ -63,6 +63,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_shuffle_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_shuffle_4.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::Shuffle4<0u, 2u, 3u, 1u>,
                                       SwizzleImpl::Ops::Shuffle4<2u, 1u, 2u, 3u>,

--- a/test/unit/cross_lane_ops_test/test/swizzle_shuffle_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_shuffle_4.cpp
@@ -68,6 +68,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_shuffle_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_shuffle_4.cpp
@@ -64,24 +64,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_shuffle_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_shuffle_4.cpp
@@ -69,7 +69,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_swap_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_swap_16.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::Swap16>;
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_swap_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_swap_16.cpp
@@ -58,24 +58,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_swap_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_swap_16.cpp
@@ -62,6 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_swap_16.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_swap_16.cpp
@@ -63,7 +63,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_swap_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_swap_2.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::Swap2>;
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_swap_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_swap_2.cpp
@@ -58,24 +58,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_swap_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_swap_2.cpp
@@ -62,6 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_swap_2.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_swap_2.cpp
@@ -63,7 +63,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_swap_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_swap_4.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::Swap4>;
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_swap_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_swap_4.cpp
@@ -58,24 +58,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_swap_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_swap_4.cpp
@@ -62,6 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_swap_4.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_swap_4.cpp
@@ -63,7 +63,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_swap_8.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_swap_8.cpp
@@ -38,8 +38,7 @@ namespace rocwmma
     {
         using Base = UnitTestParams;
 
-        // Types: Base IOC + double
-        using Types = typename Base::TestAllSizeTypes;
+        using Types = typename std::tuple<uint32_t, uint64_t>;
 
         using SwizzleOps = std::tuple<SwizzleImpl::Ops::Swap8>;
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_swap_8.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_swap_8.cpp
@@ -58,24 +58,12 @@ namespace rocwmma
         static inline std::vector<ThreadBlockT> threadBlocks()
         {
             auto warpSize = HipDevice::instance()->warpSize();
-            // clang-format off
-            return {
-                        {warpSize, 1},
-                        {warpSize * 2, 1},
-                        {warpSize * 4, 1}
-                    };
-            // clang-format on
+            return {{warpSize, 1}};
         }
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            // clang-format off
-            return {
-                        {64, 64},
-                        {128, 128},
-                        {256, 256}
-                    };
-            // clang-format on
+            return {{64, 64}};
         }
 
         // 'prev' values

--- a/test/unit/cross_lane_ops_test/test/swizzle_swap_8.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_swap_8.cpp
@@ -62,6 +62,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
+            auto warpSize = HipDevice::instance()->warpSize();
             return {{warpSize, 1}};
         }
 

--- a/test/unit/cross_lane_ops_test/test/swizzle_swap_8.cpp
+++ b/test/unit/cross_lane_ops_test/test/swizzle_swap_8.cpp
@@ -63,7 +63,7 @@ namespace rocwmma
 
         static inline std::vector<ProblemSizeT> problemSizes()
         {
-            return {{64, 64}};
+            return {{warpSize, 1}};
         }
 
         // 'prev' values

--- a/test/unit/io_shape_test/detail/io_shape.hpp
+++ b/test/unit/io_shape_test/detail/io_shape.hpp
@@ -31,9 +31,6 @@
 
 namespace rocwmma
 {
-    static constexpr uint32_t ERROR_VALUE   = 7;
-    static constexpr uint32_t SUCCESS_VALUE = 0;
-
     template <typename MatrixT,
               uint32_t BlockM,
               uint32_t BlockN,

--- a/test/unit/io_traits_test/detail/io_traits.hpp
+++ b/test/unit/io_traits_test/detail/io_traits.hpp
@@ -27,14 +27,12 @@
 #ifndef ROCWMMA_DETAIL_IO_TRAITS_HPP
 #define ROCWMMA_DETAIL_IO_TRAITS_HPP
 
+#include "common.hpp"
 #include "device/io_traits.hpp"
 #include "unit_kernel_base.hpp"
 
 namespace rocwmma
 {
-    static constexpr uint32_t ERROR_VALUE   = 7;
-    static constexpr uint32_t SUCCESS_VALUE = 0;
-
     // Wrapper into the actual device function
     template <typename DataT, uint32_t BlockDim, uint32_t BlockK, uint32_t VectorWidth>
     struct IOTraitsKernel final : public UnitKernelBase<BlockDim, BlockK, DataT, col_major>

--- a/test/unit/io_traits_test/device/io_traits.hpp
+++ b/test/unit/io_traits_test/device/io_traits.hpp
@@ -29,9 +29,6 @@
 
 #include <rocwmma/rocwmma.hpp>
 
-static constexpr uint32_t ERROR_VALUE   = 7;
-static constexpr uint32_t SUCCESS_VALUE = 0;
-
 namespace rocwmma
 {
     template <typename DataT, uint32_t BlockDim, uint32_t BlockK, uint32_t VectorWidth>

--- a/test/unit/io_traits_test/test/io_traits_16.cpp
+++ b/test/unit/io_traits_test/test/io_traits_16.cpp
@@ -26,6 +26,7 @@
 
 #include <type_traits>
 
+#include "common.hpp"
 #include "detail/io_traits.hpp"
 #include "kernel_generator.hpp"
 #include "unit_test.hpp"

--- a/test/unit/pack_util_test/device/pack_util.hpp
+++ b/test/unit/pack_util_test/device/pack_util.hpp
@@ -29,8 +29,7 @@
 
 #include <rocwmma/rocwmma.hpp>
 
-static constexpr uint32_t ERROR_VALUE   = 7u;
-static constexpr uint32_t SUCCESS_VALUE = 0u;
+#include "common.hpp"
 
 namespace rocwmma
 {

--- a/test/unit/transforms_test/detail/transforms.hpp
+++ b/test/unit/transforms_test/detail/transforms.hpp
@@ -27,6 +27,7 @@
 #ifndef ROCWMMA_DETAIL_TRANSFORMS_TEST_HPP
 #define ROCWMMA_DETAIL_TRANSFORMS_TEST_HPP
 
+#include "common.hpp"
 #include "device/transforms.hpp"
 #include "unit_kernel_base.hpp"
 

--- a/test/unit/transforms_test/device/transforms.hpp
+++ b/test/unit/transforms_test/device/transforms.hpp
@@ -31,9 +31,6 @@
 #include "transforms.hpp"
 #include <rocwmma/rocwmma.hpp>
 
-static constexpr uint32_t ERROR_VALUE   = 7u;
-static constexpr uint32_t SUCCESS_VALUE = 0u;
-
 namespace rocwmma
 {
     namespace detail

--- a/test/unit/tuple_test/detail/tuple.hpp
+++ b/test/unit/tuple_test/detail/tuple.hpp
@@ -27,6 +27,7 @@
 #ifndef ROCWMMA_DETAIL_TUPLE_TEST_HPP
 #define ROCWMMA_DETAIL_TUPLE_TEST_HPP
 
+#include "common.hpp"
 #include "device/tuple.hpp"
 #include "unit_kernel_base.hpp"
 

--- a/test/unit/tuple_test/device/tuple.hpp
+++ b/test/unit/tuple_test/device/tuple.hpp
@@ -33,9 +33,6 @@
 #include <rocwmma/internal/vector.hpp>
 #include <rocwmma/rocwmma.hpp>
 
-static constexpr uint32_t ERROR_VALUE   = 7u;
-static constexpr uint32_t SUCCESS_VALUE = 0u;
-
 namespace rocwmma
 {
     __device__ static inline bool operatorMultTest()

--- a/test/unit/vector_iterator_test/detail/vector_iterator.hpp
+++ b/test/unit/vector_iterator_test/detail/vector_iterator.hpp
@@ -27,6 +27,7 @@
 #ifndef ROCWMMA_DETAIL_VECTOR_ITERATOR_HPP
 #define ROCWMMA_DETAIL_VECTOR_ITERATOR_HPP
 
+#include "common.hpp"
 #include "device/vector_iterator.hpp"
 #include "unit_kernel_base.hpp"
 

--- a/test/unit/vector_iterator_test/device/vector_iterator.hpp
+++ b/test/unit/vector_iterator_test/device/vector_iterator.hpp
@@ -29,9 +29,6 @@
 
 #include <rocwmma/rocwmma.hpp>
 
-static constexpr uint32_t ERROR_VALUE   = 7;
-static constexpr uint32_t SUCCESS_VALUE = 0;
-
 namespace rocwmma
 {
 

--- a/test/unit/vector_test/device/vector.hpp
+++ b/test/unit/vector_test/device/vector.hpp
@@ -29,8 +29,7 @@
 
 #include <rocwmma/rocwmma.hpp>
 
-static constexpr uint32_t ERROR_VALUE   = 7u;
-static constexpr uint32_t SUCCESS_VALUE = 0u;
+#include "common.hpp"
 
 namespace rocwmma
 {

--- a/test/unit/vector_util_test/device/vector_util.hpp
+++ b/test/unit/vector_util_test/device/vector_util.hpp
@@ -29,9 +29,6 @@
 
 #include <rocwmma/rocwmma.hpp>
 
-static constexpr uint32_t ERROR_VALUE   = 7u;
-static constexpr uint32_t SUCCESS_VALUE = 0u;
-
 namespace rocwmma
 {
     template <typename DataT, uint32_t VecSize>

--- a/test/unit/vector_util_test/test/vector_util.cpp
+++ b/test/unit/vector_util_test/test/vector_util.cpp
@@ -27,6 +27,7 @@
 #include <tuple>
 #include <type_traits>
 
+#include "common.hpp"
 #include "detail/vector_util.hpp"
 #include "kernel_generator.hpp"
 #include "unit_test.hpp"


### PR DESCRIPTION
Cross lane operations are applied on register file by a wave. 

So the unit tests only need to set up the input and verify the output in registers. 

Refactored the unit tests to remove the dependency of global memory. 