### PR TITLE
Implement static unrolling in WMMA and MFMA

### DIFF
--- a/library/include/rocwmma/internal/io_config.hpp
+++ b/library/include/rocwmma/internal/io_config.hpp
@@ -91,15 +91,6 @@ namespace rocwmma
         using PostLoadXForm = register_layout_transform<typename IOLayout::StorageLayout,
                                                         typename IOLayout::FragmentLayout>;
 
-        using PreMmaXForm = register_layout_transform<typename IOLayout::FragmentLayout,
-                                                      typename IOLayout::MmaLayout>;
-
-        // Currently, only makes sense to have a post-mma transform on acc layouts
-        using PostMmaXForm = conditional_t<is_same_v<MatrixT, accumulator>,
-                                        register_layout_transform<typename IOLayout::MmaLayout,
-                                                                  typename IOLayout::FragmentLayout>,
-                                        register_layout_transform_nop>;
-
         using PreStoreXForm = register_layout_transform<typename IOLayout::FragmentLayout,
                                                         typename IOLayout::StorageLayout>;
 

--- a/library/include/rocwmma/internal/io_layout.hpp
+++ b/library/include/rocwmma/internal/io_layout.hpp
@@ -151,6 +151,9 @@ namespace rocwmma
               uint32_t WaveCount>
     struct IOLayout<matrix_a, BlockDim, BlockK, DataT, DataLayoutT, WaveCount>
     {
+        // For non-interleaved layouts, MmaDim is given by BlockDim
+        constexpr static uint32_t MmaDim = BlockDim;
+
         // Vector size properties
         constexpr static uint32_t MaxVW = detail::
             MaxVWSelector<matrix_a, BlockDim, BlockK, DataT, DataLayoutT, WaveCount>::Result;
@@ -180,7 +183,7 @@ namespace rocwmma
 
         // Register layout required for mma. Expect non-interleaved SOA format.
         // Quirk: gfx11 requires input duplication.
-        using MmaLayout = RegisterLayout::MmaInput<BlockDim,
+        using MmaLayout = RegisterLayout::MmaInput<MmaDim,
                                                    DataT,
                                                    false,
                                                    (bool)ROCWMMA_ARCH_GFX11
@@ -197,6 +200,9 @@ namespace rocwmma
               uint32_t WaveCount>
     struct IOLayout<matrix_b, BlockDim, BlockK, DataT, DataLayoutT, WaveCount>
     {
+        // For non-interleaved layouts, MmaDim is given by BlockDim
+        constexpr static uint32_t MmaDim = BlockDim;
+
         // Vector size properties
         constexpr static uint32_t MaxVW = detail::
             MaxVWSelector<matrix_b, BlockDim, BlockK, DataT, DataLayoutT, WaveCount>::Result;
@@ -226,7 +232,7 @@ namespace rocwmma
 
         // Register layout required for mma. Expect non-interleaved SOA format.
         // Quirk: gfx11 requires input duplication.
-        using MmaLayout = RegisterLayout::MmaInput<BlockDim,
+        using MmaLayout = RegisterLayout::MmaInput<MmaDim,
                                                    DataT,
                                                    false,
                                                    (bool)ROCWMMA_ARCH_GFX11
@@ -244,6 +250,9 @@ namespace rocwmma
               uint32_t WaveCount>
     struct IOLayout<accumulator, BlockDim, BlockK, DataT, DataLayoutT, WaveCount>
     {
+        // For non-interleaved layouts, MmaDim is given by BlockDim
+        constexpr static uint32_t MmaDim = BlockDim;
+
         // Vector size properties
         constexpr static uint32_t MaxVW = detail::
             MaxVWSelector<accumulator, BlockDim, BlockK, DataT, DataLayoutT, WaveCount>::Result;
@@ -262,7 +271,7 @@ namespace rocwmma
 
         // Register layout required for mma. Expect non-interleaved SOA format.
         // Quirk: gfx11 requires padded acc.
-        using MmaLayout = RegisterLayout::MmaAcc<BlockDim,
+        using MmaLayout = RegisterLayout::MmaAcc<MmaDim,
                                                  DataT,
                                                  false,
                                                  (bool)ROCWMMA_ARCH_GFX11
@@ -276,12 +285,15 @@ namespace rocwmma
     template <uint32_t BlockDim, uint32_t BlockK, typename DataT, uint32_t WaveCount>
     struct IOLayout<accumulator, BlockDim, BlockK, DataT, void, WaveCount>
     {
+        // For non-interleaved layouts, MmaDim is given by BlockDim
+        constexpr static uint32_t MmaDim = BlockDim;
+
         // We don't know which storage is needed: no DataLayout
         using StorageLayout = void;
 
         // Register layout required for mma. Expect non-interleaved SOA format.
         // Quirk: gfx11 requires padded acc.
-        using MmaLayout = RegisterLayout::MmaAcc<BlockDim,
+        using MmaLayout = RegisterLayout::MmaAcc<MmaDim,
                                                  DataT,
                                                  false,
                                                  (bool)ROCWMMA_ARCH_GFX11
@@ -289,7 +301,7 @@ namespace rocwmma
                                                      : RegisterLayout::Format::SOA>;
 
         // Fragments will assume default mma register layout.
-        using FragmentLayout = RegisterLayout::MmaAcc<BlockDim,
+        using FragmentLayout = RegisterLayout::MmaAcc<MmaDim,
                                                  DataT,
                                                  false,
                                                  RegisterLayout::Format::SOA>;

--- a/library/include/rocwmma/internal/layout/matrix_layout_impl.hpp
+++ b/library/include/rocwmma/internal/layout/matrix_layout_impl.hpp
@@ -37,10 +37,6 @@ namespace rocwmma
     // Implementations for the MatrixLayout classes
     namespace MatrixLayout
     {
-        // Representing an embedded compile time value in argument passing
-        template<uint32_t Number>
-        using I = integral_constant<uint32_t, Number>;
-
         // All of the matrix layouts are required to provide interface functions to:
         // - strideCounts()
         // - strides()

--- a/library/include/rocwmma/internal/mma.hpp
+++ b/library/include/rocwmma/internal/mma.hpp
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef ROCWMMA_MMA_HPP
+#define ROCWMMA_MMA_HPP
+
+#include "config.hpp"
+#include "vector.hpp"
+
+namespace rocwmma
+{
+    template<typename MmaImpl>
+    struct MmaTraits;
+
+    enum struct MmaAccumPolicy : uint32_t
+    {
+        ROW_MAJOR = 0u,
+        COL_MAJOR = 1u,
+    };
+
+    template <uint32_t FragM,
+            uint32_t FragN,
+            uint32_t FragK,
+            class MmaImpl,
+            MmaAccumPolicy AccumPolicy = MmaAccumPolicy::ROW_MAJOR>
+    struct Mma
+    {
+        using BlockWiseMma = MmaImpl;
+        using BlockWiseMmaTraits = MmaTraits<BlockWiseMma>;
+
+        // Block dimensions
+        constexpr static uint32_t BlockM = BlockWiseMmaTraits::BlockM;
+        constexpr static uint32_t BlockN = BlockWiseMmaTraits::BlockN;
+        constexpr static uint32_t BlockK = BlockWiseMmaTraits::BlockK;
+
+        // Block vector dimensions (packed registers as input to impl)
+        constexpr static uint32_t BlockSizeA = BlockWiseMmaTraits::BlockSizeA;
+        constexpr static uint32_t BlockSizeB = BlockWiseMmaTraits::BlockSizeB;
+        constexpr static uint32_t BlockSizeC = BlockWiseMmaTraits::BlockSizeC;
+
+        // Block counts
+        constexpr static uint32_t BlocksM = FragM / BlockM;
+        constexpr static uint32_t BlocksN = FragN / BlockN;
+        constexpr static uint32_t BlocksK = FragK / BlockK;
+        constexpr static uint32_t BlocksC = BlocksM * BlocksN;
+
+        // Register grouping size for accum
+        constexpr static uint32_t AccumRowSize = BlocksN * BlockSizeC;
+        constexpr static uint32_t AccumColSize = BlocksM * BlockSizeC;
+
+        // Sanity checks
+        static_assert(FragM >= BlockM, "FragM must be larger than BlockM");
+        static_assert(FragN >= BlockN, "FragN must be larger than BlockN");
+        static_assert(FragK >= BlockK, "FragK must be larger than BlockK");
+        static_assert(FragM % BlockM == 0u, "FragM must be a multiple of BlockM");
+        static_assert(FragN % BlockN == 0u, "FragN must be a multiple of BlockN");
+        static_assert(FragK % BlockK == 0u, "FragK must be a multiple of BlockK");
+
+    private:
+
+        template <typename VecTA, typename VecTB, typename VecTC>
+        ROCWMMA_DEVICE static inline decltype(auto) exec_row_major(VecTA&& a, VecTB&& b, VecTC&& accum);
+
+        template <typename VecTA, typename VecTB, typename VecTC>
+        ROCWMMA_DEVICE static inline decltype(auto) exec_col_major(VecTA&& a, VecTB&& b, VecTC&& accum);
+
+    public:
+
+        template <typename VecTA, typename VecTB, typename VecTC>
+        ROCWMMA_DEVICE static inline decltype(auto) exec(VecTA&& a, VecTB&& b, VecTC& accum);
+    };
+
+} // namespace rocwmma
+
+#include "mma_impl.hpp"
+
+#endif // ROCWMMA_MMA_HPP

--- a/library/include/rocwmma/internal/mma_config.hpp
+++ b/library/include/rocwmma/internal/mma_config.hpp
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef ROCWMMA_MMA_CONFIG_HPP
+#define ROCWMMA_MMA_CONFIG_HPP
+
+#include "layout/register_layout_transforms.hpp"
+#include "io_config.hpp"
+#include "mfma.hpp"
+#include "pack_util.hpp"
+#include "types.hpp"
+#include "wmma.hpp"
+
+namespace rocwmma
+{
+    template <uint32_t FragM,
+              uint32_t FragN,
+              uint32_t FragK,
+              typename InputTA,
+              typename InputTB,
+              typename ComputeT,
+              typename DataLayoutA,
+              typename DataLayoutB,
+              typename DataLayoutC,
+              typename DataLayoutD>
+    struct MmaConfig
+    {
+        using IOConfigA = IOConfig<matrix_a, FragM, FragN, FragK, InputTA, DataLayoutA>;
+        using IOConfigB = IOConfig<matrix_b, FragM, FragN, FragK, InputTB, DataLayoutB>;
+        using IOConfigC = IOConfig<accumulator, FragM, FragN, FragK, ComputeT, DataLayoutC>;
+        using IOConfigD = IOConfig<accumulator, FragM, FragN, FragK, ComputeT, DataLayoutD>;
+
+        using IOLayoutA = typename IOConfigA::IOLayout;
+        using IOLayoutB = typename IOConfigB::IOLayout;
+        using IOLayoutC = typename IOConfigC::IOLayout;
+        using IOLayoutD = typename IOConfigD::IOLayout;
+
+        constexpr static uint32_t MmaDimM = IOLayoutA::MmaDim;
+        constexpr static uint32_t MmaDimN = IOLayoutB::MmaDim;
+
+        // Sanity checks:
+        // - For now, MmaDimM/N/Acc must match
+        // - MmaLayout for input A/B must match
+        // - MmaLayout for accumulators must match
+        static_assert(MmaDimM == MmaDimN, "MmaDims must match");
+        static_assert((MmaDimN == IOLayoutC::MmaDim) && (MmaDimN == IOLayoutD::MmaDim), "Mismatched accumulator MmaDim");
+        static_assert(is_layout_same_v<typename IOLayoutA::MmaLayout, typename IOLayoutB::MmaLayout>, "Input fragment register layouts do not match");
+        static_assert(is_layout_same_v<typename IOLayoutC::MmaLayout, typename IOLayoutD::MmaLayout>, "Accumulator fragment register layouts do not match");
+
+        // Check valid mma layouts
+        static_assert(layout_traits<typename IOLayoutA::MmaLayout>::is_valid, "Invalid MmaLayout for matrix_a");
+        static_assert(layout_traits<typename IOLayoutB::MmaLayout>::is_valid, "Invalid MmaLayout for matrix_b");
+        static_assert(layout_traits<typename IOLayoutC::MmaLayout>::is_valid, "Invalid MmaLayout for accumulator C");
+        static_assert(layout_traits<typename IOLayoutD::MmaLayout>::is_valid, "Invalid MmaLayout for accumulator D");
+
+        // Input transforms
+        using PreMmaXFormA = register_layout_transform<typename IOLayoutA::FragmentLayout,
+                                                       typename IOLayoutA::MmaLayout>;
+
+        using PreMmaXFormB = register_layout_transform<typename IOLayoutB::FragmentLayout,
+                                                       typename IOLayoutB::MmaLayout>;
+
+        using PreMmaXFormC = register_layout_transform<typename IOLayoutC::FragmentLayout,
+                                                         typename IOLayoutC::MmaLayout>;
+
+        // Output accum transform
+        using PostMmaXFormD = register_layout_transform<typename IOLayoutD::MmaLayout,
+                                                          typename IOLayoutD::FragmentLayout>;
+
+        // Pack util
+        using PackB = typename IOConfigB::PackUtil;
+        using PackA = typename IOConfigA::PackUtil;
+        using PackC = typename IOConfigC::PackUtil;
+        using PackD = typename IOConfigD::PackUtil;
+
+        // Gfx9 uses MFMA, gfx11/12 uses WMMA
+        using Mma = conditional_t<(bool)ROCWMMA_ARCH_GFX9,
+                                  Mfma<FragM, FragN, FragK, InputTA, InputTB, ComputeT, MmaDimM, MmaDimN>,
+                                  Wmma<FragM, FragN, FragK, InputTA, InputTB, ComputeT, MmaDimM, MmaDimN>>;
+    };
+
+} // namespace rocwmma
+
+#endif // ROCWMMA_MMA_CONFIG_HPP

--- a/library/include/rocwmma/internal/mma_config.hpp
+++ b/library/include/rocwmma/internal/mma_config.hpp
@@ -70,10 +70,11 @@ namespace rocwmma
         static_assert(is_layout_same_v<typename IOLayoutC::MmaLayout, typename IOLayoutD::MmaLayout>, "Accumulator fragment register layouts do not match");
 
         // Check valid mma layouts
-        static_assert(layout_traits<typename IOLayoutA::MmaLayout>::is_valid, "Invalid MmaLayout for matrix_a");
-        static_assert(layout_traits<typename IOLayoutB::MmaLayout>::is_valid, "Invalid MmaLayout for matrix_b");
-        static_assert(layout_traits<typename IOLayoutC::MmaLayout>::is_valid, "Invalid MmaLayout for accumulator C");
-        static_assert(layout_traits<typename IOLayoutD::MmaLayout>::is_valid, "Invalid MmaLayout for accumulator D");
+        // TODO: eventually should enforce
+        // static_assert(layout_traits<typename IOLayoutA::MmaLayout>::is_valid, "Invalid MmaLayout for matrix_a");
+        // static_assert(layout_traits<typename IOLayoutB::MmaLayout>::is_valid, "Invalid MmaLayout for matrix_b");
+        // static_assert(layout_traits<typename IOLayoutC::MmaLayout>::is_valid, "Invalid MmaLayout for accumulator C");
+        // static_assert(layout_traits<typename IOLayoutD::MmaLayout>::is_valid, "Invalid MmaLayout for accumulator D");
 
         // Input transforms
         using PreMmaXFormA = register_layout_transform<typename IOLayoutA::FragmentLayout,

--- a/library/include/rocwmma/internal/mma_impl.hpp
+++ b/library/include/rocwmma/internal/mma_impl.hpp
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef ROCWMMA_MMA_IMPL_HPP
+#define ROCWMMA_MMA_IMPL_HPP
+
+#include "utility/vector.hpp"
+
+namespace rocwmma
+{
+
+#define MMA_TPARAMS_DECL \
+template <uint32_t FragM, \
+        uint32_t FragN, \
+        uint32_t FragK, \
+        class MmaImpl, \
+        MmaAccumPolicy AccumPolicy>
+
+#define MMA_TPARAMS FragM, FragN, FragK, MmaImpl, AccumPolicy
+
+    MMA_TPARAMS_DECL
+    template <typename VecTA, typename VecTB, typename VecTC>
+    ROCWMMA_DEVICE inline decltype(auto) Mma<MMA_TPARAMS>::exec_row_major(VecTA&& a, VecTB&& b, VecTC&& accum)
+    {
+        // Iterate through accum blocks in row_major order.
+        // FOR each row of C:
+        return vector_for_each<AccumRowSize>(
+            forward<VecTC>(accum),
+            [](auto&& row_c, auto&& row_idx, auto&& input_a, auto&& input_b)
+            {
+                // A input is constant per row, for which we can cache
+                constexpr auto rowId = decay_t<decltype(row_idx)>::value;
+                auto itA = makeVectorIterator<BlockSizeA * BlocksK>(forward<VecTA>(input_a)).it(rowId);
+
+                // FOR each block of C:
+                return vector_for_each<BlockSizeC>(row_c,
+                    [](auto&& block_c, auto&& col_idx, auto&& block_a, auto&& input_b)
+                    {
+                        // B input is constant per col
+                        constexpr auto colId = decay_t<decltype(col_idx)>::value;
+                        auto itB = makeVectorIterator<BlockSizeB * BlocksK>(forward<VecTB>(input_b)).it(colId);
+
+                        // FOR each K-iteration: invoke Mma
+                        return vector_reduce2<BlockSizeA, BlockSizeB>(
+                            block_a,
+                            *itB,
+                            block_c,
+                            [](auto&& a, auto&& b, auto&& accum, auto&& idx)
+                            {
+                                return BlockWiseMma::exec(a, b, accum);
+                            });
+                    },
+                    *itA,
+                    forward<VecTB>(input_b));
+            },
+            forward<VecTA>(a),
+            forward<VecTB>(b));
+    }
+
+    MMA_TPARAMS_DECL
+    template <typename VecTA, typename VecTB, typename VecTC>
+    ROCWMMA_DEVICE inline decltype(auto) Mma<MMA_TPARAMS>::exec_col_major(VecTA&& a, VecTB&& b, VecTC&& accum)
+    {
+        // Iterate through accum blocks in col_major order.
+        // FOR each col of C:
+        return vector_for_each<AccumColSize>(
+            forward<VecTC>(accum),
+            [](auto&& col_c, auto&& col_idx, auto&& input_a, auto&& input_b)
+            {
+                // B input is constant per col, for which we can cache
+                constexpr auto colId = decay_t<decltype(col_idx)>::value;
+                auto itB = makeVectorIterator<BlockSizeB * BlocksK>(forward<VecTB>(input_b)).it(colId);
+
+                // FOR each block of C:
+                return vector_for_each<BlockSizeC>(col_c,
+                    [](auto&& block_c, auto&& row_idx, auto&& input_a, auto&& block_b)
+                    {
+                        // A input is constant per row
+                        constexpr auto rowId = decay_t<decltype(row_idx)>::value;
+                        auto itA = makeVectorIterator<BlockSizeA * BlocksK>(forward<VecTA>(input_a)).it(rowId);
+
+                        // FOR each K-iteration: invoke Mma
+                        return vector_reduce2<BlockSizeA, BlockSizeB>(
+                            *itA,
+                            block_b,
+                            block_c,
+                            [](auto&& a, auto&& b, auto&& accum, auto&& idx)
+                            {
+                                return BlockWiseMma::exec(a, b, accum);
+                            });
+                    },
+                    forward<VecTA>(input_a),
+                    *itB);
+            },
+            forward<VecTA>(a),
+            forward<VecTB>(b));
+    }
+
+    MMA_TPARAMS_DECL
+    template <typename VecTA, typename VecTB, typename VecTC>
+    ROCWMMA_DEVICE inline decltype(auto) Mma<MMA_TPARAMS>::exec(VecTA&& a, VecTB&& b, VecTC& accum)
+    {
+        if constexpr (AccumPolicy == MmaAccumPolicy::ROW_MAJOR)
+        {
+            return exec_row_major(forward<VecTA>(a), forward<VecTB>(b), forward<VecTC>(accum));
+        }
+        else
+        {
+            return exec_col_major(forward<VecTA>(a), forward<VecTB>(b), forward<VecTC>(accum));
+        }
+    }
+
+#undef MMA_TPARAMS_DECL
+#undef MMA_TPARAMS
+
+} // namespace rocwmma
+
+#endif // ROCWMMA_MMA_IMPL_HPP

--- a/library/include/rocwmma/internal/tuple.hpp
+++ b/library/include/rocwmma/internal/tuple.hpp
@@ -238,7 +238,7 @@ namespace rocwmma
             return make_vector(inflate(forward<Coord1d>(flatCoord),
                                        get<Indices>(forward<VecT>(dims)),
                                        forward<decltype(div)&>(div),
-                                       Number<Indices == sizeof...(Indices) - 1>{})...);
+                                       I<Indices == sizeof...(Indices) - 1>{})...);
         }
     }
 
@@ -278,7 +278,7 @@ namespace rocwmma
                 inflate(forward<Coord1d>(flatCoord),
                         get<VecTraits<decay_t<VecT>>::size() - 1 - Indices>(forward<VecT>(dims)),
                         forward<decltype(div)&>(div),
-                        Number<Indices == sizeof...(Indices) - 1>{})...));
+                        I<Indices == sizeof...(Indices) - 1>{})...));
         }
     }
 

--- a/library/include/rocwmma/internal/utility/algorithm_impl.hpp
+++ b/library/include/rocwmma/internal/utility/algorithm_impl.hpp
@@ -33,13 +33,13 @@ namespace rocwmma
     {
 
         template <typename T>
-        ROCWMMA_HOST_DEVICE constexpr decltype(auto) max(T&& a, T&& b)
+        ROCWMMA_HOST_DEVICE constexpr T const& max(T const& a, T const& b)
         {
             return (a < b) ? b : a;
         }
 
         template <typename T>
-        ROCWMMA_HOST_DEVICE constexpr decltype(auto) min(T&& a, T&& b)
+        ROCWMMA_HOST_DEVICE constexpr T const& min(T const& a, T const& b)
         {
             return (a < b) ? a : b;
         }

--- a/library/include/rocwmma/internal/utility/functional_impl.hpp
+++ b/library/include/rocwmma/internal/utility/functional_impl.hpp
@@ -33,68 +33,7 @@ namespace rocwmma
 {
     namespace detail
     {
-        // Logical ops
-        template <typename... Bs>
-        struct logical_or;
 
-        template <>
-        struct logical_or<> : public false_type
-        {
-        };
-
-        template <typename T>
-        struct logical_or<T> : public T
-        {
-        };
-
-        template <typename B1, typename B2>
-        struct logical_or<B1, B2> : public conditional_t<B1::value, B1, B2>
-        {
-        };
-
-        template <typename B1, typename B2, typename B3, typename... Bs>
-        struct logical_or<B1, B2, B3, Bs...>
-            : public conditional_t<B1::value, B1, logical_or<B2, B3, Bs...>>
-        {
-        };
-
-        template <typename... Bs>
-        using logical_or_t = typename logical_or<Bs...>::type;
-
-        template <typename...>
-        struct logical_and;
-
-        template <>
-        struct logical_and<> : public true_type
-        {
-        };
-
-        template <typename B1>
-        struct logical_and<B1> : public B1
-        {
-        };
-
-        template <typename B1, typename B2>
-        struct logical_and<B1, B2> : public conditional_t<B1::value, B2, B1>
-        {
-        };
-
-        template <typename B1, typename B2, typename B3, typename... Bs>
-        struct logical_and<B1, B2, B3, Bs...>
-            : public conditional_t<B1::value, logical_and<B2, B3, Bs...>, B1>
-        {
-        };
-
-        template <typename... Bs>
-        using logical_and_t = typename logical_and<Bs...>::type;
-
-        template <typename B>
-        struct logical_not : public bool_constant<!bool(B::value)>
-        {
-        };
-
-        template <typename B>
-        using logical_not_t = typename logical_not<B>::type;
 
     } // namespace detail
 

--- a/library/include/rocwmma/internal/utility/move.hpp
+++ b/library/include/rocwmma/internal/utility/move.hpp
@@ -24,36 +24,29 @@
  *
  *******************************************************************************/
 
-#ifndef ROCWMMA_UTILITY_FUNCTIONAL_HPP
-#define ROCWMMA_UTILITY_FUNCTIONAL_HPP
+#ifndef ROCWMMA_UTILITY_MOVE_HPP
+#define ROCWMMA_UTILITY_MOVE_HPP
 
-#if defined(__HIPCC_RTC__)
+#if defined(__HIPCC_RTC__) || defined(__clang__)
 
-#include "type_traits.hpp"
-
+#include "forward_impl.hpp"
 namespace rocwmma
 {
-    using detail::logical_or;
-    using detail::logical_and;
-    using detail::logical_not;
+    // Use drop-in replacement
+    using detail::move;
 
 } // namespace rocwmma
-
-#define ROCWMMA_FUNCTIONAL_IMPL_NAMESPACE rocwmma::detail
 
 #else
 
-#include <functional>
+#include <utility>
 namespace rocwmma
 {
-    using std::logical_or;
-    using std::logical_and;
-    using std::logical_not;
+    // Use STL
+    using std::move;
 
 } // namespace rocwmma
 
-#define ROCWMMA_FUNCTIONAL_IMPL_NAMESPACE std
+#endif // defined(__HIPCC_RTC__) || defined(__clang__)
 
-#endif // defined(__HIPCC_RTC__)
-
-#endif // ROCWMMA_UTILITY_FUNCTIONAL_HPP
+#endif // ROCWMMA_UTILITY_MOVE_HPP

--- a/library/include/rocwmma/internal/utility/move_impl.hpp
+++ b/library/include/rocwmma/internal/utility/move_impl.hpp
@@ -24,36 +24,25 @@
  *
  *******************************************************************************/
 
-#ifndef ROCWMMA_UTILITY_FUNCTIONAL_HPP
-#define ROCWMMA_UTILITY_FUNCTIONAL_HPP
+#ifndef ROCWMMA_UTILITY_MOVE_IMPL_HPP
+#define ROCWMMA_UTILITY_MOVE_IMPL_HPP
 
-#if defined(__HIPCC_RTC__)
-
-#include "type_traits.hpp"
+#include <rocwmma/internal/config.hpp>
+#include <rocwmma/internal/type_traits.hpp>
 
 namespace rocwmma
 {
-    using detail::logical_or;
-    using detail::logical_and;
-    using detail::logical_not;
+    namespace detail
+    {
+
+        template <typename T>
+        ROCWMMA_HOST_DEVICE constexpr remove_reference_t<T>&& move(T&& t) noexcept
+        {
+            return static_cast<remove_reference_t<T>&&>(t);
+        }
+
+    } // namespace detail
 
 } // namespace rocwmma
 
-#define ROCWMMA_FUNCTIONAL_IMPL_NAMESPACE rocwmma::detail
-
-#else
-
-#include <functional>
-namespace rocwmma
-{
-    using std::logical_or;
-    using std::logical_and;
-    using std::logical_not;
-
-} // namespace rocwmma
-
-#define ROCWMMA_FUNCTIONAL_IMPL_NAMESPACE std
-
-#endif // defined(__HIPCC_RTC__)
-
-#endif // ROCWMMA_UTILITY_FUNCTIONAL_HPP
+#endif // ROCWMMA_UTILITY_MOVE_IMPL_HPP

--- a/library/include/rocwmma/internal/utility/sequence_impl.hpp
+++ b/library/include/rocwmma/internal/utility/sequence_impl.hpp
@@ -92,7 +92,9 @@ namespace rocwmma
 
         template <size_t N>
         using make_index_sequence = make_integer_sequence<size_t, N>;
+
     } // namespace detail
+
 } // namespace rocwmma
 
 #endif // ROCWMMA_UTILITY_SEQUENCE_IMPL_HPP

--- a/library/include/rocwmma/internal/utility/type_traits.hpp
+++ b/library/include/rocwmma/internal/utility/type_traits.hpp
@@ -53,6 +53,8 @@ namespace rocwmma
     using detail::is_arithmetic_v;
     using detail::is_array;
     using detail::is_array_v;
+    using detail::is_const;
+    using detail::is_const_v;
     using detail::is_convertible;
     using detail::is_convertible_v;
     using detail::is_floating_point;
@@ -116,6 +118,8 @@ namespace rocwmma
     using std::is_arithmetic_v;
     using std::is_array;
     using std::is_array_v;
+    using std::is_const;
+    using std::is_const_v;
     using std::is_convertible;
     using std::is_convertible_v;
     using std::is_floating_point;

--- a/library/include/rocwmma/internal/utility/type_traits.hpp
+++ b/library/include/rocwmma/internal/utility/type_traits.hpp
@@ -174,7 +174,7 @@ namespace rocwmma
 
     // Short-form integral constant
     template <uint32_t N>
-    using I = integral_constant<int32_t, N>;
+    using I = integral_constant<uint32_t, N>;
 
 } // namespace rocwmma
 

--- a/library/include/rocwmma/internal/utility/type_traits.hpp
+++ b/library/include/rocwmma/internal/utility/type_traits.hpp
@@ -34,8 +34,12 @@
 namespace rocwmma
 {
     // Use drop-in replacement
+    using detail::add_lvalue_reference;
+    using detail::add_lvalue_reference_t;
     using detail::add_pointer;
     using detail::add_pointer_t;
+    using detail::add_rvalue_reference;
+    using detail::add_rvalue_reference_t;
     using detail::bool_constant;
     using detail::conditional;
     using detail::conditional_t;
@@ -93,8 +97,12 @@ namespace rocwmma
 namespace rocwmma
 {
     // std implementations
+    using std::add_lvalue_reference;
+    using std::add_lvalue_reference_t;
     using std::add_pointer;
     using std::add_pointer_t;
+    using std::add_rvalue_reference;
+    using std::add_rvalue_reference_t;
     using std::bool_constant;
     using std::conditional;
     using std::conditional_t;

--- a/library/include/rocwmma/internal/utility/type_traits_impl.hpp
+++ b/library/include/rocwmma/internal/utility/type_traits_impl.hpp
@@ -106,25 +106,9 @@ namespace rocwmma
         {
         };
 
-        // Comply with std interface
         template <typename B1>
         struct logical_or<B1> : public B1
         {
-            constexpr bool operator()(B1 const& lhs, B1 const& rhs) const
-            {
-                return lhs || rhs;
-            }
-        };
-
-        // Comply with std interface
-        template <>
-        struct logical_or<void>
-        {
-            template<typename T>
-            constexpr bool operator()(T const& lhs, T const& rhs) const
-            {
-                return lhs || rhs;
-            }
         };
 
         template <typename B1, typename B2>

--- a/library/include/rocwmma/internal/utility/type_traits_impl.hpp
+++ b/library/include/rocwmma/internal/utility/type_traits_impl.hpp
@@ -360,6 +360,18 @@ namespace rocwmma
         template <typename T>
         inline constexpr bool is_void_v = is_void<T>::value;
 
+        // is_const
+        template<typename T>
+        struct is_const : public false_type
+        {};
+
+        template<typename T> struct
+        is_const<const T> : public true_type
+        {};
+
+        template<typename T>
+        inline constexpr bool is_const_v = is_const<T>::value;
+
         // is_reference
         template <typename T>
         struct is_reference : public logical_or_t<is_lvalue_reference<T>, is_rvalue_reference<T>>
@@ -371,7 +383,7 @@ namespace rocwmma
 
         // is_function
         template <typename T>
-        struct is_function : public true_or_false_type<!std::is_const<const T>::value && !std::is_reference<T>::value>
+        struct is_function : public true_or_false_type<!is_const_v<const T> && !is_reference_v<T>>
         {
         };
 

--- a/library/include/rocwmma/internal/utility/vector.hpp
+++ b/library/include/rocwmma/internal/utility/vector.hpp
@@ -32,15 +32,17 @@
 
 namespace rocwmma
 {
-    //! Returns the element count, or size of the input vector
-    //! @param v Input vector
-    //! @tparam Input vector type
+    /*! \brief Returns the element count, or size of the input vector
+    * @param v Input vector
+    * @tparam VecT Input vector type
+    */
     template <typename VecT>
     ROCWMMA_HOST_DEVICE constexpr static inline auto vector_size(VecT&& v);
 
-    //! Creates a vector with the given input values
-    //! @param ts Variadic list of inputs values
-    //! @tparam Types of incoming input values
+    /*! \brief Creates a vector with the given input values
+    * @param ts Variadic list of inputs values
+    * @tparam Ts Types of incoming input values
+    */
     template <typename... Ts>
     ROCWMMA_HOST_DEVICE constexpr static inline auto make_vector(Ts&&... ts);
 
@@ -50,59 +52,128 @@ namespace rocwmma
     * may accept any number of arguments and generates a single value to be used as element Idx in the
     * result.
     *
-    * @tparam Data type of the vector
-    * @tparam The number of vector elements
-    * @tparam BoundCtrl - OOB thread indices write 0 to output element
+    * @tparam DataT Data type of the vector
+    * @tparam VecSize The number of vector elements
     */
     template <typename DataT, uint32_t VecSize>
     struct vector_generator : public detail::vector_generator<VecT, DataT, VecSize>
     {
     };
 
-    //! Returns a concatenated vector of (lhs, rhs)
-    //! @param lhs Input vector, lower elements
-    //! @param rhs Input vector, upper elements
-    //! @tparam Input vector type of lhs
-    //! @tparam Input vector type of rhs
+    /*! \brief Returns a concatenated vector of (lhs, rhs)
+    * @param lhs Input vector, lower elements
+    * @param rhs Input vector, upper elements
+    * @tparam Lhs Input vector type of lhs
+    * @tparam Rhs Input vector type of rhs
+    */
     template <typename Lhs, typename Rhs>
     ROCWMMA_HOST_DEVICE constexpr static inline auto vector_cat(Lhs&& lhs, Rhs&& rhs);
 
-    //! Returns the reduction result of bit-wise and between all elements in the input vector
-    //! @param v Input vector
-    //! @tparam Input vector type
+    /*! \brief Returns the reduction result of bit-wise and between all elements in the input vector
+    * @param v Input vector
+    * @tparam VecT Input vector type
+    */
     template <typename VecT>
     ROCWMMA_HOST_DEVICE constexpr static inline auto vector_reduce_and(VecT&& v) noexcept;
 
-    //! Swaps elements in vector size of 2
-    //! @param v Input vector
-    //! @tparam Input vector type
+    /*! \brief Swaps elements in vector size of 2
+    * @param v Input vector
+    * @tparam VecT Templated input vector class
+    */
     template <template<typename, uint32_t> class VecT,
     typename DataT>
     ROCWMMA_HOST_DEVICE constexpr static inline auto swap(VecT<DataT, 2> const& v);
 
-    //! Splits input vector into sub-vectors. Func is applied to each sub-vector, which are then
-    //! concatenated and returned as a result. Does not change input vector v.
-    //! @param v Input vector
-    //! @param func Functor with signature Func(VecT<DataT, SubVecSize>, Number<I> idx, args...)
-    //! @param args Arguments that are forwarded to the functor
-    //! @tparam Sub-vector size (defaults to 1)
-    //! @tparam Type of input vector
-    //! @tparam Type of functor
-    //! @tparam Type of forwarded arguments to functor
+    /*! \brief Splits input vector into sub-vectors. Func is applied to each sub-vector, which are then
+    * concatenated and returned as a result. Does not change input vector v.
+    * @param v Input vector
+    * @param func Functor with signature Func(VecT<DataT, SubVecSize>, Number<I> idx, args...)
+    * @param args Arguments that are forwarded to the functor
+    * @tparam SubVecSize Sub-vector size (default 1)
+    * @tparam VecT Type of input vector
+    * @tparam Func Type of functor
+    * @tparam ArgsT Type of forwarded arguments to functor
+    */
     template<uint32_t SubVecSize = 1u, typename VecT, class Func, typename... ArgsT>
     ROCWMMA_HOST_DEVICE constexpr static inline auto vector_for_each(VecT&& v, Func&& func, ArgsT&&... args);
 
-    //! Splits input vector into sub-vectors. Func is applied to each sub-vector in-place. Returns
-    //! a reference to modified input vector.
-    //! @param v Input vector
-    //! @param func Functor with signature Func(VecT<DataT, SubVecSize>, Number<I> idx, args...)
-    //! @param args Arguments that are forwarded to the functor
-    //! @tparam Sub-vector size (defaults to 1)
-    //! @tparam Type of input vector
-    //! @tparam Type of functor
-    //! @tparam Type of forwarded arguments to functor
+    /*! \brief Splits input vector into sub-vectors. Func is applied to each sub-vector in-place. Returns
+    * a reference to modified input vector.
+    * @param v Input vector
+    * @param func Functor with signature Func(VecT<DataT, SubVecSize>, Number<I> idx, args...)
+    * @param args Arguments that are forwarded to the functor
+    * @tparam SubVecSize Sub-vector size (default 1)
+    * @tparam VecT Type of input vector
+    * @tparam Func Type of functor
+    * @tparam ArgsT Type of forwarded arguments to functor
+    */
     template<uint32_t SubVecSize = 1u, typename VecT, class Func, typename... ArgsT>
     ROCWMMA_HOST_DEVICE constexpr static inline decltype(auto) vector_mutate_for_each(VecT&& v, Func&& func,  ArgsT&&... args);
+
+    /*! \brief Splits input vector into sub-vectors. Func is applied to each sub-vector and updates the accumulator.
+    * Returns the final accumulator result.
+    * @param v Input vector
+    * @param init The initial accumulation value
+    * @param func Functor with signature Func(VecT<DataT, SubVecSize>, AccumT, Number<I> idx, args...)
+    * @param args Arguments that are forwarded to the functor
+    * @tparam SubVecSize Sub-vector size (default 1)
+    * @tparam VecT Type of input vector
+    * @tparam AccumT Type of accumulator
+    * @tparam Func Type of functor
+    * @tparam ArgsT Type of forwarded arguments to functor
+    */
+    template<uint32_t SubVecSize = 1u, typename VecT, typename AccumT, class Func, typename... ArgsT>
+    ROCWMMA_HOST_DEVICE constexpr static inline auto vector_reduce(VecT&& v, AccumT&& init, Func&& func, ArgsT&&... args);
+
+    /*! \brief Splits input vector into sub-vectors. Func is applied to each sub-vector and updates the accumulator.
+    * Returns the final accumulator result. Initial accumulator of VecT<DataT, SubVecSize>{0} is assumed.
+    * @param v Input vector
+    * @param func Functor with signature Func(VecT<DataT, SubVecSize>, AccumT, Number<I> idx, args...)
+    * @param args Arguments that are forwarded to the functor
+    * @tparam SubVecSize Sub-vector size (default 1)
+    * @tparam VecT Type of input vector
+    * @tparam Func Type of functor
+    * @tparam ArgsT Type of forwarded arguments to functor
+    */
+    template<uint32_t SubVecSize = 1u, typename VecT, class Func, typename... ArgsT>
+    ROCWMMA_HOST_DEVICE constexpr static inline auto vector_reduce(VecT&& v, Func&& func, ArgsT&&... args);
+
+    /*! \brief Splits two input vector into sub-vectors. Func is applied to each sub-vector and updates the accumulator.
+    * Input vectors may be different lengths, provided their size / subvecsize is the same.
+    * Returns the final accumulator result.
+    * @param v0 Input vector 0
+    * @param v1 Input vector 1
+    * @param init The initial accumulation value
+    * @param func Functor with signature Func(VecT<DataT0, SubVecSize0>, VecT<DataT1, SubVecSize1>, AccumT, Number<I> idx, args...)
+    * @param args Arguments that are forwarded to the functor
+    * @tparam SubVecSize0 Sub-vector0 size (default 1)
+    * @tparam SubVecSize1 Sub-vector1 size (default SubVecSize0)
+    * @tparam VecT0 Type of input vector 0
+    * @tparam VecT1 Type of input vector 1
+    * @tparam AccumT Type of accumulator
+    * @tparam Func Type of functor
+    * @tparam ArgsT Type of forwarded arguments to functor
+    */
+    template<uint32_t SubVecSize0 = 1u, uint32_t SubVecSize1 = SubVecSize0, typename VecT0, typename VecT1, typename AccumT, class Func, typename... ArgsT>
+    ROCWMMA_HOST_DEVICE constexpr static inline auto vector_reduce2(VecT0&& v0, VecT1&& v1, AccumT&& init, Func&& func, ArgsT&&... args);
+
+    /*! \brief Splits two input vector into sub-vectors. Func is applied to each sub-vector and updates the accumulator.
+    * Input vectors may be different lengths, provided their size / subvecsize is the same.
+    * Initial accumulator of VecT<DataT, SubVecSize0>{0} is assumed.
+    * Returns the final accumulator result.
+    * @param v0 Input vector 0
+    * @param v1 Input vector 1
+    * @param func Functor with signature Func(VecT<DataT0, SubVecSize0>, VecT<DataT1, SubVecSize1>, AccumT, Number<I> idx, args...)
+    * @param args Arguments that are forwarded to the functor
+    * @tparam SubVecSize0 Sub-vector0 size (default 1)
+    * @tparam SubVecSize1 Sub-vector1 size (default SubVecSize0)
+    * @tparam VecT0 Type of input vector 0
+    * @tparam VecT1 Type of input vector 1
+    * @tparam Func Type of functor
+    * @tparam ArgsT Type of forwarded arguments to functor
+    */
+    template<uint32_t SubVecSize0 = 1u, uint32_t SubVecSize1 = SubVecSize0, typename VecT0, typename VecT1, class Func, typename... ArgsT>
+    ROCWMMA_HOST_DEVICE constexpr static inline auto vector_reduce2(VecT0&& v0, VecT1&& v1, Func&& func, ArgsT&&... args);
 
 } // namespace rocwmma
 

--- a/library/include/rocwmma/internal/vector.hpp
+++ b/library/include/rocwmma/internal/vector.hpp
@@ -413,7 +413,7 @@ namespace rocwmma
         using VecT = HIP_vector_type<T, size>;
 
         // Current data type
-        using DataT = typename VecT<>::value_type;
+        using DataT = T;
 
         // Current vector size
         constexpr static inline uint32_t size()

--- a/library/include/rocwmma/internal/vector_util_impl.hpp
+++ b/library/include/rocwmma/internal/vector_util_impl.hpp
@@ -434,11 +434,11 @@ namespace rocwmma
             // Idx1 = 2  Idx5 = 6  Offset = 2
             // Idx2 = 1  Idx6 = 5  Offset = 1
             // Idx3 = 3  Idx7 = 7  Offset = 3
-            constexpr auto Index   = std::decay_t<decltype(Idx)>::value % ElementCount;
+            constexpr auto Index   = decay_t<decltype(Idx)>::value % ElementCount;
             constexpr auto Offset0 = (Index / GatherSize) * ElementStride % ElementCount;
             constexpr auto Offset1 = Index % GatherSize;
             constexpr auto Offset2 = (Index * ElementStride) / (ElementCount * GatherSize) * GatherSize;
-            constexpr auto Offset3 = std::decay_t<decltype(Idx)>::value / ElementCount * ElementCount;
+            constexpr auto Offset3 = decay_t<decltype(Idx)>::value / ElementCount * ElementCount;
             return I<Offset0 + Offset1 + Offset2 + Offset3>{};
         }
     };

--- a/library/include/rocwmma/internal/wmma_impl.hpp
+++ b/library/include/rocwmma/internal/wmma_impl.hpp
@@ -42,11 +42,24 @@ namespace rocwmma
                  typename Enabler = void>
         struct amdgcn_wmma
         {
+            // Choose reasonable minimal default params to satisfy static checks
             constexpr static uint32_t KPerMma = 16u;
-            using ARegsT = VRegF32x2;
-            using BRegsT = VRegF32x2;
-            using CRegsT = AccRegF32x4;
-            using DRegsT = AccRegF32x4;
+
+        private:
+            using PackTraitsA = PackTraits<InputTA>;
+            using PackTraitsB = PackTraits<InputTB>;
+            using PackTraitsAcc = PackTraits<ComputeT>;
+
+            constexpr static uint32_t InputASize = BlockM * KPerMma / (Constants::AMDGCN_WAVE_SIZE * PackTraitsA::PackRatio);
+            constexpr static uint32_t InputBSize = BlockN * KPerMma / (Constants::AMDGCN_WAVE_SIZE * PackTraitsB::PackRatio);
+            constexpr static uint32_t AccumSize = BlockM * BlockM / (Constants::AMDGCN_WAVE_SIZE * PackTraitsAcc::PackRatio);
+
+        public:
+
+            using ARegsT = VecT<typename PackTraitsA::PackedT, InputASize>;
+            using BRegsT = VecT<typename PackTraitsB::PackedT, InputBSize>;
+            using CRegsT = VecT<typename PackTraitsAcc::PackedT, AccumSize>;
+            using DRegsT = VecT<typename PackTraitsAcc::PackedT, AccumSize>;
 
             template <typename RegsA, typename RegsB, typename RegsC>
             ROCWMMA_DEVICE static inline decltype(auto) exec(RegsA&& regsA, RegsB&& regsB, RegsC&& regsC)

--- a/library/include/rocwmma/internal/wmma_impl.hpp
+++ b/library/include/rocwmma/internal/wmma_impl.hpp
@@ -26,441 +26,303 @@
 #ifndef ROCWMMA_WMMA_IMPL_HPP
 #define ROCWMMA_WMMA_IMPL_HPP
 
-#include "permute.hpp"
+#include "types.hpp"
+#include "utility/type_traits.hpp"
 
 namespace rocwmma
 {
-
     namespace detail
     {
-        template <typename InputT, typename ComputeT, uint32_t BlockM, uint32_t BlockN>
+        template <typename InputTA,
+                 typename InputTB,
+                 typename ComputeT,
+                 uint32_t BlockM,
+                 uint32_t BlockN,
+                 typename Dummy = true_type,
+                 typename Enabler = void>
         struct amdgcn_wmma
         {
+            constexpr static uint32_t KPerMma = 16u;
+            using ARegsT = VRegF32x2;
+            using BRegsT = VRegF32x2;
+            using CRegsT = AccRegF32x4;
+            using DRegsT = AccRegF32x4;
+
             template <typename RegsA, typename RegsB, typename RegsC>
-            ROCWMMA_DEVICE static inline auto exec(RegsA&& regsA, RegsB&& regsB, RegsC& regsC)
+            ROCWMMA_DEVICE static inline decltype(auto) exec(RegsA&& regsA, RegsB&& regsB, RegsC&& regsC)
             {
                 return regsC;
             }
         };
 
-// WMMA instructions are specific to gfx11 architecture
-#if ROCWMMA_ARCH_GFX11
-
-        struct WmmaCtrlFlags
+        enum struct WmmaCtrlFlags: bool
         {
-            enum : uint32_t
-            {
-                // Output register selection of WMMA.
-                // Low = bits [15:0]
-                // High = bits[31:16]
-                LOW  = 0,
-                HIGH = 1,
+            // Output register selection of WMMA.
+            // Low = bits [15:0]
+            // High = bits[31:16]
+            LOW  = false,
+            HIGH = true,
 
-                // Signage indicator of inputs / accum
-                UNSIGNED = 0,
-                SIGNED   = 1
-            };
+            // Signage indicator of inputs / accum
+            UNSIGNED = false,
+            SIGNED   = true
         };
 
-        template <>
-        struct amdgcn_wmma<float16_t, float32_t, 16, 16>
+        // gfx11 implementations
+        template <typename Dummy>
+        struct amdgcn_wmma<float16_t, float16_t, float32_t, 16u, 16u, Dummy, enable_if_t<Dummy::value && (bool)ROCWMMA_ARCH_GFX11>>
         {
-            // Packed register traits
-            struct Traits
-            {
-                enum : uint32_t
-                {
-                    KPerWmma  = 16,
-                    InputSign = WmmaCtrlFlags::SIGNED,
-                    AccumBits = WmmaCtrlFlags::LOW,
-                    AccumSign = WmmaCtrlFlags::SIGNED
-                };
-                using ARegsT = VRegF32x8;
-                using BRegsT = VRegF32x8;
-                using CRegsT = AccRegF32x8;
-                using DRegsT = AccRegF32x8;
-            };
+            constexpr static uint32_t KPerMma = 16u;
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
 
-            ROCWMMA_DEVICE static inline auto exec(typename Traits::ARegsT const& regsA,
-                                                   typename Traits::BRegsT const& regsB,
-                                                   typename Traits::CRegsT const& regsC) ->
-                typename Traits::DRegsT
+            // Packed register types
+            using ARegsT = VRegF32x8;
+            using BRegsT = VRegF32x8;
+            using CRegsT = AccRegF32x8;
+            using DRegsT = AccRegF32x8;
+
+            ROCWMMA_DEVICE static inline auto exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
-                typename Traits::DRegsT result;
-                result.data = {
-                    __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(regsA.data, regsB.data, regsC.data)};
+                DRegsT result;
+                result.data = {__builtin_amdgcn_wmma_f32_16x16x16_f16_w32(regsA.data, regsB.data, regsC.data)};
                 return result;
             }
         };
 
-        template <>
-        struct amdgcn_wmma<float16_t, float16_t, 16, 16>
+        template <typename Dummy>
+        struct amdgcn_wmma<float16_t, float16_t, float16_t, 16u, 16u, Dummy, enable_if_t<Dummy::value && (bool)ROCWMMA_ARCH_GFX11>>
         {
-            // Packed register traits
-            struct Traits
-            {
-                enum : uint32_t
-                {
-                    KPerWmma  = 16,
-                    InputSign = WmmaCtrlFlags::SIGNED,
-                    AccumBits = WmmaCtrlFlags::LOW,
-                    AccumSign = WmmaCtrlFlags::SIGNED
-                };
-                using ARegsT = VRegF32x8;
-                using BRegsT = VRegF32x8;
-                using CRegsT = AccRegF32x8;
-                using DRegsT = AccRegF32x8;
-            };
+            constexpr static uint32_t KPerMma = 16u;
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
 
-            ROCWMMA_DEVICE static inline auto exec(typename Traits::ARegsT const& regsA,
-                                                   typename Traits::BRegsT const& regsB,
-                                                   typename Traits::CRegsT const& regsC) ->
-                typename Traits::DRegsT
+            // Packed register types
+            using ARegsT = VRegF32x8;
+            using BRegsT = VRegF32x8;
+            using CRegsT = AccRegF32x8;
+            using DRegsT = AccRegF32x8;
+
+            ROCWMMA_DEVICE static inline auto exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
-                typename Traits::DRegsT result;
-                result.data = {__builtin_amdgcn_wmma_f16_16x16x16_f16_w32(
-                    regsA.data, regsB.data, regsC.data, Traits::AccumBits)};
+                DRegsT result;
+                result.data = {__builtin_amdgcn_wmma_f16_16x16x16_f16_w32(regsA.data, regsB.data, regsC.data, (bool)AccumBits)};
                 return result;
             }
         };
 
-#if !ROCWMMA_NO_HALF
-
-        template <>
-        struct amdgcn_wmma<hfloat16_t, float32_t, 16, 16>
-            : public amdgcn_wmma<float16_t, float32_t, 16, 16>
+        template <typename Dummy>
+        struct amdgcn_wmma<bfloat16_t, bfloat16_t, float32_t, 16u, 16u, Dummy, enable_if_t<Dummy::value && (bool)ROCWMMA_ARCH_GFX11>>
         {
-        };
+            constexpr static uint32_t KPerMma = 16u;
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
 
-        template <>
-        struct amdgcn_wmma<hfloat16_t, hfloat16_t, 16, 16>
-            : public amdgcn_wmma<float16_t, float16_t, 16, 16>
-        {
-        };
+            // Packed register types
+            using ARegsT = VRegF32x8;
+            using BRegsT = VRegF32x8;
+            using CRegsT = AccRegF32x8;
+            using DRegsT = AccRegF32x8;
 
-#endif // !ROCWMMA_NO_HALF
-
-        template <>
-        struct amdgcn_wmma<bfloat16_t, float32_t, 16, 16>
-        {
-            // Packed register traits
-            struct Traits
+            ROCWMMA_DEVICE static inline auto exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
-                enum : uint32_t
-                {
-                    KPerWmma  = 16,
-                    InputSign = WmmaCtrlFlags::SIGNED,
-                    AccumBits = WmmaCtrlFlags::LOW,
-                    AccumSign = WmmaCtrlFlags::SIGNED
-                };
-                using ARegsT = VRegF32x8;
-                using BRegsT = VRegF32x8;
-                using CRegsT = AccRegF32x8;
-                using DRegsT = AccRegF32x8;
-            };
-
-            ROCWMMA_DEVICE static inline auto exec(typename Traits::ARegsT const& regsA,
-                                                   typename Traits::BRegsT const& regsB,
-                                                   typename Traits::CRegsT const& regsC) ->
-                typename Traits::DRegsT
-            {
-                typename Traits::DRegsT result;
-                result.data = {__builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(
-                    regsA.data, regsB.data, regsC.data)};
+                DRegsT result;
+                result.data = {__builtin_amdgcn_wmma_f32_16x16x16_bf16_w32(regsA.data, regsB.data, regsC.data)};
                 return result;
             }
         };
 
-        template <>
-        struct amdgcn_wmma<bfloat16_t, bfloat16_t, 16, 16>
+        template <typename Dummy>
+        struct amdgcn_wmma<bfloat16_t, bfloat16_t, bfloat16_t, 16u, 16u, Dummy, enable_if_t<Dummy::value && (bool)ROCWMMA_ARCH_GFX11>>
         {
-            // Packed register traits
-            struct Traits
-            {
-                enum : uint32_t
-                {
-                    KPerWmma  = 16,
-                    InputSign = WmmaCtrlFlags::SIGNED,
-                    AccumBits = WmmaCtrlFlags::LOW,
-                    AccumSign = WmmaCtrlFlags::SIGNED
-                };
-                using ARegsT = VRegF32x8;
-                using BRegsT = VRegF32x8;
-                using CRegsT = AccRegF32x8;
-                using DRegsT = AccRegF32x8;
-            };
+            constexpr static uint32_t KPerMma = 16u;
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
 
-            ROCWMMA_DEVICE static inline auto exec(typename Traits::ARegsT const& regsA,
-                                                   typename Traits::BRegsT const& regsB,
-                                                   typename Traits::CRegsT const& regsC) ->
-                typename Traits::DRegsT
+            // Packed register types
+            using ARegsT = VRegF32x8;
+            using BRegsT = VRegF32x8;
+            using CRegsT = AccRegF32x8;
+            using DRegsT = AccRegF32x8;
+
+            ROCWMMA_DEVICE static inline auto exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
-                typename Traits::DRegsT result;
-                result.data = {__builtin_amdgcn_wmma_bf16_16x16x16_bf16_w32(
-                    regsA.data, regsB.data, regsC.data, Traits::AccumBits)};
+                DRegsT result;
+                result.data = {__builtin_amdgcn_wmma_bf16_16x16x16_bf16_w32(regsA.data, regsB.data, regsC.data, (bool)AccumBits)};
                 return result;
             }
         };
 
-        template <>
-        struct amdgcn_wmma<int8_t, int32_t, 16, 16>
+        template <typename Dummy>
+        struct amdgcn_wmma<int8_t, int8_t, int32_t, 16u, 16u, Dummy, enable_if_t<Dummy::value && (bool)ROCWMMA_ARCH_GFX11>>
         {
-            // Packed register traits
-            struct Traits
-            {
-                enum : uint32_t
-                {
-                    KPerWmma  = 16,
-                    InputSign = WmmaCtrlFlags::SIGNED,
-                    AccumBits = WmmaCtrlFlags::LOW,
-                    AccumSign = WmmaCtrlFlags::SIGNED
-                };
-                using ARegsT = VRegI32x4;
-                using BRegsT = VRegI32x4;
-                using CRegsT = AccRegI32x8;
-                using DRegsT = AccRegI32x8;
-            };
+            constexpr static uint32_t KPerMma = 16u;
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
 
-            ROCWMMA_DEVICE static inline auto exec(typename Traits::ARegsT const& regsA,
-                                                   typename Traits::BRegsT const& regsB,
-                                                   typename Traits::CRegsT const& regsC) ->
-                typename Traits::DRegsT
+            // Packed register types
+            using ARegsT = VRegI32x4;
+            using BRegsT = VRegI32x4;
+            using CRegsT = AccRegI32x8;
+            using DRegsT = AccRegI32x8;
+
+            ROCWMMA_DEVICE static inline auto exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
-                typename Traits::DRegsT result;
-                result.data = {__builtin_amdgcn_wmma_i32_16x16x16_iu8_w32(Traits::InputSign,
+                DRegsT result;
+                result.data = {__builtin_amdgcn_wmma_i32_16x16x16_iu8_w32((bool)InputSign,
                                                                           regsA.data,
-                                                                          Traits::InputSign,
+                                                                          (bool)InputSign,
                                                                           regsB.data,
                                                                           regsC.data,
-                                                                          Traits::AccumSign)};
+                                                                          (bool)AccumSign)};
                 return result;
             }
         };
 
-#endif // ROCWMMA_ARCH_GFX11
-
-// WMMA instructions are specific to gfx12 architecture
-#if ROCWMMA_ARCH_GFX12
-
-        struct WmmaCtrlFlags
+        // gfx12 implementations
+        template <typename Dummy>
+        struct amdgcn_wmma<float16_t, float16_t, float32_t, 16u, 16u, Dummy, enable_if_t<Dummy::value && (bool)ROCWMMA_ARCH_GFX12, int>>
         {
-            enum : uint32_t
-            {
-                // Output register selection of WMMA.
-                // Low = bits [15:0]
-                // High = bits[31:16]
-                LOW  = 0,
-                HIGH = 1,
+            constexpr static uint32_t KPerMma = 16u;
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
 
-                // Signage indicator of inputs / accum
-                UNSIGNED = 0,
-                SIGNED   = 1
-            };
-        };
+            // Packed register types
+            using ARegsT = VRegF32x4;
+            using BRegsT = VRegF32x4;
+            using CRegsT = AccRegF32x8;
+            using DRegsT = AccRegF32x8;
 
-        template <>
-        struct amdgcn_wmma<float16_t, float32_t, 16, 16>
-        {
-            // Packed register traits
-            struct Traits
+            ROCWMMA_DEVICE static inline auto exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
-                enum : uint32_t
-                {
-                    KPerWmma  = 16,
-                    InputSign = WmmaCtrlFlags::SIGNED,
-                    AccumBits = WmmaCtrlFlags::LOW,
-                    AccumSign = WmmaCtrlFlags::SIGNED
-                };
-                using ARegsT = VRegF32x4;
-                using BRegsT = VRegF32x4;
-                using CRegsT = AccRegF32x8;
-                using DRegsT = AccRegF32x8;
-            };
-
-            ROCWMMA_DEVICE static inline auto exec(typename Traits::ARegsT const& regsA,
-                                                   typename Traits::BRegsT const& regsB,
-                                                   typename Traits::CRegsT const& regsC) ->
-                typename Traits::DRegsT
-            {
-                typename Traits::DRegsT result;
-                result.data = {__builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(
-                    regsA.data, regsB.data, regsC.data)};
+                DRegsT result;
+                result.data = {__builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(regsA.data, regsB.data, regsC.data)};
                 return result;
             }
         };
 
-        template <>
-        struct amdgcn_wmma<float16_t, float16_t, 16, 16>
+        template <typename Dummy>
+        struct amdgcn_wmma<float16_t, float16_t, float16_t, 16u, 16u, Dummy, enable_if_t<Dummy::value && (bool)ROCWMMA_ARCH_GFX12, int>>
         {
-            // Packed register traits
-            struct Traits
-            {
-                enum : uint32_t
-                {
-                    KPerWmma  = 16,
-                    InputSign = WmmaCtrlFlags::SIGNED,
-                    AccumBits = WmmaCtrlFlags::LOW,
-                    AccumSign = WmmaCtrlFlags::SIGNED
-                };
-                using ARegsT = VRegF32x4;
-                using BRegsT = VRegF32x4;
-                using CRegsT = AccRegF32x4;
-                using DRegsT = AccRegF32x4;
-            };
+            constexpr static uint32_t KPerMma = 16u;
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
 
-            ROCWMMA_DEVICE static inline auto exec(typename Traits::ARegsT const& regsA,
-                                                   typename Traits::BRegsT const& regsB,
-                                                   typename Traits::CRegsT const& regsC) ->
-                typename Traits::DRegsT
+            // Packed register types
+            using ARegsT = VRegF32x4;
+            using BRegsT = VRegF32x4;
+            using CRegsT = AccRegF32x4;
+            using DRegsT = AccRegF32x4;
+
+            ROCWMMA_DEVICE static inline auto exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
-                typename Traits::DRegsT result;
-                result.data = {__builtin_amdgcn_wmma_f16_16x16x16_f16_w32_gfx12(
-                    regsA.data, regsB.data, regsC.data)};
+                DRegsT result;
+                result.data = {__builtin_amdgcn_wmma_f16_16x16x16_f16_w32_gfx12(regsA.data, regsB.data, regsC.data)};
                 return result;
             }
         };
 
-#if !ROCWMMA_NO_HALF
-
-        template <>
-        struct amdgcn_wmma<hfloat16_t, float32_t, 16, 16>
-            : public amdgcn_wmma<float16_t, float32_t, 16, 16>
+        template <typename Dummy>
+        struct amdgcn_wmma<bfloat16_t, bfloat16_t, float32_t, 16u, 16u, Dummy, enable_if_t<Dummy::value && (bool)ROCWMMA_ARCH_GFX12, int>>
         {
-        };
+            constexpr static uint32_t KPerMma = 16u;
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
 
-        template <>
-        struct amdgcn_wmma<hfloat16_t, hfloat16_t, 16, 16>
-            : public amdgcn_wmma<float16_t, float16_t, 16, 16>
-        {
-        };
+            // Packed register types
+            using ARegsT = VRegF32x4;
+            using BRegsT = VRegF32x4;
+            using CRegsT = AccRegF32x8;
+            using DRegsT = AccRegF32x8;
 
-#endif // !ROCWMMA_NO_HALF
-
-        template <>
-        struct amdgcn_wmma<bfloat16_t, float32_t, 16, 16>
-        {
-            // Packed register traits
-            struct Traits
+            ROCWMMA_DEVICE static inline auto exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
-                enum : uint32_t
-                {
-                    KPerWmma  = 16,
-                    InputSign = WmmaCtrlFlags::SIGNED,
-                    AccumBits = WmmaCtrlFlags::LOW,
-                    AccumSign = WmmaCtrlFlags::SIGNED
-                };
-                using ARegsT = VRegF32x4;
-                using BRegsT = VRegF32x4;
-                using CRegsT = AccRegF32x8;
-                using DRegsT = AccRegF32x8;
-            };
-
-            ROCWMMA_DEVICE static inline auto exec(typename Traits::ARegsT const& regsA,
-                                                   typename Traits::BRegsT const& regsB,
-                                                   typename Traits::CRegsT const& regsC) ->
-                typename Traits::DRegsT
-            {
-                typename Traits::DRegsT result;
-                result.data = {__builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(
-                    regsA.data, regsB.data, regsC.data)};
+                DRegsT result;
+                result.data = {__builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(regsA.data, regsB.data, regsC.data)};
                 return result;
             }
         };
 
-        template <>
-        struct amdgcn_wmma<bfloat16_t, bfloat16_t, 16, 16>
+        template <typename Dummy>
+        struct amdgcn_wmma<bfloat16_t, bfloat16_t, bfloat16_t, 16u, 16u, Dummy, enable_if_t<Dummy::value && (bool)ROCWMMA_ARCH_GFX12, int>>
         {
-            // Packed register traits
-            struct Traits
-            {
-                enum : uint32_t
-                {
-                    KPerWmma  = 16,
-                    InputSign = WmmaCtrlFlags::SIGNED,
-                    AccumBits = WmmaCtrlFlags::LOW,
-                    AccumSign = WmmaCtrlFlags::SIGNED
-                };
-                using ARegsT = VRegF32x4;
-                using BRegsT = VRegF32x4;
-                using CRegsT = AccRegF32x4;
-                using DRegsT = AccRegF32x4;
-            };
+            constexpr static uint32_t KPerMma = 16u;
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
 
-            ROCWMMA_DEVICE static inline auto exec(typename Traits::ARegsT const& regsA,
-                                                   typename Traits::BRegsT const& regsB,
-                                                   typename Traits::CRegsT const& regsC) ->
-                typename Traits::DRegsT
+            // Packed register types
+            using ARegsT = VRegF32x4;
+            using BRegsT = VRegF32x4;
+            using CRegsT = VRegF32x4;
+            using DRegsT = VRegF32x4;
+
+            ROCWMMA_DEVICE static inline auto exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
-                typename Traits::DRegsT result;
-                result.data = {__builtin_amdgcn_wmma_bf16_16x16x16_bf16_w32_gfx12(
-                    regsA.data, regsB.data, regsC.data)};
+                DRegsT result;
+                result.data = {__builtin_amdgcn_wmma_bf16_16x16x16_bf16_w32_gfx12(regsA.data, regsB.data, regsC.data)};
                 return result;
             }
         };
 
-        template <>
-        struct amdgcn_wmma<int8_t, int32_t, 16, 16>
+        template <typename Dummy>
+        struct amdgcn_wmma<int8_t, int8_t, int32_t, 16u, 16u, Dummy, enable_if_t<Dummy::value && (bool)ROCWMMA_ARCH_GFX12, int>>
         {
-            // Packed register traits
-            struct Traits
-            {
-                enum : uint32_t
-                {
-                    KPerWmma  = 16,
-                    InputSign = WmmaCtrlFlags::SIGNED,
-                    AccumBits = WmmaCtrlFlags::LOW,
-                    AccumSign = WmmaCtrlFlags::SIGNED
-                };
-                using ARegsT = VRegI32x2;
-                using BRegsT = VRegI32x2;
-                using CRegsT = AccRegI32x8;
-                using DRegsT = AccRegI32x8;
-            };
+            constexpr static uint32_t KPerMma = 16u;
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
 
-            ROCWMMA_DEVICE static inline auto exec(typename Traits::ARegsT const& regsA,
-                                                   typename Traits::BRegsT const& regsB,
-                                                   typename Traits::CRegsT const& regsC) ->
-                typename Traits::DRegsT
+            // Packed register types
+            using ARegsT = VRegI32x2;
+            using BRegsT = VRegI32x2;
+            using CRegsT = AccRegI32x8;
+            using DRegsT = AccRegI32x8;
+
+            ROCWMMA_DEVICE static inline auto exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
-                typename Traits::DRegsT result;
-                result.data = {__builtin_amdgcn_wmma_i32_16x16x16_iu8_w32_gfx12(Traits::InputSign,
+                DRegsT result;
+                result.data = {__builtin_amdgcn_wmma_i32_16x16x16_iu8_w32_gfx12((bool)InputSign,
                                                                                 regsA.data,
-                                                                                Traits::InputSign,
+                                                                                (bool)InputSign,
                                                                                 regsB.data,
                                                                                 regsC.data,
-                                                                                Traits::AccumSign)};
+                                                                                (bool)AccumSign)};
                 return result;
             }
         };
 
-        template <>
-        struct amdgcn_wmma<float8_t, float32_t, 16, 16>
+        template <typename Dummy>
+        struct amdgcn_wmma<float8_t, float8_t, float32_t, 16u, 16u, Dummy, enable_if_t<Dummy::value && (bool)ROCWMMA_ARCH_GFX12>>
         {
-            // Packed register traits
-            struct Traits
-            {
-                enum : uint32_t
-                {
-                    KPerWmma  = 16,
-                    InputSign = WmmaCtrlFlags::SIGNED,
-                    AccumBits = WmmaCtrlFlags::LOW,
-                    AccumSign = WmmaCtrlFlags::SIGNED
-                };
-                using ARegsT = VRegF32x2;
-                using BRegsT = VRegF32x2;
-                using CRegsT = AccRegF32x8;
-                using DRegsT = AccRegF32x8;
-            };
+            constexpr static uint32_t KPerMma = 16u;
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
 
-            ROCWMMA_DEVICE static inline auto exec(typename Traits::ARegsT const& regsA,
-                                                   typename Traits::BRegsT const& regsB,
-                                                   typename Traits::CRegsT const& regsC) ->
-                typename Traits::DRegsT
+            // Packed register types
+            using ARegsT = VRegF32x2;
+            using BRegsT = VRegF32x2;
+            using CRegsT = AccRegF32x8;
+            using DRegsT = AccRegF32x8;
+
+            ROCWMMA_DEVICE static inline auto exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
                 // Built-in expects vector of int.
                 using TypeIn = VecT<int, 2>;
 
-                typename Traits::DRegsT result;
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsA)>), "Inconsistent data formats");
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsB)>), "Inconsistent data formats");
+
+                DRegsT result;
                 result.data = {__builtin_amdgcn_wmma_f32_16x16x16_fp8_fp8_w32_gfx12(
                     reinterpret_cast<TypeIn const&>(regsA).data,
                     reinterpret_cast<TypeIn const&>(regsB).data,
@@ -469,34 +331,29 @@ namespace rocwmma
             }
         };
 
-        template <>
-        struct amdgcn_wmma<bfloat8_t, float32_t, 16, 16>
+        template <typename Dummy>
+        struct amdgcn_wmma<bfloat8_t, bfloat8_t, float32_t, 16u, 16u, Dummy, enable_if_t<Dummy::value && (bool)ROCWMMA_ARCH_GFX12>>
         {
-            // Packed register traits
-            struct Traits
-            {
-                enum : uint32_t
-                {
-                    KPerWmma  = 16,
-                    InputSign = WmmaCtrlFlags::SIGNED,
-                    AccumBits = WmmaCtrlFlags::LOW,
-                    AccumSign = WmmaCtrlFlags::SIGNED
-                };
-                using ARegsT = VRegF32x2;
-                using BRegsT = VRegF32x2;
-                using CRegsT = AccRegF32x8;
-                using DRegsT = AccRegF32x8;
-            };
+            constexpr static uint32_t KPerMma = 16u;
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
 
-            ROCWMMA_DEVICE static inline auto exec(typename Traits::ARegsT const& regsA,
-                                                   typename Traits::BRegsT const& regsB,
-                                                   typename Traits::CRegsT const& regsC) ->
-                typename Traits::DRegsT
+            // Packed register types
+            using ARegsT = VRegF32x2;
+            using BRegsT = VRegF32x2;
+            using CRegsT = AccRegF32x8;
+            using DRegsT = AccRegF32x8;
+
+            ROCWMMA_DEVICE static inline auto exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
                 // Built-in expects vector of int.
                 using TypeIn = VecT<int, 2>;
 
-                typename Traits::DRegsT result;
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsA)>), "Inconsistent data formats");
+                static_assert(sizeof(TypeIn) == sizeof(decay_t<decltype(regsB)>), "Inconsistent data formats");
+
+                DRegsT result;
                 result.data = {__builtin_amdgcn_wmma_f32_16x16x16_bf8_bf8_w32_gfx12(
                     reinterpret_cast<TypeIn const&>(regsA).data,
                     reinterpret_cast<TypeIn const&>(regsB).data,
@@ -505,7 +362,22 @@ namespace rocwmma
             }
         };
 
-#endif // ROCWMMA_ARCH_GFX12
+        // Derivative implementations
+        template <typename Dummy>
+        struct amdgcn_wmma<hfloat16_t, hfloat16_t, float32_t, 16u, 16u, Dummy, enable_if_t<Dummy::value
+                                                                       &&((bool)ROCWMMA_ARCH_GFX11 || (bool)ROCWMMA_ARCH_GFX12)
+                                                                       && !(bool)ROCWMMA_NO_HALF>>
+            : public amdgcn_wmma<float16_t, float16_t, float32_t, 16u, 16u>
+        {
+        };
+
+        template <typename Dummy>
+        struct amdgcn_wmma<hfloat16_t, hfloat16_t, hfloat16_t, 16u, 16u, Dummy, enable_if_t<Dummy::value
+                                                                       &&((bool)ROCWMMA_ARCH_GFX11 || (bool)ROCWMMA_ARCH_GFX12)
+                                                                       && !(bool)ROCWMMA_NO_HALF>>
+            : public amdgcn_wmma<float16_t, float16_t, float16_t, 16u, 16u>
+        {
+        };
 
     } // namespace detail
 

--- a/library/include/rocwmma/rocwmma.hpp
+++ b/library/include/rocwmma/rocwmma.hpp
@@ -293,14 +293,15 @@ namespace rocwmma
     //! @param b Input fragment B
     //! @param c Input accumulator fragment C
     //! @tparam BlockM/N/K block dimensions
-    //! @tparam InputT Datatype of input frags A and B
+    //! @tparam InputT A/B Datatype of input frags A and B
     //! @tparam ComputeT Datatype of accumulator fragment C / D
     //! @tparam LayoutA/B/C/D In-memory layout of frag as col_major or row_major
     //! @note Frag c = d is valid
     template <uint32_t BlockM,
               uint32_t BlockN,
               uint32_t BlockK,
-              typename InputT,
+              typename InputTA,
+              typename InputTB,
               typename ComputeT,
               typename LayoutA,
               typename LayoutB,
@@ -308,8 +309,8 @@ namespace rocwmma
               typename LayoutD>
     ROCWMMA_DEVICE void
         mma_sync(fragment<accumulator, BlockM, BlockN, BlockK, ComputeT, LayoutD>&       d,
-                 fragment<matrix_a, BlockM, BlockN, BlockK, InputT, LayoutA> const&      a,
-                 fragment<matrix_b, BlockM, BlockN, BlockK, InputT, LayoutB> const&      b,
+                 fragment<matrix_a, BlockM, BlockN, BlockK, InputTA, LayoutA> const&      a,
+                 fragment<matrix_b, BlockM, BlockN, BlockK, InputTB, LayoutB> const&      b,
                  fragment<accumulator, BlockM, BlockN, BlockK, ComputeT, LayoutC> const& c);
 
     //! Synchronization point for all wavefronts in a workgroup. Guarantees pending reads / writes to LDS are flushed.

--- a/library/include/rocwmma/rocwmma_impl.hpp
+++ b/library/include/rocwmma/rocwmma_impl.hpp
@@ -366,8 +366,8 @@ namespace rocwmma
 
         // Gfx9 uses MFMA, gfx11 uses WMMA
         using Mma = conditional_t<(bool)ROCWMMA_ARCH_GFX9,
-                                  Mfma<InputT, ComputeT, BlockM, BlockN, BlockK>,
-                                  Wmma<InputT, ComputeT, BlockM, BlockN, BlockK>>;
+                                  Mfma<BlockM, BlockN, BlockK, InputT, InputT, ComputeT, 16u>,
+                                  Wmma<BlockM, BlockN, BlockK, InputT, InputT, ComputeT, 16u>>;
 
         // 1. Perform input pre-ops on A, B, Acc (unpacked)
         // 2. Mma (packed)

--- a/library/include/rocwmma/rocwmma_impl.hpp
+++ b/library/include/rocwmma/rocwmma_impl.hpp
@@ -42,6 +42,8 @@
 #include "internal/layout/layout.hpp"
 #include "internal/mapping_util.hpp"
 #include "internal/mfma.hpp"
+#include "internal/mma.hpp"
+#include "internal/mma_config.hpp"
 #include "internal/opaque_load.hpp"
 #include "internal/opaque_store.hpp"
 #include "internal/pack_util.hpp"
@@ -321,7 +323,8 @@ namespace rocwmma
     template <uint32_t BlockM,
               uint32_t BlockN,
               uint32_t BlockK,
-              typename InputT,
+              typename InputTA,
+              typename InputTB,
               typename ComputeT,
               typename LayoutA,
               typename LayoutB,
@@ -329,54 +332,35 @@ namespace rocwmma
               typename LayoutD>
     ROCWMMA_DEVICE void
         mma_sync(fragment<accumulator, BlockM, BlockN, BlockK, ComputeT, LayoutD>&       d,
-                 fragment<matrix_a, BlockM, BlockN, BlockK, InputT, LayoutA> const&      a,
-                 fragment<matrix_b, BlockM, BlockN, BlockK, InputT, LayoutB> const&      b,
+                 fragment<matrix_a, BlockM, BlockN, BlockK, InputTA, LayoutA> const&      a,
+                 fragment<matrix_b, BlockM, BlockN, BlockK, InputTB, LayoutB> const&      b,
                  fragment<accumulator, BlockM, BlockN, BlockK, ComputeT, LayoutC> const& c)
     {
-        using FragA   = decay_t<decltype(a)>;
-        using FragB   = decay_t<decltype(b)>;
-        using FragAcc = decay_t<decltype(c)>;
+        using MmaConfig = MmaConfig<BlockM, BlockN, BlockK, InputTA, InputTB, ComputeT, LayoutA, LayoutB, LayoutC, LayoutD>;
 
-        using IOConfigA   = GetIOConfig_t<FragA>;
-        using IOConfigB   = GetIOConfig_t<FragB>;
-        using IOConfigAcc = GetIOConfig_t<FragAcc>;
+        // Transforms
+        using XA = typename MmaConfig::PreMmaXFormA;
+        using XB = typename MmaConfig::PreMmaXFormB;
+        using XC = typename MmaConfig::PreMmaXFormC;
+        using XD = typename MmaConfig::PostMmaXFormD;
 
-        using PreMmaA   = typename IOConfigA::PreMmaXForm;
-        using PreMmaB   = typename IOConfigB::PreMmaXForm;
-        using PreMmaAcc = typename IOConfigAcc::PreMmaXForm;
-        using PostMmaAcc = typename IOConfigAcc::PostMmaXForm;
+        // PackUtil
+        using PackA = typename MmaConfig::PackA;
+        using PackB = typename MmaConfig::PackB;
+        using PackC = typename MmaConfig::PackC;
+        using PackD = typename MmaConfig::PackD;
 
-        using PackA   = typename IOConfigA::PackUtil;
-        using PackB   = typename IOConfigB::PackUtil;
-        using PackAcc = typename IOConfigAcc::PackUtil;
+        using Mma = typename MmaConfig::Mma;
 
-        // Sanity checks
-        static_assert((IOConfigA::IOShape::BlockDim >= 16) && (IOConfigB::IOShape::BlockDim >= 16)
-                          && (IOConfigA::IOShape::BlockDim <= 32)
-                          && (IOConfigB::IOShape::BlockDim <= 32),
-                      "Input fragment BlockDim is not mfma friendly");
-
-        static_assert((IOConfigA::IOShape::BlockDim == IOConfigB::IOShape::BlockDim)
-                          && (IOConfigA::IOShape::KDim == IOConfigB::IOShape::KDim),
-                      "BlockDim and KDim of input fragments must match");
-
-        static_assert(is_layout_same_v<typename IOConfigA::IOLayout::MmaLayout,
-                                       typename IOConfigB::IOLayout::MmaLayout>,
-                      "Input fragment register layouts do not match");
-
-        // Gfx9 uses MFMA, gfx11 uses WMMA
-        using Mma = conditional_t<(bool)ROCWMMA_ARCH_GFX9,
-                                  Mfma<BlockM, BlockN, BlockK, InputT, InputT, ComputeT, 16u>,
-                                  Wmma<BlockM, BlockN, BlockK, InputT, InputT, ComputeT, 16u>>;
-
-        // 1. Perform input pre-ops on A, B, Acc (unpacked)
+        // 1. Perform input pre-ops on A, B, Acc (unpacked mAccess)
         // 2. Mma (packed)
         // 3. Perform acc post-op on Acc
         // 4. Pack back to register
-        d.mAccess = PostMmaAcc::exec(
-                    PackAcc::unpack(Mma::exec(PackA::pack(PreMmaA::exec(a.mAccess)),
-                                              PackB::pack(PreMmaB::exec(b.mAccess)),
-                                              PackAcc::pack(PreMmaAcc::exec(c.mAccess)))));
+        d.mAccess = XD::exec(PackD::unpack(
+                                Mma::exec(PackA::pack(XA::exec(a.mAccess)),
+                                          PackB::pack(XB::exec(b.mAccess)),
+                                          PackC::pack(XC::exec(c.mAccess)))));
+
     }
 
     ROCWMMA_DEVICE void synchronize_workgroup()

--- a/samples/perf_sgemm.cpp
+++ b/samples/perf_sgemm.cpp
@@ -461,7 +461,7 @@ ROCWMMA_DEVICE static inline void uniformFma(MfmaFragD (&fragsD)[BLOCKS_X][BLOCK
     }
 }
 
-ROCWMMA_KERNEL void __launch_bounds__(256) gemm_rocwmma_d(uint32_t       m,
+ROCWMMA_KERNEL void __launch_bounds__(256) sgemm_rocwmma_d(uint32_t       m,
                                                           uint32_t       n,
                                                           uint32_t       k,
                                                           InputT const*  a,
@@ -475,188 +475,190 @@ ROCWMMA_KERNEL void __launch_bounds__(256) gemm_rocwmma_d(uint32_t       m,
                                                           ComputeT       alpha,
                                                           ComputeT       beta)
 {
-    if constexpr((bool)ROCWMMA_ARCH_GFX9)
+#if ROCWMMA_ARCH_GFX9
+
+    ///
+    /// 2D matrix coordinate setup
+    ///
+
+    // Tile Sizes
+    constexpr auto warpTileSize  = make_coord2d(WARP_TILE_X, WARP_TILE_Y);
+    constexpr auto macroTileSize = make_coord2d(MACRO_TILE_X, MACRO_TILE_Y);
+
+    // Local warp coordinate relative to current threadblock (wg).
+    constexpr auto warpDims        = make_coord2d(WARPS_X, WARPS_Y);
+    auto           localWarpCoord  = make_coord2d(threadIdx.x / WARP_SIZE, threadIdx.y);
+    auto           localWarpOffset = localWarpCoord * warpTileSize;
+
+    // Global matrix coordinates for C/D
+    auto macroTileCoord = make_coord2d(blockIdx.x, blockIdx.y) * macroTileSize;
+    auto warpTileCoord  = macroTileCoord + localWarpOffset;
+
+    // Bounds check
+    auto warpTileBound = warpTileCoord + warpTileSize;
+    if(get<0>(warpTileBound) > m || get<1>(warpTileBound) > n)
     {
-        ///
-        /// 2D matrix coordinate setup
-        ///
+        return;
+    }
 
-        // Tile Sizes
-        constexpr auto warpTileSize  = make_coord2d(WARP_TILE_X, WARP_TILE_Y);
-        constexpr auto macroTileSize = make_coord2d(MACRO_TILE_X, MACRO_TILE_Y);
+    ///
+    /// 1D global read coordinate setup
+    ///
+    using GRBuffAMap1d = GetDataLayout_t<GRBuffA>;
+    using GRBuffBMap1d = GetDataLayout_t<GRBuffB>;
 
-        // Local warp coordinate relative to current threadblock (wg).
-        constexpr auto warpDims        = make_coord2d(WARPS_X, WARPS_Y);
-        auto           localWarpCoord  = make_coord2d(threadIdx.x / WARP_SIZE, threadIdx.y);
-        auto           localWarpOffset = localWarpCoord * warpTileSize;
+    // Initial globa read address offsets
+    auto globalReadOffsetA
+        = GRBuffAMap1d::fromMatrixCoord(make_coord2d(get<0>(macroTileCoord), 0u), lda);
+    auto globalReadOffsetB
+        = GRBuffBMap1d::fromMatrixCoord(make_coord2d(0u, get<1>(macroTileCoord)), ldb);
 
-        // Global matrix coordinates for C/D
-        auto macroTileCoord = make_coord2d(blockIdx.x, blockIdx.y) * macroTileSize;
-        auto warpTileCoord  = macroTileCoord + localWarpOffset;
+    // Incremental global read address offsets
+    auto kStepOffsetA = GRBuffAMap1d::fromMatrixCoord(make_coord2d(0u, ROCWMMA_K), lda);
+    auto kStepOffsetB = GRBuffBMap1d::fromMatrixCoord(make_coord2d(ROCWMMA_K, 0u), ldb);
 
-        // Bounds check
-        auto warpTileBound = warpTileCoord + warpTileSize;
-        if(get<0>(warpTileBound) > m || get<1>(warpTileBound) > n)
-        {
-            return;
-        }
+    ///
+    /// Cooperative config for global read A / B
+    ///
 
-        ///
-        /// 1D global read coordinate setup
-        ///
-        using GRBuffAMap1d = GetDataLayout_t<GRBuffA>;
-        using GRBuffBMap1d = GetDataLayout_t<GRBuffB>;
+    // WorkItems will be split up by minimum IOCount to perform either global read or local write.
+    // These are inputs to cooperative functions.
+    constexpr auto warpCount = get<0>(warpDims) * get<1>(warpDims);
 
-        // Initial globa read address offsets
-        auto globalReadOffsetA
-            = GRBuffAMap1d::fromMatrixCoord(make_coord2d(get<0>(macroTileCoord), 0u), lda);
-        auto globalReadOffsetB
-            = GRBuffBMap1d::fromMatrixCoord(make_coord2d(0u, get<1>(macroTileCoord)), ldb);
+    // Scheduling warp order is analogous to row major priority.
+    // E.g. Wg = (128, 2) = 2x2 warps
+    // (0, 0)   (0, 1)   Share Schedule: w0 = (0, 0), w1 = (0, 1),
+    // (1, 0)   (1, 1)                   w2 = (1, 0), w3 = (1, 1), count = 4
+    const auto warpIndex = get<0>(localWarpCoord) * get<1>(warpDims) + get<1>(localWarpCoord);
 
-        // Incremental global read address offsets
-        auto kStepOffsetA = GRBuffAMap1d::fromMatrixCoord(make_coord2d(0u, ROCWMMA_K), lda);
-        auto kStepOffsetB = GRBuffBMap1d::fromMatrixCoord(make_coord2d(ROCWMMA_K, 0u), ldb);
+    ///
+    /// Perform initial global pre-fetch
+    ///
 
-        ///
-        /// Cooperative config for global read A / B
-        ///
+    GRBuffA grBuffA;
+    GRBuffB grBuffB;
 
-        // WorkItems will be split up by minimum IOCount to perform either global read or local write.
-        // These are inputs to cooperative functions.
-        constexpr auto warpCount = get<0>(warpDims) * get<1>(warpDims);
+    globalReadCoopA<warpCount>(grBuffA, a + globalReadOffsetA, lda, warpIndex);
+    globalReadCoopB<warpCount>(grBuffB, b + globalReadOffsetB, ldb, warpIndex);
 
-        // Scheduling warp order is analogous to row major priority.
-        // E.g. Wg = (128, 2) = 2x2 warps
-        // (0, 0)   (0, 1)   Share Schedule: w0 = (0, 0), w1 = (0, 1),
-        // (1, 0)   (1, 1)                   w2 = (1, 0), w3 = (1, 1), count = 4
-        const auto warpIndex = get<0>(localWarpCoord) * get<1>(warpDims) + get<1>(localWarpCoord);
+    globalReadOffsetA += kStepOffsetA;
+    globalReadOffsetB += kStepOffsetB;
 
-        ///
-        /// Perform initial global pre-fetch
-        ///
+    ///
+    /// Setup LDS addressing
+    /// This kernel will use 2 separate LDS blocks for pipelining
+    /// the input prefetching during the accumulation loop
+    ///
 
-        GRBuffA grBuffA;
-        GRBuffB grBuffB;
+    HIP_DYNAMIC_SHARED(void*, localMemPtr);
+    using LWBuffAShape = GetIOShape_t<LWBuffA>;
+    using LWBuffBShape = GetIOShape_t<LWBuffB>;
+    using LWBuffAMap1d = GetDataLayout_t<LWBuffA>;
+    using LWBuffBMap1d = GetDataLayout_t<LWBuffB>;
 
-        globalReadCoopA<warpCount>(grBuffA, a + globalReadOffsetA, lda, warpIndex);
-        globalReadCoopB<warpCount>(grBuffB, b + globalReadOffsetB, ldb, warpIndex);
+    constexpr uint32_t ldsWidth  = ROCWMMA_K;
+    constexpr uint32_t ldsHeight = LWBuffAShape::BlockHeight + LWBuffBShape::BlockHeight;
+    constexpr uint32_t sizeLds   = ldsHeight * ldsWidth;
+    constexpr uint32_t ldsld = std::is_same_v<DataLayoutLds, row_major> ? ldsWidth : ldsHeight;
 
-        globalReadOffsetA += kStepOffsetA;
-        globalReadOffsetB += kStepOffsetB;
+    auto* ldsPtrLo = reinterpret_cast<InputT*>(localMemPtr);
+    auto* ldsPtrHi = ldsPtrLo + sizeLds;
 
-        ///
-        /// Setup LDS addressing
-        /// This kernel will use 2 separate LDS blocks for pipelining
-        /// the input prefetching during the accumulation loop
-        ///
+    // Local write offsets to start of A / B data
+    auto ldsWriteOffsetA = 0u;
+    auto ldsWriteOffsetB
+        = LWBuffAMap1d::fromMatrixCoord(make_coord2d(LWBuffAShape::BlockHeight, 0u), ldsld);
 
-        HIP_DYNAMIC_SHARED(void*, localMemPtr);
-        using LWBuffAShape = GetIOShape_t<LWBuffA>;
-        using LWBuffBShape = GetIOShape_t<LWBuffB>;
-        using LWBuffAMap1d = GetDataLayout_t<LWBuffA>;
-        using LWBuffBMap1d = GetDataLayout_t<LWBuffB>;
+    // Local read offsets for mfma frags
+    auto ldsReadOffsetA
+        = ldsWriteOffsetA
+            + LWBuffAMap1d::fromMatrixCoord(make_coord2d(get<0>(localWarpOffset), 0u), ldsld);
+    auto ldsReadOffsetB
+        = ldsWriteOffsetB
+            + LWBuffBMap1d::fromMatrixCoord(make_coord2d(get<1>(localWarpOffset), 0u), ldsld);
 
-        constexpr uint32_t ldsWidth  = ROCWMMA_K;
-        constexpr uint32_t ldsHeight = LWBuffAShape::BlockHeight + LWBuffBShape::BlockHeight;
-        constexpr uint32_t sizeLds   = ldsHeight * ldsWidth;
-        constexpr uint32_t ldsld = std::is_same_v<DataLayoutLds, row_major> ? ldsWidth : ldsHeight;
+    ///
+    /// Write prefetch to local
+    ///
+    localWriteCoopA<warpCount>(ldsPtrLo + ldsWriteOffsetA, grBuffA, ldsld, warpIndex);
+    localWriteCoopB<warpCount>(ldsPtrLo + ldsWriteOffsetB, grBuffB, ldsld, warpIndex);
 
-        auto* ldsPtrLo = reinterpret_cast<InputT*>(localMemPtr);
-        auto* ldsPtrHi = ldsPtrLo + sizeLds;
+    ///
+    /// Initialize accumulation frags
+    ///
+    MfmaFragAcc fragsAcc[BLOCKS_X][BLOCKS_Y];
+    fill(fragsAcc, 0.0f);
 
-        // Local write offsets to start of A / B data
-        auto ldsWriteOffsetA = 0u;
-        auto ldsWriteOffsetB
-            = LWBuffAMap1d::fromMatrixCoord(make_coord2d(LWBuffAShape::BlockHeight, 0u), ldsld);
+    ///
+    /// Synchronize warps and memory
+    ///
+    synchronize_workgroup();
 
-        // Local read offsets for mfma frags
-        auto ldsReadOffsetA
-            = ldsWriteOffsetA
-              + LWBuffAMap1d::fromMatrixCoord(make_coord2d(get<0>(localWarpOffset), 0u), ldsld);
-        auto ldsReadOffsetB
-            = ldsWriteOffsetB
-              + LWBuffBMap1d::fromMatrixCoord(make_coord2d(get<1>(localWarpOffset), 0u), ldsld);
-
-        ///
-        /// Write prefetch to local
-        ///
-        localWriteCoopA<warpCount>(ldsPtrLo + ldsWriteOffsetA, grBuffA, ldsld, warpIndex);
-        localWriteCoopB<warpCount>(ldsPtrLo + ldsWriteOffsetB, grBuffB, ldsld, warpIndex);
-
-        ///
-        /// Initialize accumulation frags
-        ///
-        MfmaFragAcc fragsAcc[BLOCKS_X][BLOCKS_Y];
-        fill(fragsAcc, 0.0f);
-
-        ///
-        /// Synchronize warps and memory
-        ///
-        synchronize_workgroup();
-
-        ///
-        /// Accumulate A * B for all mfma frags in warp tile
-        ///
-        for(auto currentK = ROCWMMA_K; currentK < k; currentK += ROCWMMA_K)
-        {
-            MfmaFragA fragsA[BLOCKS_X];
-            MfmaFragB fragsB[BLOCKS_Y];
-
-            // Local read mfma frags from first LDS buffer
-            localReadA(fragsA, ldsPtrLo + ldsReadOffsetA, ldsld);
-            localReadB(fragsB, ldsPtrLo + ldsReadOffsetB, ldsld);
-
-            // Prefetch next round of global frags
-            globalReadCoopA<warpCount>(grBuffA, a + globalReadOffsetA, lda, warpIndex);
-            globalReadCoopB<warpCount>(grBuffB, b + globalReadOffsetB, ldb, warpIndex);
-
-            // Advance offsets to next k step
-            globalReadOffsetA += kStepOffsetA;
-            globalReadOffsetB += kStepOffsetB;
-
-            // accum(A * B)
-            mfma(fragsAcc, fragsA, fragsB, fragsAcc);
-
-            // Write prefetch to second LDS buffer
-            localWriteCoopA<warpCount>(ldsPtrHi + ldsWriteOffsetA, grBuffA, ldsld, warpIndex);
-            localWriteCoopB<warpCount>(ldsPtrHi + ldsWriteOffsetB, grBuffB, ldsld, warpIndex);
-
-            // Make sure that all waves have finished reading / writing to lds for currentK.
-            synchronize_workgroup();
-
-            // Swap Lds buffers
-            auto* tmp = ldsPtrLo;
-            ldsPtrLo  = ldsPtrHi;
-            ldsPtrHi  = tmp;
-        }
-
-        ///
-        /// Start loading C
-        ///
-        using MfmaFragCMap1d = GetDataLayout_t<MfmaFragC>;
-        using MfmaFragDMap1d = GetDataLayout_t<MfmaFragD>;
-
-        MfmaFragC fragsC[BLOCKS_X][BLOCKS_Y];
-        globalReadC(fragsC, c + MfmaFragCMap1d::fromMatrixCoord(warpTileCoord, ldc), ldc);
-
-        ///
-        /// Clean up tail A * B
-        ///
+    ///
+    /// Accumulate A * B for all mfma frags in warp tile
+    ///
+    for(auto currentK = ROCWMMA_K; currentK < k; currentK += ROCWMMA_K)
+    {
         MfmaFragA fragsA[BLOCKS_X];
         MfmaFragB fragsB[BLOCKS_Y];
 
-        // Local read mfma frags
+        // Local read mfma frags from first LDS buffer
         localReadA(fragsA, ldsPtrLo + ldsReadOffsetA, ldsld);
         localReadB(fragsB, ldsPtrLo + ldsReadOffsetB, ldsld);
+
+        // Prefetch next round of global frags
+        globalReadCoopA<warpCount>(grBuffA, a + globalReadOffsetA, lda, warpIndex);
+        globalReadCoopB<warpCount>(grBuffB, b + globalReadOffsetB, ldb, warpIndex);
+
+        // Advance offsets to next k step
+        globalReadOffsetA += kStepOffsetA;
+        globalReadOffsetB += kStepOffsetB;
+
+        // accum(A * B)
         mfma(fragsAcc, fragsA, fragsB, fragsAcc);
 
-        ///
-        /// D = alpha * accum + beta * C
-        ///
-        MfmaFragD fragsD[BLOCKS_X][BLOCKS_Y];
-        uniformFma(fragsD, alpha, fragsAcc, beta, fragsC);
-        globalWriteD(d + MfmaFragDMap1d::fromMatrixCoord(warpTileCoord, ldd), fragsD, ldd);
+        // Write prefetch to second LDS buffer
+        localWriteCoopA<warpCount>(ldsPtrHi + ldsWriteOffsetA, grBuffA, ldsld, warpIndex);
+        localWriteCoopB<warpCount>(ldsPtrHi + ldsWriteOffsetB, grBuffB, ldsld, warpIndex);
+
+        // Make sure that all waves have finished reading / writing to lds for currentK.
+        synchronize_workgroup();
+
+        // Swap Lds buffers
+        auto* tmp = ldsPtrLo;
+        ldsPtrLo  = ldsPtrHi;
+        ldsPtrHi  = tmp;
     }
+
+    ///
+    /// Start loading C
+    ///
+    using MfmaFragCMap1d = GetDataLayout_t<MfmaFragC>;
+    using MfmaFragDMap1d = GetDataLayout_t<MfmaFragD>;
+
+    MfmaFragC fragsC[BLOCKS_X][BLOCKS_Y];
+    globalReadC(fragsC, c + MfmaFragCMap1d::fromMatrixCoord(warpTileCoord, ldc), ldc);
+
+    ///
+    /// Clean up tail A * B
+    ///
+    MfmaFragA fragsA[BLOCKS_X];
+    MfmaFragB fragsB[BLOCKS_Y];
+
+    // Local read mfma frags
+    localReadA(fragsA, ldsPtrLo + ldsReadOffsetA, ldsld);
+    localReadB(fragsB, ldsPtrLo + ldsReadOffsetB, ldsld);
+    mfma(fragsAcc, fragsA, fragsB, fragsAcc);
+
+    ///
+    /// D = alpha * accum + beta * C
+    ///
+    MfmaFragD fragsD[BLOCKS_X][BLOCKS_Y];
+    uniformFma(fragsD, alpha, fragsAcc, beta, fragsC);
+    globalWriteD(d + MfmaFragDMap1d::fromMatrixCoord(warpTileCoord, ldd), fragsD, ldd);
+
+#endif // ROCWMMA_ARCH_GFX9
+
 }
 
 ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, ComputeT alpha, ComputeT beta)
@@ -748,7 +750,7 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, ComputeT alpha, 
         = 2u * sizeof(InputT) * (get<0>(macroTileSize) + get<1>(macroTileSize)) * ROCWMMA_K;
 
     auto rocwmmaKernel = [&]() {
-        hipExtLaunchKernelGGL(gemm_rocwmma_d,
+        hipExtLaunchKernelGGL(sgemm_rocwmma_d,
                               gridDim,
                               blockDim,
                               ldsusage,


### PR DESCRIPTION
- Refactored WMMA and MFMA backends. 
  - Created common Mma base class to implement unrolling, based on input backend.
  - Created MmaTraits class to hold block-wise mma traits
  - amdgcn_* backends now selective of gfx architecture support or other flags.
  - Mfma sub-b32 accumulation refactored to a single case to eliminate code duplication.
  - Allow for different input types of A & B, (e.g., bf8 / f8 mix inputT mixing)
  - Simplified architecture exposure for each builtin
- Added: 
  - MmaConfig class to consolidate Mma-specific configurations.
  - Each IOLayout has property MmaDim
  - vector_for_each: apply a functor operation to each subvector (immutable, by copy)
  - vector_mutate_for_each: apply a functor operation to each subvector (mutable, in-place)
  - vector_reduce: apply a functor operation to each subvector and an accumulator object
  - vector_reduce2: apply a functor operation to each subvector of 2 inputs and an accumulator object
  - type traits: add_lvalue_reference and add_rvalue_reference
  - move utility
- Fixed compiler error for logical operator utility
- Refactored is_arithmetic type_trait with general solution
- Fixed is_function type_trait - incorrect implementation
- Generalized VectorIterator class to handle both HIP_vector_type and non_native_vector_base