### PR TITLE
Remove targets 940 and 941

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
  #
  # MIT License
  #
- # Copyright (C) 2021-2024 Advanced Micro Devices, Inc. All rights reserved.
+ # Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
  #
  # Permission is hereby granted, free of charge, to any person obtaining a copy
  # of this software and associated documentation files (the "Software"), to deal
@@ -98,12 +98,12 @@ if (ADDRESS_SANITIZER_ENABLED)
     #TODO: Remove next line when rocm-cmake fix is available
     set(CMAKE_NO_BUILTIN_CHRPATH ON)
     rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-        TARGETS "gfx90a:xnack+;gfx940:xnack+;gfx941:xnack+;gfx942:xnack+" )
+        TARGETS "gfx90a:xnack+;gfx942:xnack+" )
 else()
     #TODO: Remove next line when rocm-cmake fix is available
     set(CMAKE_NO_BUILTIN_CHRPATH ON)
     rocm_check_target_ids(DEFAULT_AMDGPU_TARGETS
-        TARGETS "gfx908;gfx90a;gfx940;gfx941;gfx942;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201" )
+        TARGETS "gfx908;gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201" )
 endif()
 
 


### PR DESCRIPTION
Stop building 940 and 941 targets in Rocm 6.3