### PR TITLE
Fixes bug in f64 vw=1 transform for interleaved layouts

### DIFF
--- a/library/include/rocwmma/internal/coop_io_config.hpp
+++ b/library/include/rocwmma/internal/coop_io_config.hpp
@@ -84,13 +84,16 @@ namespace rocwmma
                                        WaveCount>;
 
         using PostLoadXForm = register_layout_transform<typename IOLayout::StorageLayout,
-                                                        typename IOLayout::FragmentLayout>;
+                                                        typename IOLayout::FragmentLayout,
+                                                        WaveCount>;
 
         using PreMmaXForm = register_layout_transform<typename IOLayout::FragmentLayout,
-                                                      typename IOLayout::MmaLayout>;
+                                                      typename IOLayout::MmaLayout,
+                                                      WaveCount>;
 
         using PreStoreXForm = register_layout_transform<typename IOLayout::FragmentLayout,
-                                                        typename IOLayout::StorageLayout>;
+                                                        typename IOLayout::StorageLayout,
+                                                        WaveCount>;
 
         using Storer = CooperativeStore<typename IOLayout::DataLayout,
                                         typename IOLayout::MatrixLayout,

--- a/library/include/rocwmma/internal/io_config.hpp
+++ b/library/include/rocwmma/internal/io_config.hpp
@@ -84,10 +84,12 @@ namespace rocwmma
         using Loader = OpaqueLoad<typename IOLayout::DataLayout, typename IOLayout::MatrixLayout>;
 
         using PostLoadXForm = register_layout_transform<typename IOLayout::StorageLayout,
-                                                        typename IOLayout::FragmentLayout>;
+                                                        typename IOLayout::FragmentLayout,
+                                                        1u>;
 
         using PreStoreXForm = register_layout_transform<typename IOLayout::FragmentLayout,
-                                                        typename IOLayout::StorageLayout>;
+                                                        typename IOLayout::StorageLayout,
+                                                        1u>;
 
         using Storer = OpaqueStore<typename IOLayout::DataLayout, typename IOLayout::MatrixLayout>;
     };
@@ -109,10 +111,12 @@ namespace rocwmma
         using Broadcaster = Broadcast<DataT, IOTraits::UnpackedSize>;
 
         using PreMmaXForm = register_layout_transform<typename IOLayout::FragmentLayout,
-                                                      typename IOLayout::MmaLayout>;
+                                                      typename IOLayout::MmaLayout,
+                                                      1u>;
 
         using PostMmaXForm = register_layout_transform<typename IOLayout::MmaLayout,
-                                                       typename IOLayout::FragmentLayout>;
+                                                       typename IOLayout::FragmentLayout,
+                                                       1u>;
     };
     /** @}*/
 

--- a/library/include/rocwmma/internal/layout/register_layout_transforms.hpp
+++ b/library/include/rocwmma/internal/layout/register_layout_transforms.hpp
@@ -35,11 +35,11 @@ namespace rocwmma
     *  @tparam RegisterLayoutLhs Source register layout
     *  @tparam RegisterLayoutRhs Target register layout
     */
-    template <typename RegisterLayoutLhs, typename RegisterLayoutRhs>
+    template <typename RegisterLayoutLhs, typename RegisterLayoutRhs, uint32_t WaveCount>
     using register_layout_transform
-        = LayoutTransforms_impl::register_layout_transform<RegisterLayoutLhs, RegisterLayoutRhs>;
+        = LayoutTransforms_impl::register_layout_transform<RegisterLayoutLhs, RegisterLayoutRhs, WaveCount>;
 
-    using register_layout_transform_nop = register_layout_transform<void, void>;
+    using register_layout_transform_nop = register_layout_transform<void, void, 0u>;
 
 } // namespace rocWMMA
 

--- a/library/include/rocwmma/internal/layout/transforms/transforms_int_impl.hpp
+++ b/library/include/rocwmma/internal/layout/transforms/transforms_int_impl.hpp
@@ -120,8 +120,11 @@ namespace rocwmma
                     // unpackLoHi16 on entire vector
                     // unpackLoHi32 on entire vector
                     // interleave entire vector
-                    return interleave<1u, MaxVW * MmaBlocksB>(
+                    // Note: make a copy here, due to interleave may return
+                    // fwd arg input on nop.
+                    auto result = interleave<1u, MaxVW * MmaBlocksB>(
                         unpackLoHi32(unpackLoHi16(forward<VecT>(v))));
+                    return result;
                 }
                 else if constexpr(MaxVW == 4u)
                 {

--- a/library/include/rocwmma/internal/mma_config.hpp
+++ b/library/include/rocwmma/internal/mma_config.hpp
@@ -78,17 +78,21 @@ namespace rocwmma
 
         // Input transforms
         using PreMmaXFormA = register_layout_transform<typename IOLayoutA::FragmentLayout,
-                                                       typename IOLayoutA::MmaLayout>;
+                                                       typename IOLayoutA::MmaLayout,
+                                                       1u>;
 
         using PreMmaXFormB = register_layout_transform<typename IOLayoutB::FragmentLayout,
-                                                       typename IOLayoutB::MmaLayout>;
+                                                       typename IOLayoutB::MmaLayout,
+                                                       1u>;
 
         using PreMmaXFormC = register_layout_transform<typename IOLayoutC::FragmentLayout,
-                                                         typename IOLayoutC::MmaLayout>;
+                                                       typename IOLayoutC::MmaLayout,
+                                                       1u>;
 
         // Output accum transform
         using PostMmaXFormD = register_layout_transform<typename IOLayoutD::MmaLayout,
-                                                          typename IOLayoutD::FragmentLayout>;
+                                                        typename IOLayoutD::FragmentLayout,
+                                                        1u>;
 
         // Pack util
         using PackB = typename IOConfigB::PackUtil;

--- a/library/include/rocwmma/rocwmma_transforms_impl.hpp
+++ b/library/include/rocwmma/rocwmma_transforms_impl.hpp
@@ -213,7 +213,7 @@ namespace rocwmma
 
                 auto result = DstFrag{};
                 result.mAccess
-                    = register_layout_transform<SrcLayout, DstLayout>::exec(frag.mAccess);
+                    = register_layout_transform<SrcLayout, DstLayout, WaveCount>::exec(frag.mAccess);
                 return result;
             }
         };

--- a/test/gemm/gemm_driver_impl.hpp
+++ b/test/gemm/gemm_driver_impl.hpp
@@ -260,7 +260,9 @@ namespace rocwmma
         __device__ inline void GemmDriver<GemmDriverT_impl>::localReadA(
             MfmaFragA& fragsA, GetDataType_t<MfmaFragA> const* ldsAddrA, uint32_t ldlds)
         {
-            rocwmma::load_matrix_sync(reinterpret_cast<LRFragA&>(fragsA), ldsAddrA, ldlds);
+            LRFragA lrFragA;
+            rocwmma::load_matrix_sync(lrFragA, ldsAddrA, ldlds);
+            fragsA.mStorage = LdsMapping::formatLRFragA(lrFragA).mStorage;
         }
 
         template <GemmDriverT>
@@ -281,7 +283,9 @@ namespace rocwmma
         __device__ inline void GemmDriver<GemmDriverT_impl>::localReadB(
             MfmaFragB& fragsB, GetDataType_t<MfmaFragB> const* ldsAddrB, uint32_t ldlds)
         {
-            rocwmma::load_matrix_sync(reinterpret_cast<LRFragB&>(fragsB), ldsAddrB, ldlds);
+            LRFragB lrFragB;
+            rocwmma::load_matrix_sync(lrFragB, ldsAddrB, ldlds);
+            fragsB.mStorage = LdsMapping::formatLRFragB(lrFragB).mStorage;
         }
 
         template <GemmDriverT>

--- a/test/gemm/gemm_local_mapping.hpp
+++ b/test/gemm/gemm_local_mapping.hpp
@@ -458,6 +458,20 @@ namespace rocwmma
                     ApplyDataLayout_t<ApplyRegisterFile_t<typename GlobalMapping::GRFragB>,
                                       LayoutLds> const&>(grFragB);
             }
+
+            __device__ constexpr static inline auto
+                formatLRFragA(LRFragA const& lrFragA)
+            {
+                using MfmaLayout = typename GetDataLayout_t<typename GlobalMapping::MfmaFragA>::Orientation;
+                return rocwmma::template applyDataLayout<MfmaLayout, 1u>(lrFragA);
+            }
+
+            __device__ constexpr static inline auto
+                formatLRFragB(LRFragB const& lrFragB)
+            {
+                using MfmaLayout = typename GetDataLayout_t<typename GlobalMapping::MfmaFragB>::Orientation;
+                return rocwmma::template applyDataLayout<MfmaLayout, 1u>(lrFragB);
+            }
         };
 
     } // namespace LocalMapping

--- a/test/gemm/gemm_local_mapping.hpp
+++ b/test/gemm/gemm_local_mapping.hpp
@@ -154,6 +154,20 @@ namespace rocwmma
             {
                 return rocwmma::template applyDataLayout<LayoutLds, WaveCount>(grFragB);
             }
+
+            __device__ constexpr static inline auto
+                formatLRFragA(LRFragA const& lrFragA)
+            {
+                using MfmaLayout = typename GetDataLayout_t<typename GlobalMapping::MfmaFragA>::Orientation;
+                return rocwmma::template applyDataLayout<MfmaLayout, 1u>(applyTranspose(lrFragA));
+            }
+
+            __device__ constexpr static inline auto
+                formatLRFragB(LRFragB const& lrFragB)
+            {
+                using MfmaLayout = typename GetDataLayout_t<typename GlobalMapping::MfmaFragB>::Orientation;
+                return rocwmma::template applyDataLayout<MfmaLayout, 1u>(lrFragB);
+            }
         };
 
         template <typename GlobalMapping, typename LayoutLds>
@@ -282,6 +296,20 @@ namespace rocwmma
                 formatLWFragB(typename GlobalMapping::GRFragB const& grFragB)
             {
                 return applyDataLayout<LayoutLds, WaveCount>(applyTranspose(grFragB));
+            }
+
+            __device__ constexpr static inline auto
+                formatLRFragA(LRFragA const& lrFragA)
+            {
+                using MfmaLayout = typename GetDataLayout_t<typename GlobalMapping::MfmaFragA>::Orientation;
+                return rocwmma::template applyDataLayout<MfmaLayout, 1u>(lrFragA);
+            }
+
+            __device__ constexpr static inline auto
+                formatLRFragB(LRFragB const& lrFragB)
+            {
+                using MfmaLayout = typename GetDataLayout_t<typename GlobalMapping::MfmaFragB>::Orientation;
+                return rocwmma::template applyDataLayout<MfmaLayout, 1u>(applyTranspose(lrFragB));
             }
         };
 


### PR DESCRIPTION
Issue 1: Fixed a returned reference to temp variable
Issue 2: For correctness, interleaved transforms on cooperative fragments must only operate on local (reduced size) frag data. A bit like coop load / store where only the partial frag data is used. Therefore, knowledge of WaveCount is required.
Issue 3: GEMM driver can no longer assume dataLayout changes in mma fragments are free. They must take appropriate transforms route.