### PR TITLE
Moves vector operator overrides from tuple.hpp to vector.hpp

### DIFF
--- a/library/include/rocwmma/internal/tuple.hpp
+++ b/library/include/rocwmma/internal/tuple.hpp
@@ -33,68 +33,13 @@
 
 #endif // !defined(__HIPCC_RTC__)
 
+#include "vector.hpp"
 #include "utility/forward.hpp"
 #include "utility/sequence.hpp"
 #include "utils.hpp"
 
 namespace rocwmma
 {
-    template <typename VecT, unsigned int Rank, typename U>
-    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<VecT, Rank>
-        operator+(non_native_vector_base<VecT, Rank> const& x, U y) noexcept
-    {
-        return non_native_vector_base<VecT, Rank>{x} += non_native_vector_base<VecT, Rank>{y};
-    }
-
-    template <typename VecT, unsigned int Rank, typename U>
-    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<VecT, Rank>
-        operator+(U x, non_native_vector_base<VecT, Rank> const& y) noexcept
-    {
-        return non_native_vector_base<VecT, Rank>{x} += non_native_vector_base<VecT, Rank>{y};
-    }
-
-    template <typename VecT, unsigned int Rank, typename U>
-    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<VecT, Rank>
-        operator-(non_native_vector_base<VecT, Rank> const& x, U y) noexcept
-    {
-        return non_native_vector_base<VecT, Rank>{x} -= non_native_vector_base<VecT, Rank>{y};
-    }
-
-    template <typename VecT, unsigned int Rank, typename U>
-    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<VecT, Rank>
-        operator-(U x, const non_native_vector_base<VecT, Rank>& y) noexcept
-    {
-        return non_native_vector_base<VecT, Rank>{x} -= non_native_vector_base<VecT, Rank>{y};
-    }
-
-    template <typename VecT, unsigned int Rank, typename U>
-    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<VecT, Rank>
-        operator*(const non_native_vector_base<VecT, Rank>& x, U y) noexcept
-    {
-        return non_native_vector_base<VecT, Rank>{x} *= non_native_vector_base<VecT, Rank>{y};
-    }
-
-    template <typename VecT, unsigned int Rank, typename U>
-    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<VecT, Rank>
-        operator*(U x, const non_native_vector_base<VecT, Rank>& y) noexcept
-    {
-        return non_native_vector_base<VecT, Rank>{x} *= non_native_vector_base<VecT, Rank>{y};
-    }
-
-    template <typename VecT, unsigned int Rank, typename U>
-    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<VecT, Rank>
-        operator/(const non_native_vector_base<VecT, Rank>& x, U y) noexcept
-    {
-        return non_native_vector_base<VecT, Rank>{x} /= non_native_vector_base<VecT, Rank>{y};
-    }
-
-    template <typename VecT, unsigned int Rank, typename U>
-    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<VecT, Rank>
-        operator/(U x, const non_native_vector_base<VecT, Rank>& y) noexcept
-    {
-        return non_native_vector_base<VecT, Rank>{x} /= non_native_vector_base<VecT, Rank>{y};
-    }
-
     namespace detail
     {
         template <typename VecT, size_t... Indices>

--- a/library/include/rocwmma/internal/vector.hpp
+++ b/library/include/rocwmma/internal/vector.hpp
@@ -171,32 +171,32 @@ namespace rocwmma
         ROCWMMA_HOST_DEVICE
         constexpr inline VecT& operator/=(const VecT& x_) noexcept;
 
-        ROCWMMA_HOST_DEVICE
-        constexpr inline VecT operator+(const VecT& x_) noexcept;
-
-        ROCWMMA_HOST_DEVICE
-        constexpr inline VecT operator-(const VecT& x_) noexcept;
-
-        ROCWMMA_HOST_DEVICE
-        constexpr inline VecT operator*(const VecT& x_) noexcept;
-
-        ROCWMMA_HOST_DEVICE
-        constexpr inline VecT operator/(const VecT& x_) noexcept;
-
         template <typename U = T, enable_if_integral_t<U>* = nullptr>
         ROCWMMA_HOST_DEVICE inline VecT& operator%=(const VecT& x_) noexcept;
 
+        ROCWMMA_HOST_DEVICE
+        constexpr inline VecT& operator++() noexcept;
+
+        ROCWMMA_HOST_DEVICE
+        constexpr inline VecT operator++(int) noexcept;
+
+        ROCWMMA_HOST_DEVICE
+        constexpr inline VecT& operator--() noexcept;
+
+        ROCWMMA_HOST_DEVICE
+        constexpr inline VecT operator--(int) noexcept;
+
         template <typename U = T, enable_if_signed_t<U>* = nullptr>
         ROCWMMA_HOST_DEVICE inline VecT operator-() const noexcept;
+
+        template <typename U = T, enable_if_integral_t<U>* = nullptr>
+        ROCWMMA_HOST_DEVICE inline VecT operator~() const noexcept;
 
         template <typename U = T, enable_if_integral_t<U>* = nullptr>
         ROCWMMA_HOST_DEVICE inline VecT& operator&=(const VecT& x_) noexcept;
 
         template <typename U = T, enable_if_integral_t<U>* = nullptr>
         ROCWMMA_HOST_DEVICE inline VecT& operator|=(const VecT& x_) noexcept;
-
-        template <typename U = T, enable_if_integral_t<U>* = nullptr>
-        ROCWMMA_HOST_DEVICE inline VecT operator~() const noexcept;
 
         template <typename U = T, enable_if_integral_t<U>* = nullptr>
         ROCWMMA_HOST_DEVICE inline VecT& operator^=(const VecT& x_) noexcept;
@@ -228,6 +228,136 @@ namespace rocwmma
         /// Storage
         T d[Rank];
     };
+
+    template <typename T, unsigned int Rank>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator+(non_native_vector_base<T, Rank> const& x,
+                  non_native_vector_base<T, Rank> const& y) noexcept;
+
+    template <typename T, unsigned int Rank, typename U>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator+(non_native_vector_base<T, Rank> const& x, U y) noexcept;
+
+    template <typename T, unsigned int Rank, typename U>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator+(U x, non_native_vector_base<T, Rank> const& y) noexcept;
+
+    template <typename T, unsigned int Rank>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator-(non_native_vector_base<T, Rank> const& x,
+                  non_native_vector_base<T, Rank> const& y) noexcept;
+
+    template <typename T, unsigned int Rank, typename U>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator-(non_native_vector_base<T, Rank> const& x, U y) noexcept;
+
+    template <typename T, unsigned int Rank, typename U>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator-(U x, non_native_vector_base<T, Rank> const& y) noexcept;
+
+    template <typename T, unsigned int Rank>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator*(non_native_vector_base<T, Rank> const& x,
+                  non_native_vector_base<T, Rank> const& y) noexcept;
+
+    template <typename T, unsigned int Rank, typename U>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator*(non_native_vector_base<T, Rank> const& x, U y) noexcept;
+
+    template <typename T, unsigned int Rank, typename U>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator*(U x, non_native_vector_base<T, Rank> const& y) noexcept;
+
+    template <typename T, unsigned int Rank>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator/(non_native_vector_base<T, Rank> const& x,
+                  non_native_vector_base<T, Rank> const& y) noexcept;
+
+    template <typename T, unsigned int Rank, typename U>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator/(non_native_vector_base<T, Rank> const& x, U y) noexcept;
+
+    template <typename T, unsigned int Rank, typename U>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator/(U x, non_native_vector_base<T, Rank> const& y) noexcept;
+
+    template <typename T, unsigned int Rank, enable_if_integral_t<T>* = nullptr>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator%(non_native_vector_base<T, Rank> const& x,
+                  non_native_vector_base<T, Rank> const& y) noexcept;
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* = nullptr>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator%(non_native_vector_base<T, Rank> const& x, U y) noexcept;
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* = nullptr>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator%(U x, non_native_vector_base<T, Rank> const& y) noexcept;
+
+    template <typename T, unsigned int Rank, enable_if_integral_t<T>* = nullptr>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator&(non_native_vector_base<T, Rank> const& x,
+                  non_native_vector_base<T, Rank> const& y) noexcept;
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* = nullptr>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator&(non_native_vector_base<T, Rank> const& x, U y) noexcept;
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* = nullptr>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator&(U x, non_native_vector_base<T, Rank> const& y) noexcept;
+
+    template <typename T, unsigned int Rank, enable_if_integral_t<T>* = nullptr>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator|(non_native_vector_base<T, Rank> const& x,
+                  non_native_vector_base<T, Rank> const& y) noexcept;
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* = nullptr>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator|(non_native_vector_base<T, Rank> const& x, U y) noexcept;
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* = nullptr>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator|(U x, non_native_vector_base<T, Rank> const& y) noexcept;
+
+    template <typename T, unsigned int Rank, enable_if_integral_t<T>* = nullptr>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator^(non_native_vector_base<T, Rank> const& x,
+                  non_native_vector_base<T, Rank> const& y) noexcept;
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* = nullptr>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator^(non_native_vector_base<T, Rank> const& x, U y) noexcept;
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* = nullptr>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator^(U x, non_native_vector_base<T, Rank> const& y) noexcept;
+
+    template <typename T, unsigned int Rank, enable_if_integral_t<T>* = nullptr>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator>>(non_native_vector_base<T, Rank> const& x,
+                  non_native_vector_base<T, Rank> const& y) noexcept;
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* = nullptr>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator>>(non_native_vector_base<T, Rank> const& x, U y) noexcept;
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* = nullptr>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator>>(U x, non_native_vector_base<T, Rank> const& y) noexcept;
+
+    template <typename T, unsigned int Rank, enable_if_integral_t<T>* = nullptr>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator<<(non_native_vector_base<T, Rank> const& x,
+                  non_native_vector_base<T, Rank> const& y) noexcept;
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* = nullptr>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator<<(non_native_vector_base<T, Rank> const& x, U y) noexcept;
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* = nullptr>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator<<(U x, non_native_vector_base<T, Rank> const& y) noexcept;
 
 } // namespace rocwmma
 

--- a/library/include/rocwmma/internal/vector_impl.hpp
+++ b/library/include/rocwmma/internal/vector_impl.hpp
@@ -343,38 +343,6 @@ namespace rocwmma
     }
 
     template <typename T, unsigned int Rank>
-    ROCWMMA_HOST_DEVICE constexpr inline auto
-        non_native_vector_base<T, Rank>::operator+(const VecT& x_) noexcept -> VecT
-    {
-        auto ret = VecT{*this};
-        return (ret += x_);
-    }
-
-    template <typename T, unsigned int Rank>
-    ROCWMMA_HOST_DEVICE constexpr inline auto
-        non_native_vector_base<T, Rank>::operator-(const VecT& x_) noexcept -> VecT
-    {
-        auto ret = VecT{*this};
-        return (ret -= x_);
-    }
-
-    template <typename T, unsigned int Rank>
-    ROCWMMA_HOST_DEVICE constexpr inline auto
-        non_native_vector_base<T, Rank>::operator*(const VecT& x_) noexcept -> VecT
-    {
-        auto ret = VecT{*this};
-        return (ret *= x_);
-    }
-
-    template <typename T, unsigned int Rank>
-    ROCWMMA_HOST_DEVICE constexpr inline auto
-        non_native_vector_base<T, Rank>::operator/(const VecT& x_) noexcept -> VecT
-    {
-        auto ret = VecT{*this};
-        return (ret /= x_);
-    }
-
-    template <typename T, unsigned int Rank>
     template <typename U, enable_if_integral_t<U>*>
     ROCWMMA_HOST_DEVICE inline auto
         non_native_vector_base<T, Rank>::operator%=(const VecT& x_) noexcept -> VecT&
@@ -383,11 +351,51 @@ namespace rocwmma
     }
 
     template <typename T, unsigned int Rank>
+    ROCWMMA_HOST_DEVICE constexpr inline auto
+        non_native_vector_base<T, Rank>::operator++() noexcept -> VecT&
+    {
+        return *this += VecT{static_cast<T>(1.0f)};
+    }
+
+    template <typename T, unsigned int Rank>
+    ROCWMMA_HOST_DEVICE constexpr inline auto
+        non_native_vector_base<T, Rank>::operator++(int) noexcept -> VecT
+    {
+        auto before(*this);
+        ++(*this);
+        return before;
+    }
+
+    template <typename T, unsigned int Rank>
+    ROCWMMA_HOST_DEVICE constexpr inline auto
+        non_native_vector_base<T, Rank>::operator--() noexcept -> VecT&
+    {
+        return *this -= VecT{static_cast<T>(1.0f)};
+    }
+
+    template <typename T, unsigned int Rank>
+    ROCWMMA_HOST_DEVICE constexpr inline auto
+        non_native_vector_base<T, Rank>::operator--(int) noexcept -> VecT
+    {
+        auto before(*this);
+        --(*this);
+        return before;
+    }
+
+    template <typename T, unsigned int Rank>
     template <typename U, enable_if_signed_t<U>*>
     ROCWMMA_HOST_DEVICE inline auto non_native_vector_base<T, Rank>::operator-() const noexcept
         -> VecT
     {
         return detail::unOp<detail::ArithmeticOp::Minus>(*this, detail::Seq<Rank>{});
+    }
+
+    template <typename T, unsigned int Rank>
+    template <typename U, enable_if_integral_t<U>*>
+    ROCWMMA_HOST_DEVICE inline auto non_native_vector_base<T, Rank>::operator~() const noexcept
+        -> VecT
+    {
+        return detail::unOp<detail::BitwiseOp::Not>(*this, detail::Seq<Rank>{});
     }
 
     // @cond
@@ -406,14 +414,6 @@ namespace rocwmma
         non_native_vector_base<T, Rank>::operator|=(const VecT& x_) noexcept -> VecT&
     {
         return (*this = detail::binOp<detail::BitwiseOp::Or>(*this, x_, detail::Seq<Rank>{}));
-    }
-
-    template <typename T, unsigned int Rank>
-    template <typename U, enable_if_integral_t<U>*>
-    ROCWMMA_HOST_DEVICE inline auto non_native_vector_base<T, Rank>::operator~() const noexcept
-        -> VecT
-    {
-        return detail::unOp<detail::BitwiseOp::Not>(*this, detail::Seq<Rank>{});
     }
 
     template <typename T, unsigned int Rank>
@@ -480,6 +480,227 @@ namespace rocwmma
         non_native_vector_base<T, Rank>::operator<(const VecT& x_) const noexcept -> BoolVecT
     {
         return detail::boolOp<detail::RelationalOp::Lt>(*this, x_, detail::Seq<Rank>{});
+    }
+
+    // External ops
+    template <typename T, unsigned int Rank>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator+(non_native_vector_base<T, Rank> const& x,
+                  non_native_vector_base<T, Rank> const& y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} += y;
+    }
+
+    template <typename T, unsigned int Rank, typename U>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator+(non_native_vector_base<T, Rank> const& x, U y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} += non_native_vector_base<T, Rank>{y};
+    }
+
+    template <typename T, unsigned int Rank, typename U>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator+(U x, non_native_vector_base<T, Rank> const& y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} += y;
+    }
+
+    template <typename T, unsigned int Rank>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator-(non_native_vector_base<T, Rank> const& x,
+                  non_native_vector_base<T, Rank> const& y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} -= y;
+    }
+
+    template <typename T, unsigned int Rank, typename U>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator-(non_native_vector_base<T, Rank> const& x, U y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} -= non_native_vector_base<T, Rank>{y};
+    }
+
+    template <typename T, unsigned int Rank, typename U>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator-(U x, non_native_vector_base<T, Rank> const& y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} -= y;
+    }
+
+    template <typename T, unsigned int Rank>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator*(non_native_vector_base<T, Rank> const& x,
+                  non_native_vector_base<T, Rank> const& y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} *= y;
+    }
+
+    template <typename T, unsigned int Rank, typename U>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator*(non_native_vector_base<T, Rank> const& x, U y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} *= non_native_vector_base<T, Rank>{y};
+    }
+
+    template <typename T, unsigned int Rank, typename U>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator*(U x, non_native_vector_base<T, Rank> const& y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} *= y;
+    }
+
+    template <typename T, unsigned int Rank>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator/(non_native_vector_base<T, Rank> const& x,
+                  non_native_vector_base<T, Rank> const& y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} /= y;
+    }
+
+    template <typename T, unsigned int Rank, typename U>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator/(non_native_vector_base<T, Rank> const& x, U y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} /= non_native_vector_base<T, Rank>{y};
+    }
+
+    template <typename T, unsigned int Rank, typename U>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator/(U x, non_native_vector_base<T, Rank> const& y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} /= y;
+    }
+
+    template <typename T, unsigned int Rank, enable_if_integral_t<T>* /* = nullptr */>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator%(non_native_vector_base<T, Rank> const& x,
+                  non_native_vector_base<T, Rank> const& y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} %= y;
+    }
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* /* = nullptr */>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator%(non_native_vector_base<T, Rank> const& x, U y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} %= non_native_vector_base<T, Rank>{y};
+    }
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* /* = nullptr */>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator%(U x, non_native_vector_base<T, Rank> const& y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} %= y;
+    }
+
+    template <typename T, unsigned int Rank, enable_if_integral_t<T>* /* = nullptr */>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator&(non_native_vector_base<T, Rank> const& x,
+                  non_native_vector_base<T, Rank> const& y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} &= y;
+    }
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* /* = nullptr */>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator&(non_native_vector_base<T, Rank> const& x, U y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} &= non_native_vector_base<T, Rank>{y};
+    }
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* /* = nullptr */>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator&(U x, non_native_vector_base<T, Rank> const& y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} &= y;
+    }
+
+    template <typename T, unsigned int Rank, enable_if_integral_t<T>* /* = nullptr */>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator|(non_native_vector_base<T, Rank> const& x,
+                  non_native_vector_base<T, Rank> const& y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} |= y;
+    }
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* /* = nullptr */>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator|(non_native_vector_base<T, Rank> const& x, U y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} |= non_native_vector_base<T, Rank>{y};
+    }
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* /* = nullptr */>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator|(U x, non_native_vector_base<T, Rank> const& y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} |= y;
+    }
+
+    template <typename T, unsigned int Rank, enable_if_integral_t<T>* /* = nullptr */>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator^(non_native_vector_base<T, Rank> const& x,
+                  non_native_vector_base<T, Rank> const& y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} ^= y;
+    }
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* /* = nullptr */>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator^(non_native_vector_base<T, Rank> const& x, U y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} ^= non_native_vector_base<T, Rank>{y};
+    }
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* /* = nullptr */>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator^(U x, non_native_vector_base<T, Rank> const& y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} ^= y;
+    }
+
+    template <typename T, unsigned int Rank, enable_if_integral_t<T>* /* = nullptr */>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator>>(non_native_vector_base<T, Rank> const& x,
+                  non_native_vector_base<T, Rank> const& y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} >>= y;
+    }
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* /* = nullptr */>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator>>(non_native_vector_base<T, Rank> const& x, U y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} >>= non_native_vector_base<T, Rank>{y};
+    }
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* /* = nullptr */>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator>>(U x, non_native_vector_base<T, Rank> const& y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} >>= y;
+    }
+
+    template <typename T, unsigned int Rank, enable_if_integral_t<T>* /* = nullptr */>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator<<(non_native_vector_base<T, Rank> const& x,
+                  non_native_vector_base<T, Rank> const& y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} <<= y;
+    }
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* /* = nullptr */>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator<<(non_native_vector_base<T, Rank> const& x, U y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} <<= non_native_vector_base<T, Rank>{y};
+    }
+
+    template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* /* = nullptr */>
+    ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
+        operator<<(U x, non_native_vector_base<T, Rank> const& y) noexcept
+    {
+        return non_native_vector_base<T, Rank>{x} <<= y;
     }
 
 } // namespace rocwmma


### PR DESCRIPTION
- Fixes an issue with ambiguous arithmetic operators when compiling interleaved code
- Adds missing incr / decr operators
- Adds more scalar operator overloads