### PR TITLE
Reduce parameter set redundancy for CI build

### DIFF
--- a/test/unit/layout_traits_test/test/layout_traits_int_128.cpp
+++ b/test/unit/layout_traits_test/test/layout_traits_int_128.cpp
@@ -34,10 +34,22 @@ namespace rocwmma
 
     struct TestParams : public UnitTestParams
     {
-        using Base        = UnitTestParams;
-        using Types       = typename Base::TestAllSizeTypes;
-        using MmaDims     = std::tuple<I<16>, I<32>, I<64>>;
-        using SplitKs     = std::tuple<I<1>, I<2>, I<4>>;
+        using Base    = UnitTestParams;
+        using Types   = typename Base::TestAllSizeTypes;
+        using MmaDims = std::tuple<I<16>,
+                                   I<32>
+#if ROCWMMA_EXTENDED_TESTS
+                                   ,
+                                   I<64>
+#endif // ROCWMMA_EXTENDED_TESTS
+                                   >;
+        using SplitKs = std::tuple<I<1>,
+                                   I<4>
+#if ROCWMMA_EXTENDED_TESTS
+                                   ,
+                                   I<2>
+#endif // ROCWMMA_EXTENDED_TESTS
+                                   >;
         using BlockSizes  = typename Base::TestBlockSizes128;
         using DataLayouts = typename Base::TestLayoutsAll;
 

--- a/test/unit/layout_traits_test/test/layout_traits_int_256.cpp
+++ b/test/unit/layout_traits_test/test/layout_traits_int_256.cpp
@@ -34,10 +34,22 @@ namespace rocwmma
 
     struct TestParams : public UnitTestParams
     {
-        using Base        = UnitTestParams;
-        using Types       = typename Base::TestAllSizeTypes;
-        using MmaDims     = std::tuple<I<16>, I<32>, I<64>>;
-        using SplitKs     = std::tuple<I<1>, I<2>, I<4>>;
+        using Base    = UnitTestParams;
+        using Types   = typename Base::TestAllSizeTypes;
+        using MmaDims = std::tuple<I<16>,
+                                   I<32>
+#if ROCWMMA_EXTENDED_TESTS
+                                   ,
+                                   I<64>
+#endif // ROCWMMA_EXTENDED_TESTS
+                                   >;
+        using SplitKs = std::tuple<I<1>,
+                                   I<4>
+#if ROCWMMA_EXTENDED_TESTS
+                                   ,
+                                   I<2>
+#endif // ROCWMMA_EXTENDED_TESTS
+                                   >;
         using BlockSizes  = typename Base::TestBlockSizes256;
         using DataLayouts = typename Base::TestLayoutsAll;
 

--- a/test/unit/layout_traits_test/test/layout_traits_int_64.cpp
+++ b/test/unit/layout_traits_test/test/layout_traits_int_64.cpp
@@ -34,10 +34,22 @@ namespace rocwmma
 
     struct TestParams : public UnitTestParams
     {
-        using Base        = UnitTestParams;
-        using Types       = typename Base::TestAllSizeTypes;
-        using MmaDims     = std::tuple<I<16>, I<32>, I<64>>;
-        using SplitKs     = std::tuple<I<1>, I<2>, I<4>>;
+        using Base    = UnitTestParams;
+        using Types   = typename Base::TestAllSizeTypes;
+        using MmaDims = std::tuple<I<16>,
+                                   I<32>
+#if ROCWMMA_EXTENDED_TESTS
+                                   ,
+                                   I<64>
+#endif // ROCWMMA_EXTENDED_TESTS
+                                   >;
+        using SplitKs = std::tuple<I<1>,
+                                   I<4>
+#if ROCWMMA_EXTENDED_TESTS
+                                   ,
+                                   I<2>
+#endif // ROCWMMA_EXTENDED_TESTS
+                                   >;
         using BlockSizes  = typename Base::TestBlockSizes64;
         using DataLayouts = typename Base::TestLayoutsAll;
 


### PR DESCRIPTION
- Reduces CI test params coverage.
- Moves extra coverage to extended testing context