### PR TITLE
Refactor layout iteration

### DIFF
--- a/library/include/rocwmma/internal/layout/layout.hpp
+++ b/library/include/rocwmma/internal/layout/layout.hpp
@@ -130,6 +130,12 @@ namespace rocwmma
                   uint32_t SplitK = 1> // # of splits
         struct RowOrthoInt;
 
+        template<typename MatrixLayout, typename Coord1d>
+        ROCWMMA_DEVICE constexpr static inline decltype(auto) cumulative_offset(Coord1d&& flatCoord);
+
+        template<typename MatrixLayout, typename Coord1d>
+        ROCWMMA_DEVICE constexpr static inline decltype(auto) incrementalOffset(Coord1d&& flatCoord);
+
     } // namespace MatrixLayout
 
     // Register layouts describe in-register layout and serve as transform states, or endpoints.

--- a/library/include/rocwmma/internal/layout/layout.hpp
+++ b/library/include/rocwmma/internal/layout/layout.hpp
@@ -130,12 +130,6 @@ namespace rocwmma
                   uint32_t SplitK = 1> // # of splits
         struct RowOrthoInt;
 
-        template<typename MatrixLayout, typename Coord1d>
-        ROCWMMA_DEVICE constexpr static inline decltype(auto) cumulative_offset(Coord1d&& flatCoord);
-
-        template<typename MatrixLayout, typename Coord1d>
-        ROCWMMA_DEVICE constexpr static inline decltype(auto) incrementalOffset(Coord1d&& flatCoord);
-
     } // namespace MatrixLayout
 
     // Register layouts describe in-register layout and serve as transform states, or endpoints.

--- a/library/include/rocwmma/internal/layout/matrix_layout_impl.hpp
+++ b/library/include/rocwmma/internal/layout/matrix_layout_impl.hpp
@@ -636,23 +636,23 @@ namespace rocwmma
             {
             };
 
-            ROCWMMA_DEVICE constexpr static inline auto strideCounts()
+            ROCWMMA_DEVICE constexpr static inline decltype(auto) strideCounts()
             {
                 return MatrixLayout::strideCounts();
             }
 
-            ROCWMMA_DEVICE constexpr static inline auto strides()
+            ROCWMMA_DEVICE constexpr static inline decltype(auto) strides()
             {
                 constexpr auto t = MatrixLayout::strides();
                 constexpr auto swap_strides = [](auto&&... args)
                 {
-                    return make_vector(swap(args)...);
+                    return make_vector(swap(forward<decay_t<decltype(args)>>(args))...);
                 };
 
                 return apply(swap_strides, t);
             }
 
-            ROCWMMA_DEVICE static inline auto baseOffset()
+            ROCWMMA_DEVICE static inline decltype(auto) baseOffset()
             {
                 return swap(MatrixLayout::baseOffset());
             }

--- a/library/include/rocwmma/internal/layout/matrix_layout_impl.hpp
+++ b/library/include/rocwmma/internal/layout/matrix_layout_impl.hpp
@@ -35,6 +35,94 @@ namespace rocwmma
     // Implementations for the MatrixLayout classes
     namespace MatrixLayout
     {
+        // Representing an embedded compile time value in argument passing
+        template<uint32_t Number>
+        using I = integral_constant<uint32_t, Number>;
+
+        // All of the matrix layouts are required to provide interface functions to:
+        // - strideCounts()
+        // - strides()
+        template<typename MatrixLayoutT>
+        struct MatrixLayoutBase
+        {
+            private:
+
+            // Incremental iteration offset
+            template<typename Coord1d, size_t... Indices>
+            ROCWMMA_DEVICE constexpr static inline auto incrementalOffset_impl(Coord1d&& flatCoord, index_sequence<Indices...>)
+            {
+                // This will get invoked for each MatrixLayout stride component to determine
+                // iterative stride offset contributions
+                auto component_offset = [](auto&& flatCoord, auto& flatStride, auto&& component, auto&& stride)
+                {
+                    constexpr auto comp = decay_t<decltype(component)>::value;
+
+                    // Ensure component is a contributor
+                    if constexpr (comp > 1)
+                    {
+                        // flatStride it how many iterations between a contribution of given component.
+                        // The stride of the LAST iteration of any component will reset the offset back
+                        // to the component origin.
+                        // Any other component stride will advance the iterative offset.
+                        auto next = flatCoord + 1;
+                        auto nextOffset = next % (comp * flatStride) == 0
+                            ? (-(comp - 1) * stride) // reset stride
+                            : (next % flatStride == 0
+                                ? stride // advance stride
+                                : decay_t<decltype(stride)>{0}); // NOP
+
+                        // scale the flatStride by current component
+                        flatStride *= comp;
+                        return nextOffset;
+                    }
+                    else
+                    {
+                        return decay_t<decltype(stride)>{0};
+                    }
+                };
+
+                // Initialize the MatrixLayout strides and stride space
+                constexpr auto strideSpace = MatrixLayoutT::strideCounts();
+                constexpr auto strides = MatrixLayoutT::strides();
+
+                // Flat stride begins with neighbor elements
+                auto flatStride = decay_t<Coord1d>{1};
+
+                // Accumulate the matrix offset contributions of each component to the next iteration.
+                // Note: Build strides in reverse order due to layouts are built in reverse order
+                return (component_offset(forward<Coord1d>(flatCoord),
+                                        forward<decltype(flatStride)&>(flatStride),
+                                        I<get<sizeof...(Indices) - 1 - Indices>(strideSpace)>{},
+                                        get<sizeof...(Indices) - 1 - Indices>(strides))
+                        + ...);
+            }
+
+            public:
+
+            template<typename Coord1d>
+            ROCWMMA_DEVICE constexpr static inline decltype(auto) cumulativeOffset(Coord1d&& flatCoord)
+            {
+                // Get the iterative stride coord in the stride space.
+                // Note: Using the reverse inflate because layouts generate strideSpace in reverse order.
+                constexpr auto strideSpace = MatrixLayoutT::strideCounts();
+                auto strideCoord = inflate_coord_left(forward<Coord1d>(flatCoord), strideSpace);
+
+                // Calculate the final matrix offset by applying the stride coord on the physical strides
+                constexpr auto strides = MatrixLayoutT::strides();
+                return to_matrix_space(strideCoord, strides);
+            }
+
+            // Incremental iteration offset
+            template<typename Coord1d>
+            ROCWMMA_DEVICE constexpr static inline decltype(auto) incrementalOffset(Coord1d&& flatCoord)
+            {
+                using VecT = decay_t<decltype(MatrixLayoutT::strideCounts())>;
+
+                return incrementalOffset_impl(forward<Coord1d>(flatCoord),
+                                              make_index_sequence<VecTraits<VecT>::size()>{});
+            }
+        };
+
         /* Pattern that maps threads contiguously to matrix columns and assumes
         * that VW will be mapped orthogonally to the column.
         * This pattern considers VW up to MaxVW, BlockDim <= 64 and BlockDim > 64.
@@ -94,7 +182,7 @@ namespace rocwmma
                   typename DataT,
                   uint32_t VectorWidth,
                   uint32_t MaxVectorWidth>
-        struct ColOrthoVW
+        struct ColOrthoVW : public MatrixLayoutBase<ColOrthoVW<BlockDim, BlockK, DataT, VectorWidth, MaxVectorWidth>>
         {
             struct Traits
             {
@@ -138,12 +226,6 @@ namespace rocwmma
                               "MaxVectorWidth must larger than VWStride_Y");
                 static_assert(MaxVectorWidth % VWStride_Y == 0,
                               "MaxVectorWidth must be a multiple of VWStride_Y");
-
-                // Orthogonal layout, coordinates are reversed
-                // using OrthoLayout
-                //     = RowOrthoVW<BlockDim, BlockK, DataT, VectorWidth, MaxVectorWidth>;
-
-                // using MatrixCoordT = Coord2d;
             };
 
             ROCWMMA_DEVICE constexpr static inline auto strideCounts()
@@ -175,8 +257,6 @@ namespace rocwmma
                                             % Traits::BlockKStride_Y);
                 }
             }
-
-            ROCWMMA_DEVICE static inline auto debug() {}
         };
 
         /* Pattern that maps threads to matrix columns and assumes
@@ -275,7 +355,7 @@ namespace rocwmma
                   typename DataT,
                   uint32_t VectorWidth,
                   uint32_t MaxVectorWidth>
-        struct ColInlineVW
+        struct ColInlineVW : public MatrixLayoutBase<ColInlineVW<BlockDim, BlockK, DataT, VectorWidth, MaxVectorWidth>>
         {
 
             struct Traits
@@ -321,12 +401,6 @@ namespace rocwmma
                               "MaxVectorWidth must larger than VWStride_X");
                 static_assert(MaxVectorWidth % VWStride_X == 0,
                               "MaxVectorWidth must be a multiple of VWStride_X");
-
-                // Orthogonal layout, coordinates are reversed
-                //using OrthoLayout
-                //    = RowInlineVW<BlockDim, BlockK, DataT, VectorWidth, MaxVectorWidth>;
-
-                //using MatrixCoordT = Coord2d;
             };
 
             ROCWMMA_DEVICE constexpr static inline auto strideCounts()
@@ -359,8 +433,6 @@ namespace rocwmma
                                             % Traits::BlockKStride_Y);
                 }
             }
-
-            ROCWMMA_DEVICE static inline auto debug() {}
         };
 
         template <uint32_t BlockDim,
@@ -368,7 +440,7 @@ namespace rocwmma
                   typename DataT,
                   uint32_t MfmaDim, // MFMA instruction size
                   uint32_t SplitK /* = 1*/> // # of splits
-        struct ColInlineInt
+        struct ColInlineInt : public MatrixLayoutBase<ColInlineInt<BlockDim, BlockK, DataT, MfmaDim, SplitK>>
         {
             struct Traits
             {
@@ -399,11 +471,6 @@ namespace rocwmma
                 static constexpr uint32_t BlockKSegs = KPerThread / BlockKStride_Y;
                 static constexpr uint32_t VWSegs     = DimPerThread / VWStride_X;
 
-                // // Check VectorWidth validity
-                // static_assert((uint32_t)Traits::DimPerThread >= VectorWidth, "Invalid VectorWidth");
-                // static_assert((uint32_t)Traits::DimPerThread % VectorWidth == 0,
-                //               "DimPerThread not a multiple of VectorWidth");
-
                 // Check KPerThread validity
                 static_assert(BlockK >= KPerThread, "Invalid KPerThread");
                 static_assert(BlockK % KPerThread == 0, "BlockK is not a multiple of KPerThread");
@@ -415,11 +482,6 @@ namespace rocwmma
                 // Check MfmaDim validity
                 static_assert(BlockDim >= MfmaDim, "BlockDim must be larger than MfmaDim");
                 static_assert(BlockDim % MfmaDim == 0, "BlockDim must be a multiple of MfmaDim");
-
-                // Orthogonal layout, coordinates are reversed
-                //using OrthoLayout = RowInlineInt<BlockDim, BlockK, DataT, MfmaDim, SplitK>;
-
-                //using MatrixCoordT = Coord2d;
             };
 
             ROCWMMA_DEVICE constexpr static inline auto strideCounts()
@@ -439,33 +501,6 @@ namespace rocwmma
                 return make_coord2d((threadIdx.x * Traits::DimPerThread) % BlockDim,
                                     (threadIdx.x / MfmaDim * Traits::KPerThread) % BlockK);
             }
-
-            ROCWMMA_DEVICE static inline auto debug()
-            {
-                // if(threadIdx.x == 0 && threadIdx.y == 0)
-                // {
-                //     printf("SplitKSegs: %d, BlockKSegs: %d, VWSegs: %d\n",
-                //            (uint32_t)Traits::SplitKSegs,
-                //            (uint32_t)Traits::BlockKSegs,
-                //            (uint32_t)Traits::VWSegs);
-
-                //     printf("SplitKStride_X: %d, SplitKStride_Y: %d\nBlockKStride_X: %d, "
-                //            "BlockKStride_Y: %d\nVWStride_X: %d, VWStride_Y: %d\n",
-                //            (uint32_t)Traits::SplitKStride_X,
-                //            (uint32_t)Traits::SplitKStride_Y,
-                //            (uint32_t)Traits::BlockKStride_X,
-                //            (uint32_t)Traits::BlockKStride_Y,
-                //            (uint32_t)Traits::VWStride_X,
-                //            (uint32_t)Traits::VWStride_Y);
-                // }
-                // if(threadIdx.x <= 63 && threadIdx.y == 0)
-                // {
-                //     printf("Tid: (%d) Base offset(X, Y): = (%d, %d)\n",
-                //            threadIdx.x,
-                //            get<0>(baseOffset()),
-                //            get<1>(baseOffset()));
-                // }
-            }
         };
 
         template <uint32_t BlockDim,
@@ -473,7 +508,7 @@ namespace rocwmma
                   typename DataT,
                   uint32_t MfmaDim, // MFMA instruction size
                   uint32_t SplitK /*= 1*/> // # of splits
-        struct ColOrthoInt
+        struct ColOrthoInt : public MatrixLayoutBase<ColOrthoInt<BlockDim, BlockK, DataT, MfmaDim, SplitK>>
         {
             struct Traits
             {
@@ -508,11 +543,6 @@ namespace rocwmma
                 static_assert(BlockK >= KPerThread, "Invalid KPerThread");
                 static_assert(BlockK % KPerThread == 0, "BlockK is not a multiple of KPerThread");
 
-                // // Check VectorWidth validity
-                // static_assert((uint32_t)Traits::KPerThread >= VectorWidth, "Invalid VectorWidth");
-                // static_assert((uint32_t)Traits::KPerThread % VectorWidth == 0,
-                //               "KPerThread not a multiple of VectorWidth");
-
                 // Check SplitK validity
                 static_assert(BlockK >= SplitK, "Invalid SplitK");
                 static_assert(BlockK % SplitK == 0, "BlockK is not a multiple of SplitK");
@@ -520,11 +550,6 @@ namespace rocwmma
                 // Check MfmaDim validity
                 static_assert(BlockDim >= MfmaDim, "BlockDim must be larger than MfmaDim");
                 static_assert(BlockDim % MfmaDim == 0, "BlockDim must be a multiple of MfmaDim");
-
-                // Orthogonal layout, coordinates are reversed
-                //using OrthoLayout = RowOrthoInt<BlockDim, BlockK, DataT, MfmaDim, SplitK>;
-
-                //using MatrixCoordT = Coord2d;
             };
 
             ROCWMMA_DEVICE constexpr static inline auto strideCounts()
@@ -545,30 +570,6 @@ namespace rocwmma
             {
                 return make_coord2d((threadIdx.x * Traits::DimPerThread) % BlockDim,
                                     (threadIdx.x / MfmaDim * Traits::KPerThread) % BlockK);
-            }
-
-            ROCWMMA_DEVICE static inline auto debug()
-            {
-                // if(threadIdx.x == 0 && threadIdx.y == 0)
-                // {
-                //     printf("SplitKSegs: %d, BlockKSegs: %d, VWSegs: %d\n",
-                //         (uint32_t)Traits::SplitKSegs,
-                //         (uint32_t)Traits::BlockKSegs,
-                //         (uint32_t)Traits::VWSegs);
-
-                //     printf("SplitKStride_X: %d, SplitKStride_Y: %d\nBlockKStride_X: %d, BlockKStride_Y: %d\nVWStride_X: %d, VWStride_Y: %d\n",
-                //         (uint32_t)Traits::SplitKStride_X,
-                //         (uint32_t)Traits::SplitKStride_Y,
-                //         (uint32_t)Traits::BlockKStride_X,
-                //         (uint32_t)Traits::BlockKStride_Y,
-                //         (uint32_t)Traits::VWStride_X,
-                //         (uint32_t)Traits::VWStride_Y);
-
-                // }
-                // if(threadIdx.x <= 63 && threadIdx.y == 0)
-                // {
-                //     printf("Base offset(X, Y): = (%d, %d)", get<0>(baseOffset()), get<1>(baseOffset()));
-                // }
             }
         };
 
@@ -629,7 +630,7 @@ namespace rocwmma
         };
 
         template <typename MatrixLayout>
-        struct OrthoImpl
+        struct OrthoImpl : public MatrixLayoutBase<OrthoImpl<MatrixLayout>>
         {
             struct Traits : public OrthoTraits<MatrixLayout>
             {
@@ -642,18 +643,19 @@ namespace rocwmma
 
             ROCWMMA_DEVICE constexpr static inline auto strides()
             {
-                auto t = MatrixLayout::strides();
-                // TODO: use apply
-                //apply([](auto const& v){ return swap(v); });
-                return make_vector(swap(get<0>(t)), swap(get<1>(t)), swap(get<2>(t)));
+                constexpr auto t = MatrixLayout::strides();
+                constexpr auto swap_strides = [](auto&&... args)
+                {
+                    return make_vector(swap(args)...);
+                };
+
+                return apply(swap_strides, t);
             }
 
             ROCWMMA_DEVICE static inline auto baseOffset()
             {
                 return swap(MatrixLayout::baseOffset());
             }
-
-            ROCWMMA_DEVICE static inline auto debug() {}
         };
 
         template <uint32_t BlockDim,
@@ -694,107 +696,6 @@ namespace rocwmma
             : public OrthoImpl<ColInlineInt<BlockDim, BlockK, DataT, MmaDim, SplitK>>
         {
         };
-
-
-        template <uint32_t SpaceX,
-                  uint32_t SpaceY,
-                  uint32_t SpaceZ,
-                  uint32_t StrideX0,
-                  uint32_t StrideX1,
-                  uint32_t StrideY0,
-                  uint32_t StrideY1,
-                  uint32_t StrideZ0,
-                  uint32_t StrideZ1>
-        struct TestLayout
-        {
-            ROCWMMA_DEVICE constexpr static inline auto strideCounts()
-            {
-                return make_vector(SpaceX, SpaceY, SpaceZ);
-            }
-
-            ROCWMMA_DEVICE constexpr static inline auto strides()
-            {
-                return make_vector(make_coord2d(StrideX0, StrideX1),
-                                   make_coord2d(StrideY0, StrideY1),
-                                   make_coord2d(StrideZ0, StrideZ1));
-            }
-        };
-
-        template<uint32_t Number>
-        using I = integral_constant<uint32_t, Number>;
-
-        template<typename MatrixLayout, typename Coord1d>
-        ROCWMMA_DEVICE constexpr static inline decltype(auto) cumulative_offset(Coord1d&& flatCoord)
-        {
-            // Get the iterative stride coord in the stride space.
-            // Note: Using the reverse inflate because layouts generate strideSpace in reverse order.
-            constexpr auto strideSpace = MatrixLayout::strideCounts();
-            auto strideCoord = inflate_coord_left(forward<Coord1d>(flatCoord), strideSpace);
-
-            // Calculate the final matrix offset by applying the stride coord on the physical strides
-            constexpr auto strides = MatrixLayout::strides();
-            return to_matrix_space(strideCoord, strides);
-        }
-
-        // Incremental iteration offset
-        template<typename MatrixLayout, typename Coord1d, size_t... Indices>
-        ROCWMMA_DEVICE constexpr static inline auto incremental_offset(Coord1d&& flatCoord, index_sequence<Indices...>)
-        {
-            // This will get invoked for each MatrixLayout stride component to determine
-            // iterative stride offset contributions
-            auto component_offset = [](auto&& flatCoord, auto& flatStride, auto&& component, auto&& stride)
-            {
-                constexpr auto comp = decay_t<decltype(component)>::value;
-
-                // Ensure component is a contributor
-                if constexpr (comp > 1)
-                {
-                    // flatStride it how many iterations between a contribution of given component.
-                    // The stride of the LAST iteration of any component will reset the offset back
-                    // to the component origin.
-                    // Any other component stride will advance the iterative offset.
-                    auto next = flatCoord + 1;
-                    auto nextOffset = next % (comp * flatStride) == 0
-                        ? (-(comp - 1) * stride) // reset stride
-                        : (next % flatStride == 0
-                            ? stride // advance stride
-                            : decay_t<decltype(stride)>{0}); // NOP
-
-                    // scale the flatStride by current component
-                    flatStride *= comp;
-                    return nextOffset;
-                }
-                else
-                {
-                    return decay_t<decltype(stride)>{0};
-                }
-            };
-
-            // Initialize the MatrixLayout strides and stride space
-            constexpr auto strideSpace = MatrixLayout::strideCounts();
-            constexpr auto strides = MatrixLayout::strides();
-
-            // Flat stride begins with neighbor elements
-            auto flatStride = decay_t<Coord1d>{1};
-
-            // Accumulate the matrix offset contributions of each component to the next iteration.
-            // Note: Build strides in reverse order due to layouts are built in reverse order
-            return (component_offset(forward<Coord1d>(flatCoord),
-                                     forward<decltype(flatStride)&>(flatStride),
-                                     I<get<sizeof...(Indices) - 1 - Indices>(strideSpace)>{},
-                                     get<sizeof...(Indices) - 1 - Indices>(strides))
-                    + ...);
-        }
-
-        // Incremental iteration offset
-        template<typename MatrixLayout, typename Coord1d>
-        ROCWMMA_DEVICE constexpr static inline decltype(auto) incremental_offset(Coord1d&& flatCoord)
-        {
-            using VecT = decay_t<decltype(MatrixLayout::strideCounts())>;
-
-            return incremental_offset<MatrixLayout>(forward<Coord1d>(flatCoord),
-                                      make_index_sequence<VecTraits<VecT>::size()>{});
-        }
 
     } // namespace MatrixLayout
 

--- a/library/include/rocwmma/internal/tuple.hpp
+++ b/library/include/rocwmma/internal/tuple.hpp
@@ -218,17 +218,25 @@ namespace rocwmma
         constexpr static inline decltype(auto)
             inflate_coord_right_impl(Coord1d&& flatCoord, VecT&& dims, index_sequence<Indices...>)
         {
-            auto inflate = [](auto&& c, auto&& d, auto& div, bool last) {
-                auto result = (last ? (c / div) : (c / div % d));
-                div *= d;
-                return result;
+            auto inflate = [](auto&& c, auto&& d, auto& div, auto&& is_last) {
+
+                if constexpr ((bool)decay_t<decltype(is_last)>::value == true)
+                {
+                    div *= d;
+                    return c / div;
+                }
+                else
+                {
+                    div *= d;
+                    return c / div % d;
+                }
             };
 
             auto div = decay_t<Coord1d>{1};
             return make_vector(inflate(forward<Coord1d>(flatCoord),
                                        get<Indices>(forward<VecT>(dims)),
                                        forward<decltype(div)&>(div),
-                                       Indices == sizeof...(Indices) - 1)...);
+                                       Number<Indices == sizeof...(Indices) - 1>{})...);
         }
     }
 
@@ -247,10 +255,18 @@ namespace rocwmma
         constexpr static inline decltype(auto)
             inflate_coord_left_impl(Coord1d&& flatCoord, VecT&& dims, index_sequence<Indices...>)
         {
-            auto inflate = [](auto&& c, auto&& d, auto& div, bool last) {
-                auto result = (last ? (c / div) : (c / div % d));
-                div *= d;
-                return result;
+            auto inflate = [](auto&& c, auto&& d, auto& div, auto&& is_last) {
+
+                if constexpr ((bool)decay_t<decltype(is_last)>::value == true)
+                {
+                    div *= d;
+                    return c / div;
+                }
+                else
+                {
+                    div *= d;
+                    return c / div % d;
+                }
             };
 
             auto div = decay_t<Coord1d>{1};
@@ -258,7 +274,7 @@ namespace rocwmma
                 inflate(forward<Coord1d>(flatCoord),
                         get<VecTraits<decay_t<VecT>>::size() - 1 - Indices>(forward<VecT>(dims)),
                         forward<decltype(div)&>(div),
-                        Indices == sizeof...(Indices) - 1)...));
+                        Number<Indices == sizeof...(Indices) - 1>{})...));
         }
     }
 

--- a/library/include/rocwmma/internal/tuple.hpp
+++ b/library/include/rocwmma/internal/tuple.hpp
@@ -267,7 +267,7 @@ namespace rocwmma
                 }
                 else
                 {
-                    auto result = c / div % d
+                    auto result = c / div % d;
                     div *= d;
                     return result;
                 }

--- a/library/include/rocwmma/internal/tuple.hpp
+++ b/library/include/rocwmma/internal/tuple.hpp
@@ -273,29 +273,32 @@ namespace rocwmma
 
     namespace detail
     {
-        template <typename Vec0, typename Vec1, size_t... Indices>
+        template <typename VecT0, typename VecT1, size_t... Indices>
         constexpr static inline decltype(auto)
-            to_matrix_space_impl(Vec0&& strides, Vec1&& strideSpace, index_sequence<Indices...>)
+            to_matrix_space_impl(VecT0&& strideCoord, VecT1&& strides, index_sequence<Indices...>)
         {
-            static_assert(VecTraits<decay_t<Vec0>>::size() == sizeof...(Indices)
-                              && VecTraits<decay_t<Vec1>>::size() == sizeof...(Indices),
-                          "strides and strideSpace vectors must be the same size");
+            static_assert(VecTraits<decay_t<VecT0>>::size() == sizeof...(Indices)
+                       && VecTraits<decay_t<VecT1>>::size() == sizeof...(Indices),
+                          "strideCoord and strides vectors must be the same size");
 
-            auto inflate = [](auto&& stride, auto&& dim) { return stride * dim; };
+            auto matrix_space_offset = [](auto&& component, auto&& stride) { return component * stride; };
 
-            return (inflate(get<Indices>(forward<Vec0>(strides)),
-                            get<Indices>(forward<Vec1>(strideSpace)))
+            // Calculate a final matrix-space offset by accumulating
+            // each stride coordinate component multiplied by their respective stride:
+            // result = Sum(strideCoord[0]* strides[0] + ... + strideCoord[N-1] * strides[N-1])
+            return (matrix_space_offset(get<Indices>(forward<VecT0>(strideCoord)),
+                                        get<Indices>(forward<VecT1>(strides)))
                     + ...);
         }
     }
 
-    template <typename Vec0, typename Vec1>
-    constexpr static inline decltype(auto) to_matrix_space(Vec0&& strides, Vec1&& strideSpace)
+    template <typename VecT0, typename VecT1>
+    constexpr static inline decltype(auto) to_matrix_space(VecT0&& strideCoord, VecT1&& strides)
     {
         return detail::to_matrix_space_impl(
-            forward<Vec0>(strides),
-            forward<Vec1>(strideSpace),
-            make_index_sequence<VecTraits<decay_t<Vec0>>::size()>{});
+            forward<VecT0>(strideCoord),
+            forward<VecT1>(strides),
+            make_index_sequence<VecTraits<decay_t<VecT0>>::size()>{});
     }
 
 #if !defined(__HIPCC_RTC__)

--- a/library/include/rocwmma/internal/tuple.hpp
+++ b/library/include/rocwmma/internal/tuple.hpp
@@ -222,13 +222,15 @@ namespace rocwmma
 
                 if constexpr ((bool)decay_t<decltype(is_last)>::value == true)
                 {
+                    auto result = c / div;
                     div *= d;
-                    return c / div;
+                    return result;
                 }
                 else
                 {
+                    auto result = c / div % d;
                     div *= d;
-                    return c / div % d;
+                    return result;
                 }
             };
 
@@ -259,13 +261,15 @@ namespace rocwmma
 
                 if constexpr ((bool)decay_t<decltype(is_last)>::value == true)
                 {
+                    auto result = c / div;
                     div *= d;
-                    return c / div;
+                    return result;
                 }
                 else
                 {
+                    auto result = c / div % d
                     div *= d;
-                    return c / div % d;
+                    return result;
                 }
             };
 

--- a/library/include/rocwmma/internal/utility/apply_impl.hpp
+++ b/library/include/rocwmma/internal/utility/apply_impl.hpp
@@ -41,50 +41,40 @@ namespace rocwmma
             return fn(get<I>(forward<VecT>(v))...);
         }
 
-        template <typename F, typename DataT, uint32_t Rank>
-        ROCWMMA_HOST_DEVICE constexpr decltype(auto) apply(F fn, HIP_vector_type<DataT, Rank>& v)
+        template <typename F,
+        typename DataT,
+        uint32_t VecSize,
+        template<typename, uint32_t> class VecT>
+        ROCWMMA_HOST_DEVICE constexpr decltype(auto) apply(F&& fn, VecT<DataT, VecSize>&& v)
         {
-            constexpr size_t size = VecTraits<decay_t<decltype(v)>>::size();
-            return detail::apply_impl(fn, v, detail::make_index_sequence<size>());
+            constexpr size_t size = VecTraits<VecT<DataT, VecSize>>::size();
+            return detail::apply_impl(forward<F>(fn),
+                                      v,
+                                      detail::make_index_sequence<size>());
         }
 
-        template <typename F, typename DataT, uint32_t Rank>
-        ROCWMMA_HOST_DEVICE constexpr decltype(auto) apply(F                                   fn,
-                                                           HIP_vector_type<DataT, Rank> const& v)
+        template <typename F,
+        typename DataT,
+        uint32_t VecSize,
+        template<typename, uint32_t> class VecT>
+        ROCWMMA_HOST_DEVICE constexpr decltype(auto) apply(F&& fn, VecT<DataT, VecSize>& v)
         {
-            constexpr size_t size = VecTraits<decay_t<decltype(v)>>::size();
-            return detail::apply_impl(fn, v, detail::make_index_sequence<size>());
+            constexpr size_t size = VecTraits<VecT<DataT, VecSize>>::size();
+            return detail::apply_impl(forward<F>(fn),
+                                      v,
+                                      detail::make_index_sequence<size>());
         }
 
-        template <typename F, typename DataT, uint32_t Rank>
-        ROCWMMA_HOST_DEVICE constexpr decltype(auto) apply(F fn, HIP_vector_type<DataT, Rank>&& v)
+        template <typename F,
+        typename DataT,
+        uint32_t VecSize,
+        template<typename, uint32_t> class VecT>
+        ROCWMMA_HOST_DEVICE constexpr decltype(auto) apply(F&& fn, VecT<DataT, VecSize> const& v)
         {
-            constexpr size_t size = VecTraits<decay_t<decltype(v)>>::size();
-            return detail::apply_impl(fn, v, detail::make_index_sequence<size>());
-        }
-
-        template <typename F, typename DataT, uint32_t Rank>
-        ROCWMMA_HOST_DEVICE constexpr decltype(auto) apply(F                                    fn,
-                                                           non_native_vector_base<DataT, Rank>& v)
-        {
-            constexpr size_t size = VecTraits<decay_t<decltype(v)>>::size();
-            return detail::apply_impl(fn, v, detail::make_index_sequence<size>());
-        }
-
-        template <typename F, typename DataT, uint32_t Rank>
-        ROCWMMA_HOST_DEVICE constexpr decltype(auto)
-            apply(F fn, non_native_vector_base<DataT, Rank> const& v)
-        {
-            constexpr size_t size = VecTraits<decay_t<decltype(v)>>::size();
-            return detail::apply_impl(fn, v, detail::make_index_sequence<size>());
-        }
-
-        template <typename F, typename DataT, uint32_t Rank>
-        ROCWMMA_HOST_DEVICE constexpr decltype(auto) apply(F                                     fn,
-                                                           non_native_vector_base<DataT, Rank>&& v)
-        {
-            constexpr size_t size = VecTraits<decay_t<decltype(v)>>::size();
-            return detail::apply_impl(fn, v, detail::make_index_sequence<size>());
+            constexpr size_t size = VecTraits<VecT<DataT, VecSize>>::size();
+            return detail::apply_impl(forward<F>(fn),
+                                      v,
+                                      detail::make_index_sequence<size>());
         }
 
     } // namespace detail


### PR DESCRIPTION
- Generalizes apply utility to any vector type with DataT, VecSize as params
- Factors out repetitive code for cumulative and iterative offsets to a static base class
- Fully generalize the OrthoImpl class
- Cleans up some unnecessary commented code