### PR TITLE
Mma refactor

### DIFF
--- a/library/include/rocwmma/internal/layout/matrix_layout_traits_impl.hpp
+++ b/library/include/rocwmma/internal/layout/matrix_layout_traits_impl.hpp
@@ -561,6 +561,7 @@ namespace rocwmma
         {
             using type = ColInlineInt<BlockDim, BlockK, DataT, MmaDim, SplitK>;
         };
+        
         template <typename MatrixLayout>
         struct layout_traits<MatrixLayout, enable_if_t<is_matrix_layout_v<MatrixLayout>>>
             : public matrix_layout_traits<MatrixLayout>

--- a/library/include/rocwmma/internal/mfma.hpp
+++ b/library/include/rocwmma/internal/mfma.hpp
@@ -71,10 +71,8 @@ namespace rocwmma
                  typename MfmaSelector<InputTA, InputTB, ComputeT, BlockM, BlockN, BlockK>::SelectedOp,
                  AccumPolicy>
     {
-        // Sanity check
+        // Op cache
         using SelectedOp = typename MfmaSelector<InputTA, InputTB, ComputeT, BlockM, BlockN, BlockK>::SelectedOp;
-
-        //static_assert(is_same_v<void, SelectedOp>, "NOPE");
 
         // Driver interface from base class Mma:
         // template <typename VecTA, typename VecTB, typename VecTC>

--- a/library/include/rocwmma/internal/mfma_impl.hpp
+++ b/library/include/rocwmma/internal/mfma_impl.hpp
@@ -171,6 +171,8 @@ namespace rocwmma
             }
         };
 
+#if ROCWMMA_ARCH_GFX9
+
         // fp16
         template <typename GfxTarget>
         struct amdgcn_mfma<float16_t,
@@ -799,7 +801,7 @@ namespace rocwmma
             ROCWMMA_DEVICE static inline auto
                 exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
             {
-                
+
                 DRegsT result;
                 result.data
                     = {__builtin_amdgcn_mfma_i32_16x16x64_i8(regsA.data,
@@ -1588,6 +1590,8 @@ namespace rocwmma
                 return result;
             }
         };
+
+#endif // ROCWMMA_ARCH_GFX9
 
     } // namespace detail
 

--- a/library/include/rocwmma/internal/mma.hpp
+++ b/library/include/rocwmma/internal/mma.hpp
@@ -40,6 +40,16 @@ namespace rocwmma
         COL_MAJOR = 1u,
     };
 
+    /*! \class Mma
+    *   \brief Driver for the wave-tile Mma operation. Given a backend block-wise mma implementation (e.g., mfma or wmma),
+    * this class performs block-wise decomposition to matrix-multiply input fragments of (A: FragM x FragK) x (B: FragK x FragN)
+    * and accumulates results into output fragment (C: FragM x FragN).
+    *  @tparam FragM Mma fragment M dimension
+    *  @tparam FragN Mma fragment K dimension
+    *  @tparam FragK Mma fragment M dimension
+    *  @tparam MmaImpl The backend wrapper class that will perform block-wise mma op (e.g., mfma or wmma)
+    *  @tparam MmaAccumPolicy The block order of the accumulation registers (row major or col major block order)
+    */
     template <uint32_t FragM,
             uint32_t FragN,
             uint32_t FragK,

--- a/library/include/rocwmma/internal/mma_selector.hpp
+++ b/library/include/rocwmma/internal/mma_selector.hpp
@@ -43,7 +43,7 @@ namespace rocwmma
     struct MmaSelector
     {
         private:
-        static_assert((BlockKTest & (BlockKTest - 1) == 0u), "BlockK must be a power of 2");
+        static_assert((BlockKTest & (BlockKTest - 1)) == 0u, "BlockK must be a power of 2");
 
         // Candidate operation for the current params
         using CandidateOp = Mma_impl<InputTA, InputTB, ComputeT, BlockM, BlockN, BlockKTest>;

--- a/library/include/rocwmma/internal/mma_selector.hpp
+++ b/library/include/rocwmma/internal/mma_selector.hpp
@@ -30,7 +30,7 @@
 
 namespace rocwmma
 {
-    
+
     // Inputs BlockM and BlockN are expected to be fixed (e.g., determined previously by other means).
     // This class will attempt to find appropriate BlockK and map to a backend if it exists.
     template<template<typename, typename, typename, uint32_t, uint32_t, uint32_t> class Mma_impl,
@@ -47,12 +47,13 @@ namespace rocwmma
 
         // Candidate operation for the current params
         using CandidateOp = Mma_impl<InputTA, InputTB, ComputeT, BlockM, BlockN, BlockKTest>;
-        using Traits = MmaTraits<CandidateOp>;
+        using CandidateTraits = MmaTraits<CandidateOp>;
 
         public:
         // If the candidate is supported (e.g., a backend implementation exists), then select it.
-        // Otherwise, test another implementation with a smaller BlockK.
-        using SelectedOp = conditional_t<Traits::is_supported, 
+        // Otherwise, test another smaller BlockK. If no existing implementations, keep the current
+        // candidate.
+        using SelectedOp = conditional_t<CandidateTraits::is_supported,
                                         CandidateOp,
                                         typename MmaSelector<Mma_impl, InputTA, InputTB, ComputeT, BlockM, BlockN, BlockKTest / 2u>::SelectedOp>;
     };

--- a/library/include/rocwmma/internal/mma_selector.hpp
+++ b/library/include/rocwmma/internal/mma_selector.hpp
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef ROCWMMA_MMA_SELECTOR_HPP
+#define ROCWMMA_MMA_SELECTOR_HPP
+
+#include "mma_traits.hpp"
+
+namespace rocwmma
+{
+    
+    // Inputs BlockM and BlockN are expected to be fixed (e.g., determined previously by other means).
+    // This class will attempt to find appropriate BlockK and map to a backend if it exists.
+    template<template<typename, typename, typename, uint32_t, uint32_t, uint32_t> class Mma_impl,
+             typename InputTA,
+             typename InputTB,
+             typename ComputeT,
+             uint32_t BlockM,
+             uint32_t BlockN,
+             uint32_t BlockKTest = 64u> // Current max possible K-value for backend instr (most efficient)
+    struct MmaSelector
+    {
+        private:
+        static_assert(BlockKTest % 2u == 0u, "BlockK must be a multiple of 2");
+
+        // Candidate operation for the current params
+        using CandidateOp = Mma_impl<InputTA, InputTB, ComputeT, BlockM, BlockN, BlockKTest>;
+        using Traits = MmaTraits<CandidateOp>;
+
+        public:
+        // If the candidate is supported (e.g., a backend implementation exists), then select it.
+        // Otherwise, test another implementation with a smaller BlockK.
+        using SelectedOp = conditional_t<Traits::is_supported, 
+                                        CandidateOp,
+                                        typename MmaSelector<Mma_impl, InputTA, InputTB, ComputeT, BlockM, BlockN, BlockKTest / 2u>::SelectedOp>;
+    };
+
+    template<template<typename, typename, typename, uint32_t, uint32_t, uint32_t> class Mma_impl,
+             typename InputTA,
+             typename InputTB,
+             typename ComputeT,
+             uint32_t BlockM,
+             uint32_t BlockN>
+    struct MmaSelector<Mma_impl, InputTA, InputTB, ComputeT, BlockM, BlockN, 1u>
+    {
+        // Mma_impl will just be a pass-through if no instruction is found
+        using SelectedOp = Mma_impl<InputTA, InputTB, ComputeT, BlockM, BlockN, 1u>;
+    };
+
+} // namespace rocwmma
+
+#endif // ROCWMMA_MMA_SELECTOR_HPP

--- a/library/include/rocwmma/internal/mma_selector.hpp
+++ b/library/include/rocwmma/internal/mma_selector.hpp
@@ -43,7 +43,7 @@ namespace rocwmma
     struct MmaSelector
     {
         private:
-        static_assert(BlockKTest % 2u == 0u, "BlockK must be a multiple of 2");
+        static_assert((BlockKTest & (BlockKTest - 1) == 0u), "BlockK must be a power of 2");
 
         // Candidate operation for the current params
         using CandidateOp = Mma_impl<InputTA, InputTB, ComputeT, BlockM, BlockN, BlockKTest>;

--- a/library/include/rocwmma/internal/mma_traits.hpp
+++ b/library/include/rocwmma/internal/mma_traits.hpp
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef ROCWMMA_MMA_TRAITS_HPP
+#define ROCWMMA_MMA_TRAITS_HPP
+
+#include "mma_traits_impl.hpp"
+
+namespace rocwmma
+{
+    template<typename MmaOp>
+    struct MmaTraits : public MmaTraits_impl::MmaTraits<MmaOp>
+    {
+        // The following traits will have to be filled
+        // by the mfma and the wmma backends
+
+        // using Impl = amdgcn_mfma/wmma<...>;
+
+        // Operand types
+        // using InputTA = ...;
+        // using InputTB = ...;
+        // using ComputeT = ...;
+
+        // Raw input / output types
+        // using ARegsT = ...;
+        // using BRegsT = ...;
+        // using CRegsT = ...;
+        // using DRegsT = ...;
+
+        // Geometric block sizes
+        // constexpr static uint32_t BlockM = ...;
+        // constexpr static uint32_t BlockN = ...;
+        // constexpr static uint32_t BlockK = ...;
+
+        // Vector sizes per block (packed)
+        // constexpr static uint32_t BlockSizeA = ...;
+        // constexpr static uint32_t BlockSizeB = ...;
+        // constexpr static uint32_t BlockSizeC = ...;
+
+        // Backend flags
+        // constexpr static bool is_wmma = ...;
+        // constexpr static bool is_mfma = ...;
+        // constexpr static bool is_supported = ...;
+    };
+
+} // namespace rocwmma
+
+#endif // ROCWMMA_MMA_TRAITS_HPP

--- a/library/include/rocwmma/internal/mma_traits_impl.hpp
+++ b/library/include/rocwmma/internal/mma_traits_impl.hpp
@@ -34,7 +34,7 @@ namespace rocwmma
     {
         // This interface will be specialized by each
         // Mma operation backed, e.g., mfma and wmma.
-        // The interface in mma_traits.hpp is expected to 
+        // The interface in mma_traits.hpp is expected to
         // be filled by the backends.
         template<typename MmaOp, typename Enabler = void>
         struct MmaTraits;
@@ -44,6 +44,7 @@ namespace rocwmma
 } // namespace rocwmma
 
 // Backend fulfillments
+
 #include "mfma_impl.hpp"
 #include "wmma_impl.hpp"
 

--- a/library/include/rocwmma/internal/mma_traits_impl.hpp
+++ b/library/include/rocwmma/internal/mma_traits_impl.hpp
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef ROCWMMA_MMA_TRAITS_IMPL_HPP
+#define ROCWMMA_MMA_TRAITS_IMPL_HPP
+
+#include "mma_traits.hpp"
+
+namespace rocwmma
+{
+    namespace MmaTraits_impl
+    {
+        // This interface will be specialized by each
+        // Mma operation backed, e.g., mfma and wmma.
+        // The interface in mma_traits.hpp is expected to 
+        // be filled by the backends.
+        template<typename MmaOp, typename Enabler = void>
+        struct MmaTraits;
+
+    } // namespace MmaTraits_impl
+
+} // namespace rocwmma
+
+// Backend fulfillments
+#include "mfma_impl.hpp"
+#include "wmma_impl.hpp"
+
+#endif // ROCWMMA_MMA_TRAITS_IMPL_HPP

--- a/library/include/rocwmma/internal/wmma.hpp
+++ b/library/include/rocwmma/internal/wmma.hpp
@@ -68,6 +68,10 @@ namespace rocwmma
                  typename WmmaSelector<InputTA, InputTB, ComputeT, BlockM, BlockN, BlockK>::SelectedOp,
                  AccumPolicy>
     {
+
+        // Op cache
+        using SelectedOp = typename WmmaSelector<InputTA, InputTB, ComputeT, BlockM, BlockN, BlockK>::SelectedOp;
+
         // Driver interface from base class Mma:
         // template <typename VecTA, typename VecTB, typename VecTC>
         // ROCWMMA_DEVICE static inline decltype(auto) exec(VecTA&& a, VecTB&& b, VecTC& accum);


### PR DESCRIPTION
* Mfma and wmma wrappers to have BlockK template parameter to disambiguate instructions
* Refactored MmaTraits class to have isSupported tag to identify whether a backend instruction supports the requested block sizes.
* Mma class now uses an MmaSelector to select the appropriate BlockK dimension for the mfma/wmma backend.
* Fixes missing F64 mfma on gfx950
* Fixes incorrect input arg types for extended f16/bf16 mfma on gfx950