### PR TITLE
Partials

### DIFF
--- a/library/include/rocwmma/internal/convert.hpp
+++ b/library/include/rocwmma/internal/convert.hpp
@@ -38,7 +38,7 @@ namespace rocwmma
         template <typename InputT, typename OutputT>
         struct amdgcn_convert
         {
-            template <uint32_t NumRegs>
+            template <template <typename, uint32_t> class VecT, uint32_t NumRegs>
             ROCWMMA_DEVICE static inline auto exec(VecT<InputT, NumRegs> const& regsIn)
                 -> VecT<OutputT, NumRegs>
             {
@@ -57,7 +57,7 @@ namespace rocwmma
         struct amdgcn_convert<T, T>
         {
             template <typename IncomingT>
-            ROCWMMA_DEVICE static inline auto exec(IncomingT&& regsIn) -> IncomingT&&
+            ROCWMMA_DEVICE static inline decltype(auto) exec(IncomingT&& regsIn)
             {
                 return forward<IncomingT>(regsIn);
             }
@@ -67,9 +67,8 @@ namespace rocwmma
         template <>
         struct amdgcn_convert<hfloat16_t, float32_t>
         {
-            template <uint32_t NumRegs>
+            template <template <typename, uint32_t> class VecT, uint32_t NumRegs>
             ROCWMMA_DEVICE static inline auto exec(VecT<hfloat16_t, NumRegs> const& regsIn)
-                -> VecT<float32_t, NumRegs>
             {
                 VecT<float32_t, NumRegs> result;
 
@@ -85,9 +84,8 @@ namespace rocwmma
         template <>
         struct amdgcn_convert<float32_t, hfloat16_t>
         {
-            template <uint32_t NumRegs>
+            template <template <typename, uint32_t> class VecT, uint32_t NumRegs>
             ROCWMMA_DEVICE static inline auto exec(VecT<float32_t, NumRegs> const& regsIn)
-                -> VecT<hfloat16_t, NumRegs>
             {
                 VecT<hfloat16_t, NumRegs> result;
 

--- a/library/include/rocwmma/internal/coop_io_bearer.hpp
+++ b/library/include/rocwmma/internal/coop_io_bearer.hpp
@@ -31,26 +31,42 @@
 
 namespace rocwmma
 {
+    //! @struct CoopIOBearer
+    //! @brief CoopIOBearer is the vehicle that executes BearerPolicy transactions iteratively through the coordinate space
+    //! offsets given by the MatrixLayout, while checking and applying bounds controls. Additional logic is present to manage
+    //! splitting load between waves.
+    //! @tparam DataLayout The class that handles the configuration of the 1d data layout.
+    //! @tparam CoopMatrixLayout The class that handles the configuration of the 2d iterative space in which the BearerPolicy is applied.
+    //! It is a basic MatrixLayout wrapped in the MatrixCoopLayout class to get access to WaveCount and splitting properties.
+    //! @tparam BearerPolicy Typically represents a memory transaction such as a store or load, described by data type and vector size.
+    //! @tparam BoundsCtrl Checks bounding box boundary violations by the BearerPolicy and may apply adjustments to the violating buffer.
     template <class DataLayout,
               class CoopMatrixLayout,
               template <typename, uint32_t>
-              class BearerPolicy>
-    struct CoopIOBearer : public IOBearer<DataLayout, CoopMatrixLayout, BearerPolicy>
+              class BearerPolicy,
+              class BoundsCtrl>
+    struct CoopIOBearer : public IOBearer<DataLayout, CoopMatrixLayout, BearerPolicy, BoundsCtrl>
     {
-    private:
+    protected:
         // Traits
-        using Base               = IOBearer<DataLayout, CoopMatrixLayout, BearerPolicy>;
+        using Base               = IOBearer<DataLayout, CoopMatrixLayout, BearerPolicy, BoundsCtrl>;
         using MatrixLayoutTraits = layout_traits<CoopMatrixLayout>;
         using DataLayoutTraits   = layout_traits<DataLayout>;
         using DataT              = typename MatrixLayoutTraits::DataT;
 
-        // Iterative chunk buffer for unroll decomposition
-        using Bearer                        = BearerPolicy<DataT, MatrixLayoutTraits::VectorWidth>;
-        static constexpr uint32_t ChunkSize = Base::ChunkSize;
-        static constexpr uint32_t WaveCount = MatrixLayoutTraits::WaveCount;
+        // Iterative transaction buffer for unroll decomposition
+        static constexpr uint32_t TransactionSize = Base::TransactionSize;
+        static constexpr uint32_t WaveCount       = MatrixLayoutTraits::WaveCount;
+        using Bearer                              = BearerPolicy<DataT, TransactionSize>;
 
-        // Outer loop = index 0,
-        // Inner loop = index N-1
+        //! @brief Loop-unroll to cover all transactions described by MatrixLayout strides
+        //! @tparam Depth The loop recursion depth (Default 0)
+        //! @tparam Iterator a given iterator on a given buffer for the current depth
+        //! @tparam ExternDataT The type of the pointer given by the user
+        //! @tparam StrideSpace The iteration counts of strides at each depth
+        //! @tparam Strides2d The 2d offset strides at each depth
+        //! @note This class is used for both load / store transactions, so the ExternDataT
+        //! is intended to be opaque on the const-ness.
         template <size_t Depth = 0,
                   typename Iterator,
                   typename ExternDataT,
@@ -60,97 +76,34 @@ namespace rocwmma
                                                       ExternDataT*  dataPtr,
                                                       uint32_t      ldm,
                                                       StrideSpace&& strideCounts,
-                                                      Strides2d&&   strides2d)
-        {
-            static_assert(VecTraits<decay_t<StrideSpace>>::size()
-                              == VecTraits<decay_t<Strides2d>>::size(),
-                          "Mismatched size");
-            auto strideOffset = DataLayout::fromMatrixCoord(get<Depth>(strides2d), ldm);
-            auto strideCount  = get<Depth>(strideCounts);
-
-            // Last depth layer will invoke the load
-            if constexpr(Depth == (VecTraits<decay_t<StrideSpace>>::size() - 1u))
-            {
-                for(uint32_t i = 0u; i < strideCount; i++)
-                {
-                    Bearer::exec(*it, dataPtr);
-                    dataPtr += strideOffset;
-                    it++;
-                }
-            }
-            // Recurse to the next nested layer
-            else
-            {
-                for(uint32_t i = 0u; i < strideCount; i++)
-                {
-                    unroll_impl<Depth + 1>(forward<Iterator&>(it),
-                                           dataPtr,
-                                           ldm,
-                                           forward<StrideSpace>(strideCounts),
-                                           forward<Strides2d>(strides2d));
-
-                    dataPtr += strideOffset;
-                }
-            }
-        }
+                                                      Strides2d&&   strides2d);
 
     public:
-        // Forwards to base class static unroll using static WaveCount
+        //! @brief Interface driver for loop-unroll to cover all transactions described by MatrixLayout strides
+        //! @tparam BufferT The buffer full buffer segment for all transactions
+        //! @tparam ExternDataT The type of the pointer given by the user
+        //! @note This class is used for both load / store transactions, so the ExternDataT
+        //! is intended to be opaque on the const-ness.
         template <typename BufferT, typename ExternDataT>
-        ROCWMMA_DEVICE static void
-            exec(BufferT&& buffer, ExternDataT* dataPtr, uint32_t ldm, uint32_t waveIndex)
-        {
-            // Filter out waves we don't want participating
-            if(!CoopMatrixLayout::waveEnabler(waveIndex, WaveCount))
-            {
-                return;
-            }
+        ROCWMMA_DEVICE static inline void
+            exec(BufferT&& buffer, ExternDataT* dataPtr, uint32_t ldm, uint32_t waveIndex);
 
-            // The base offset will include the wave offset
-            auto baseOffset = CoopMatrixLayout::baseOffset(waveIndex, WaveCount);
-
-            // We need to shrink the buffer for the unroll
-            constexpr auto BuffSize
-                = reduce_mult(CoopMatrixLayout::strideCounts(WaveCount)) * ChunkSize;
-            using ReducedBufferT = conditional_t<is_const_v<BufferT>,
-                                                 VecT<DataT, BuffSize> const,
-                                                 VecT<DataT, BuffSize>>;
-
-            // Base can unroll statically
-            Base::unroll_impl((ReducedBufferT&)(buffer),
-                              dataPtr + DataLayout::fromMatrixCoord(baseOffset, ldm),
-                              ldm);
-        }
-
-        // Forwards to iterative unroll because waveCount override may not be known at compile time.
+        //! @brief Interface driver for loop-unroll to cover all transactions described by MatrixLayout strides
+        //! @tparam BufferT The buffer full buffer segment for all transactions
+        //! @tparam ExternDataT The type of the pointer given by the user
+        //! @note This class is used for both load / store transactions, so the ExternDataT
+        //! is intended to be opaque on the const-ness.
+        //! This interface provides a run-time waveCount in case the WaveCount is not known at compile-time.
         template <typename BufferT, typename ExternDataT>
-        ROCWMMA_DEVICE static void exec(BufferT&&    buffer,
-                                        ExternDataT* dataPtr,
-                                        uint32_t     ldm,
-                                        uint32_t     waveIndex,
-                                        uint32_t     waveCount)
-        {
-            // Filter out waves we don't want participating
-            if(!CoopMatrixLayout::waveEnabler(waveIndex, waveCount))
-            {
-                return;
-            }
-
-            // The base offset will include the wave offset
-            auto baseOffset = CoopMatrixLayout::baseOffset(waveIndex, waveCount);
-
-            // Each basic transaction will be of ChunkSize
-            auto it = makeVectorIterator<ChunkSize>(buffer).begin();
-
-            // Alternative iterative unroll
-            unroll_impl(it,
-                        dataPtr + DataLayout::fromMatrixCoord(baseOffset, ldm),
-                        ldm,
-                        CoopMatrixLayout::strideCounts(waveCount),
-                        CoopMatrixLayout::strides());
-        }
+        ROCWMMA_DEVICE static inline void exec(BufferT&&    buffer,
+                                               ExternDataT* dataPtr,
+                                               uint32_t     ldm,
+                                               uint32_t     waveIndex,
+                                               uint32_t     waveCount);
     };
 
 } // namespace rocwmma
+
+#include "coop_io_bearer_impl.hpp"
 
 #endif // ROCWMMA_COOP_IO_BEARER_HPP

--- a/library/include/rocwmma/internal/coop_io_bearer_impl.hpp
+++ b/library/include/rocwmma/internal/coop_io_bearer_impl.hpp
@@ -28,6 +28,7 @@
 
 #include "io_bearer.hpp"
 #include "layout/matrix_coop_layout.hpp"
+#include "utility/math.hpp"
 #include "vector.hpp"
 
 namespace rocwmma
@@ -39,51 +40,56 @@ namespace rocwmma
         class BearerPolicy, class BoundsCtrl
 #define CoopIOBearerTypesImpl DataLayout, CoopMatrixLayout, BearerPolicy, BoundsCtrl
 
-    // Outer loop = index 0,
-    // Inner loop = index N-1
+    // Forwards to iterative unroll because waveCount override may not be known at compile time.
     template <CoopIOBearerTypesDecl>
-    template <size_t Depth /*= 0*/,
-              typename Iterator,
-              typename ExternDataT,
-              typename StrideSpace,
-              typename Strides2d>
-    ROCWMMA_DEVICE inline auto
-        CoopIOBearer<CoopIOBearerTypesImpl>::unroll_impl(Iterator&     it,
-                                                         ExternDataT*  dataPtr,
-                                                         uint32_t      ldm,
-                                                         StrideSpace&& strideCounts,
-                                                         Strides2d&&   strides2d)
+    template <typename BufferT, typename ExternDataT>
+    ROCWMMA_DEVICE inline void CoopIOBearer<CoopIOBearerTypesImpl>::exec(BufferT&&    buffer,
+                                                                         ExternDataT* dataPtr,
+                                                                         uint32_t     ldm,
+                                                                         uint32_t     waveIndex,
+                                                                         uint32_t     waveCount)
     {
-        static_assert(VecTraits<decay_t<StrideSpace>>::size()
-                          == VecTraits<decay_t<Strides2d>>::size(),
-                      "Mismatched size");
-        auto strideOffset = DataLayout::fromMatrixCoord(get<Depth>(strides2d), ldm);
-        auto strideCount  = get<Depth>(strideCounts);
-
-        // Last depth layer will invoke the load
-        if constexpr(Depth == (VecTraits<decay_t<StrideSpace>>::size() - 1u))
+        // Filter out waves we don't want participating
+        if(!CoopMatrixLayout::waveEnabler(waveIndex, waveCount))
         {
-            for(uint32_t i = 0u; i < strideCount; i++)
-            {
-                Bearer::exec(*it, dataPtr);
-                dataPtr += strideOffset;
-                it++;
-            }
+            return;
         }
-        // Recurse to the next nested layer
-        else
-        {
-            for(uint32_t i = 0u; i < strideCount; i++)
-            {
-                unroll_impl<Depth + 1>(forward<Iterator&>(it),
-                                       dataPtr,
-                                       ldm,
-                                       forward<StrideSpace>(strideCounts),
-                                       forward<Strides2d>(strides2d));
 
-                dataPtr += strideOffset;
-            }
-        }
+        // The base offset will include the wave offset
+        auto baseOffset = CoopMatrixLayout::baseOffset(waveIndex, waveCount);
+
+        // Dispatch run-time wave count to the IOBearer class
+        static_for<0u, 3u, 1u>(
+            [](auto&& idx,
+               auto   waveCount,
+               auto&& buffer,
+               auto&& baseOffset,
+               auto*  dataPtr,
+               auto   ldm) {
+                // Wave counts only supported as powers of 2
+                constexpr auto Idx       = pow2<decay_t<decltype(idx)>::value>::value;
+                bool           processed = false;
+
+                if(Idx == waveCount && !processed)
+                {
+                    // We need to shrink the buffer for the unroll
+                    constexpr auto BuffSize
+                        = reduce_mult(CoopMatrixLayout::strideCounts(Idx)) * TransactionSize;
+                    using ReducedBufferT = conditional_t<is_const_v<BufferT>,
+                                                         VecT<DataT, BuffSize> const,
+                                                         VecT<DataT, BuffSize>>;
+
+                    // Base can unroll statically
+                    Base::unroll_impl((ReducedBufferT&)(buffer), baseOffset, dataPtr, ldm);
+
+                    processed = true;
+                }
+            },
+            waveCount,
+            forward<BufferT>(buffer),
+            baseOffset,
+            dataPtr,
+            ldm);
     }
 
     // Forwards to base class static unroll using static WaveCount
@@ -112,35 +118,6 @@ namespace rocwmma
 
         // Base can unroll statically
         Base::unroll_impl((ReducedBufferT&)(buffer), baseOffset, dataPtr, ldm);
-    }
-
-    // Forwards to iterative unroll because waveCount override may not be known at compile time.
-    template <CoopIOBearerTypesDecl>
-    template <typename BufferT, typename ExternDataT>
-    ROCWMMA_DEVICE inline void CoopIOBearer<CoopIOBearerTypesImpl>::exec(BufferT&&    buffer,
-                                                                         ExternDataT* dataPtr,
-                                                                         uint32_t     ldm,
-                                                                         uint32_t     waveIndex,
-                                                                         uint32_t     waveCount)
-    {
-        // Filter out waves we don't want participating
-        if(!CoopMatrixLayout::waveEnabler(waveIndex, waveCount))
-        {
-            return;
-        }
-
-        // The base offset will include the wave offset
-        auto baseOffset = CoopMatrixLayout::baseOffset(waveIndex, waveCount);
-
-        // Each basic transaction will be of TransactionSize
-        auto it = makeVectorIterator<TransactionSize>(buffer).begin();
-
-        // Alternative iterative unroll
-        unroll_impl(it,
-                    dataPtr + DataLayout::fromMatrixCoord(baseOffset, ldm),
-                    ldm,
-                    CoopMatrixLayout::strideCounts(waveCount),
-                    CoopMatrixLayout::strides());
     }
 
 #undef CoopIOBearerTypesDecl

--- a/library/include/rocwmma/internal/coop_io_bearer_impl.hpp
+++ b/library/include/rocwmma/internal/coop_io_bearer_impl.hpp
@@ -1,0 +1,151 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef ROCWMMA_COOP_IO_BEARER_IMPL_HPP
+#define ROCWMMA_COOP_IO_BEARER_IMPL_HPP
+
+#include "io_bearer.hpp"
+#include "layout/matrix_coop_layout.hpp"
+#include "vector.hpp"
+
+namespace rocwmma
+{
+
+#define CoopIOBearerTypesDecl                 \
+    class DataLayout, class CoopMatrixLayout, \
+        template <typename, uint32_t>         \
+        class BearerPolicy, class BoundsCtrl
+#define CoopIOBearerTypesImpl DataLayout, CoopMatrixLayout, BearerPolicy, BoundsCtrl
+
+    // Outer loop = index 0,
+    // Inner loop = index N-1
+    template <CoopIOBearerTypesDecl>
+    template <size_t Depth /*= 0*/,
+              typename Iterator,
+              typename ExternDataT,
+              typename StrideSpace,
+              typename Strides2d>
+    ROCWMMA_DEVICE inline auto
+        CoopIOBearer<CoopIOBearerTypesImpl>::unroll_impl(Iterator&     it,
+                                                         ExternDataT*  dataPtr,
+                                                         uint32_t      ldm,
+                                                         StrideSpace&& strideCounts,
+                                                         Strides2d&&   strides2d)
+    {
+        static_assert(VecTraits<decay_t<StrideSpace>>::size()
+                          == VecTraits<decay_t<Strides2d>>::size(),
+                      "Mismatched size");
+        auto strideOffset = DataLayout::fromMatrixCoord(get<Depth>(strides2d), ldm);
+        auto strideCount  = get<Depth>(strideCounts);
+
+        // Last depth layer will invoke the load
+        if constexpr(Depth == (VecTraits<decay_t<StrideSpace>>::size() - 1u))
+        {
+            for(uint32_t i = 0u; i < strideCount; i++)
+            {
+                Bearer::exec(*it, dataPtr);
+                dataPtr += strideOffset;
+                it++;
+            }
+        }
+        // Recurse to the next nested layer
+        else
+        {
+            for(uint32_t i = 0u; i < strideCount; i++)
+            {
+                unroll_impl<Depth + 1>(forward<Iterator&>(it),
+                                       dataPtr,
+                                       ldm,
+                                       forward<StrideSpace>(strideCounts),
+                                       forward<Strides2d>(strides2d));
+
+                dataPtr += strideOffset;
+            }
+        }
+    }
+
+    // Forwards to base class static unroll using static WaveCount
+    template <CoopIOBearerTypesDecl>
+    template <typename BufferT, typename ExternDataT>
+    ROCWMMA_DEVICE inline void CoopIOBearer<CoopIOBearerTypesImpl>::exec(BufferT&&    buffer,
+                                                                         ExternDataT* dataPtr,
+                                                                         uint32_t     ldm,
+                                                                         uint32_t     waveIndex)
+    {
+        // Filter out waves we don't want participating
+        if(!CoopMatrixLayout::waveEnabler(waveIndex, WaveCount))
+        {
+            return;
+        }
+
+        // The base offset will include the wave offset
+        auto baseOffset = CoopMatrixLayout::baseOffset(waveIndex, WaveCount);
+
+        // We need to shrink the buffer for the unroll
+        constexpr auto BuffSize
+            = reduce_mult(CoopMatrixLayout::strideCounts(WaveCount)) * TransactionSize;
+        using ReducedBufferT = conditional_t<is_const_v<BufferT>,
+                                             VecT<DataT, BuffSize> const,
+                                             VecT<DataT, BuffSize>>;
+
+        // Base can unroll statically
+        Base::unroll_impl((ReducedBufferT&)(buffer), baseOffset, dataPtr, ldm);
+    }
+
+    // Forwards to iterative unroll because waveCount override may not be known at compile time.
+    template <CoopIOBearerTypesDecl>
+    template <typename BufferT, typename ExternDataT>
+    ROCWMMA_DEVICE inline void CoopIOBearer<CoopIOBearerTypesImpl>::exec(BufferT&&    buffer,
+                                                                         ExternDataT* dataPtr,
+                                                                         uint32_t     ldm,
+                                                                         uint32_t     waveIndex,
+                                                                         uint32_t     waveCount)
+    {
+        // Filter out waves we don't want participating
+        if(!CoopMatrixLayout::waveEnabler(waveIndex, waveCount))
+        {
+            return;
+        }
+
+        // The base offset will include the wave offset
+        auto baseOffset = CoopMatrixLayout::baseOffset(waveIndex, waveCount);
+
+        // Each basic transaction will be of TransactionSize
+        auto it = makeVectorIterator<TransactionSize>(buffer).begin();
+
+        // Alternative iterative unroll
+        unroll_impl(it,
+                    dataPtr + DataLayout::fromMatrixCoord(baseOffset, ldm),
+                    ldm,
+                    CoopMatrixLayout::strideCounts(waveCount),
+                    CoopMatrixLayout::strides());
+    }
+
+#undef CoopIOBearerTypesDecl
+#undef CoopIOBearerTypesImpl
+
+} // namespace rocwmma
+
+#endif // ROCWMMA_COOP_IO_BEARER_IMPL_HPP

--- a/library/include/rocwmma/internal/coop_io_config.hpp
+++ b/library/include/rocwmma/internal/coop_io_config.hpp
@@ -72,7 +72,7 @@ namespace rocwmma
     {
         using IOShape = IOShape<MatrixT, BlockM, BlockN, BlockK>;
         using IOLayout
-            = IOLayout<MatrixT, IOShape::BlockDim, IOShape::KDim, DataT, DataLayoutT, WaveCount>;
+            = IOLayoutInt<MatrixT, IOShape::BlockDim, IOShape::KDim, DataT, DataLayoutT, WaveCount>;
         using IOTraits = IOTraits<IOShape::BlockDim, IOShape::KDim, DataT, IOLayout::VW>;
 
         using PackUtil = PackUtil<DataT>;

--- a/library/include/rocwmma/internal/coop_io_config.hpp
+++ b/library/include/rocwmma/internal/coop_io_config.hpp
@@ -28,8 +28,10 @@
 
 #include "coop_load.hpp"
 #include "coop_store.hpp"
+#include "io_bounds_ctrl.hpp"
 #include "io_layout.hpp"
 #include "io_shape.hpp"
+#include "io_tile.hpp"
 #include "io_traits.hpp"
 #include "layout/register_layout_transforms.hpp"
 #include "pack_util.hpp"
@@ -44,60 +46,84 @@ namespace rocwmma
      * @{
      */
 
-    /*! \struct CoopIOConfig
- *  \brief Definition of cooperative fragment input / output configurations
- *         in specific matrix context.
- *
- * @tparam Matrix fragment context
- * @tparam BlockM/N/K block dimensions
- * @tparam DataT data type
- * @tparam DataLayoutT in-memory layout as col_major or row_major
- * @param IOShape dimensional properties of the fragment
- * @param IOLayout 1d and 2d layouts of the fragment
- * @param IOTraits meta-properties for input and output of the fragment
- * @param PackUtil utility for packing / unpacking fragment data
- * @param MappingUtil global mapping utility for current fragment
- * @param Loader Issues cooperative load instructions for raw fragment data
- * @param Storer Issues cooperative store instructions for raw fragment data
- */
-
+    //! @struct CoopIOConfig
+    //! @brief Definition of cooperative fragment input / output configurations
+    //!         in specific matrix context.
+    //!
+    //! @tparam Matrix fragment context
+    //! @tparam BlockM/N/K block dimensions
+    //! @tparam DataT data type
+    //! @tparam DataLayoutT in-memory layout as col_major or row_major
+    //! @param IOShape dimensional properties of the fragment
+    //! @param IOLayout 1d and 2d layouts of the fragment
+    //! @param IOTraits meta-properties for input and output of the fragment
+    //! @param PackUtil utility for packing / unpacking fragment data
+    //! @param MappingUtil global mapping utility for current fragment
+    //! @param Loader Issues cooperative load instructions for raw fragment data
+    //! @param Storer Issues cooperative store instructions for raw fragment data
     template <typename MatrixT,
-              uint32_t BlockM,
-              uint32_t BlockN,
-              uint32_t BlockK,
+              uint32_t FragM,
+              uint32_t FragN,
+              uint32_t FragK,
               typename DataT,
               typename DataLayoutT,
               uint32_t WaveCount>
     struct CoopIOConfig
     {
-        using IOShape = IOShape<MatrixT, BlockM, BlockN, BlockK>;
+        // The specific size of the requested fragment
+        using IOBounds = IOShape<MatrixT, FragM, FragN, FragK>;
+
+        // Internally, block-wise decomposition dictates the need for quantized block dimensions.
+        // IOTile will determine ideal block size.
+        using IOTile  = IOTile<FragM, FragN, FragK, DataT>;
+        using IOShape = IOShape<MatrixT, IOTile::BlockM, IOTile::BlockN, IOTile::BlockK>;
+
+        // Bounds control is needed if the original frag size doesn't match block size quantizations.
+        static constexpr bool IOBoundsCtrlRequired
+            = (FragM != IOTile::BlockM) || (FragN != IOTile::BlockN) || (FragK != IOTile::BlockK);
+
+        // Using quantized block dimensions, determine the layout characteristics we will use with
+        // this fragment.
         using IOLayout
             = IOLayoutInt<MatrixT, IOShape::BlockDim, IOShape::KDim, DataT, DataLayoutT, WaveCount>;
+
         using IOTraits = IOTraits<IOShape::BlockDim, IOShape::KDim, DataT, IOLayout::VW>;
 
-        using PackUtil = PackUtil<DataT>;
+        // Define functional classes used during fragment IO workflow operations such as loading / storing
         using MappingUtil
             = MappingUtil<IOShape::BlockHeight, IOShape::BlockWidth, DataT, DataLayoutT>;
 
+        using PackUtil = PackUtil<DataT>;
+
+        // When loading for Mma, we need to replace clipped areas with 0's to ensure correctness.
+        using IOBoundsCtrlLoad = conditional_t<
+            IOBoundsCtrlRequired,
+            IOBoundsCtrl::ClipAndReplace2d<IOBounds::BlockHeight, IOBounds::BlockWidth>,
+            IOBoundsCtrl::Default>;
+
         using Loader = CooperativeLoad<typename IOLayout::DataLayout,
                                        typename IOLayout::MatrixLayout,
-                                       WaveCount>;
+                                       WaveCount,
+                                       IOBoundsCtrlLoad>;
 
         using PostLoadXForm = register_layout_transform<typename IOLayout::StorageLayout,
                                                         typename IOLayout::FragmentLayout,
                                                         WaveCount>;
 
-        using PreMmaXForm = register_layout_transform<typename IOLayout::FragmentLayout,
-                                                      typename IOLayout::MmaLayout,
-                                                      WaveCount>;
-
         using PreStoreXForm = register_layout_transform<typename IOLayout::FragmentLayout,
                                                         typename IOLayout::StorageLayout,
                                                         WaveCount>;
 
+        // Storage requires only clipping.
+        using IOBoundsCtrlStore
+            = conditional_t<IOBoundsCtrlRequired,
+                            IOBoundsCtrl::Clip2d<IOBounds::BlockHeight, IOBounds::BlockWidth>,
+                            IOBoundsCtrl::Default>;
+
         using Storer = CooperativeStore<typename IOLayout::DataLayout,
                                         typename IOLayout::MatrixLayout,
-                                        WaveCount>;
+                                        WaveCount,
+                                        IOBoundsCtrlStore>;
     };
 
     /************************************************
@@ -107,10 +133,11 @@ namespace rocwmma
  * general IOShape, PackUtil, Broadcast still available.
  *
  * */
-    template <uint32_t BlockM, uint32_t BlockN, uint32_t BlockK, typename DataT, uint32_t WaveCount>
-    struct CoopIOConfig<accumulator, BlockM, BlockN, BlockK, DataT, void, WaveCount>
+    template <uint32_t FragM, uint32_t FragN, uint32_t FragK, typename DataT, uint32_t WaveCount>
+    struct CoopIOConfig<accumulator, FragM, FragN, FragK, DataT, void, WaveCount>
     {
-        using IOShape  = IOShape<accumulator, BlockM, BlockN, BlockK>;
+        using IOTile   = IOTile<FragM, FragN, FragK, DataT>;
+        using IOShape  = IOShape<accumulator, IOTile::BlockM, IOTile::BlockN, IOTile::BlockK>;
         using PackUtil = PackUtil<DataT>;
     };
     /** @}*/

--- a/library/include/rocwmma/internal/coop_load.hpp
+++ b/library/include/rocwmma/internal/coop_load.hpp
@@ -27,6 +27,7 @@
 #define ROCWMMA_COOP_LOAD_HPP
 
 #include "coop_io_bearer.hpp"
+#include "io_bounds_ctrl.hpp"
 #include "layout/matrix_coop_layout_impl.hpp"
 #include "opaque_load.hpp"
 
@@ -35,10 +36,14 @@ namespace rocwmma
     using MatrixLayout::MatrixCoopLayout;
 
     // This class wraps an incoming MatrixLayout into a cooperative one
-    template <class DataLayout, class MatrixLayout, uint32_t WaveCount>
+    template <class DataLayout,
+              class MatrixLayout,
+              uint32_t WaveCount,
+              class BoundsCtrl = IOBoundsCtrl::Default>
     struct CooperativeLoad : public CoopIOBearer<DataLayout,
                                                  MatrixCoopLayout<MatrixLayout, WaveCount>,
-                                                 detail::OpaqueLoadBearer>
+                                                 detail::OpaqueLoadBearer,
+                                                 BoundsCtrl>
     {
     };
 

--- a/library/include/rocwmma/internal/coop_store.hpp
+++ b/library/include/rocwmma/internal/coop_store.hpp
@@ -27,6 +27,7 @@
 #define ROCWMMA_COOP_STORE_HPP
 
 #include "coop_io_bearer.hpp"
+#include "io_bounds_ctrl.hpp"
 #include "layout/matrix_coop_layout_impl.hpp"
 #include "opaque_store.hpp"
 
@@ -36,15 +37,20 @@ namespace rocwmma
     using MatrixLayout::MatrixCoopLayout;
 
     // This class wraps an incoming MatrixLayout into a cooperative one
-    template <class DataLayout, class MatrixLayout, uint32_t WaveCount>
+    template <class DataLayout,
+              class MatrixLayout,
+              uint32_t WaveCount,
+              class BoundsCtrl = IOBoundsCtrl::Default>
     struct CooperativeStore : public CoopIOBearer<DataLayout,
                                                   MatrixCoopLayout<MatrixLayout, WaveCount>,
-                                                  detail::OpaqueStoreBearer>
+                                                  detail::OpaqueStoreBearer,
+                                                  BoundsCtrl>
     {
     private:
         using Base = CoopIOBearer<DataLayout,
                                   MatrixCoopLayout<MatrixLayout, WaveCount>,
-                                  detail::OpaqueStoreBearer>;
+                                  detail::OpaqueStoreBearer,
+                                  BoundsCtrl>;
 
         // Don't expose the base implementation, we change arg forwarding order
         using Base::exec;

--- a/library/include/rocwmma/internal/io_bearer.hpp
+++ b/library/include/rocwmma/internal/io_bearer.hpp
@@ -28,107 +28,76 @@
 
 #include "layout/layout.hpp"
 #include "layout/layout_traits.hpp"
-#include "tuple.hpp"
-#include "utility/vector.hpp"
-
+#include "utility/forward.hpp"
 namespace rocwmma
 {
+    //! @struct IOBearer
+    //! @brief IOBearer is the vehicle that executes BearerPolicy transactions iteratively through the coordinate space
+    //! offsets given by the MatrixLayout, while checking and applying bounds controls.
+    //! @tparam DataLayout The class that handles the configuration of the 1d data layout.
+    //! @tparam MatrixLayout The class that handles the configuration of the 2d iterative space in which the BearerPolicy is applied.
+    //! @tparam BearerPolicy Typically represents a memory transaction such as a store or load, described by data type and vector size.
+    //! @tparam BoundsCtrl Checks bounding box boundary violations by the BearerPolicy and may apply adjustments to the violating buffer.
     template <class DataLayout,
               class MatrixLayout,
               template <typename, uint32_t>
-              class BearerPolicy>
+              class BearerPolicy,
+              class BoundsCtrl>
     struct IOBearer
     {
     protected:
+        // Access traits from Matrix and DataLayouts
         using MatrixLayoutTraits = layout_traits<MatrixLayout>;
         using DataLayoutTraits   = layout_traits<DataLayout>;
         using DataT              = typename MatrixLayoutTraits::DataT;
 
-        // Iterative policy traits
-        using Bearer                        = BearerPolicy<DataT, MatrixLayoutTraits::VectorWidth>;
-        static constexpr uint32_t ChunkSize = Bearer::size();
-
-        // Vector type of the bearer
-        template <typename DataT, uint32_t VecSize>
-        using VecT =
-            typename VecTraits<decay_t<typename Bearer::BufferT>>::template VecT<DataT, VecSize>;
+        // Iterative BearerPolicy traits
+        static constexpr uint32_t TransactionSize = MatrixLayoutTraits::VectorWidth;
+        static constexpr uint32_t IterationCount  = reduce_mult(MatrixLayout::strideCounts());
+        static constexpr uint32_t BuffSize        = TransactionSize * IterationCount;
 
     public:
-        // Full buffer traits
-        static constexpr uint32_t BufferSize
-            = ChunkSize * reduce_mult(MatrixLayout::strideCounts());
-        using BufferT = VecT<DataT, BufferSize>;
+        // Full sized buffer for the whole operation
+        using BufferT = typename BearerPolicy<DataT, BuffSize>::BufferT;
 
     protected:
-        // Outer loop = index 0,
-        // Inner loop = index N-1
-        // Notes:
-        // - Assumption: MatrixLayout provides constexpr strideCounts and strides.
-        //   We can then use static unroll to eliminate looping.
-        // - Unroll model will use vector_mutate_for_each because the current bearers are implemented
-        //   as visitor patterns. They either write to, or read from an input vector object.
-        //   The vector needs to be mutable for loads, but the stores will cast as const reference.
-        //   vector_mutate_for_each provides a reference to raw vector data it is operating on, which
-        //   will satisfy both loading and storing visitation needs.
-        template <size_t Depth = 0, typename BuffT, typename ExternDataT>
+        //! @brief Handle partial transactions from front-to-back.
+        //! @tparam PartialCount The number of partial elements in the transaction
+        //! @tparam PBufferT The buffer partial transactions will apply to
+        //! @tparam DataPtrT The base memory data pointer
+        template <uint32_t PartialCount, typename PBufferT, typename DataPtrT>
+        ROCWMMA_DEVICE static inline auto partial_impl(PBufferT& buff, DataPtrT&& dataPtr);
+
+        //! @brief Handle bounds violations from back-to-front.
+        //! @tparam CoundCount The number of boundary violations in the transaction
+        //! @tparam BBufferT The buffer boundary control will apply to
+        //! @tparam ScalarT The datatype of a scalar value to apply in the bounds control
+        template <uint32_t BoundCount, typename BBufferT, typename ScalarT>
+        ROCWMMA_DEVICE static inline auto bounds_impl(BBufferT& buff, ScalarT&& clipVal);
+
+        //! @brief Loop-unroll to cover all transactions described by MatrixLayout strides
+        //! @tparam Depth The loop recursion depth (Default 0)
+        //! @tparam BufferT The buffer segment for the current recursion depth
+        //! @tparam Coord2d The type of the given 2d coordinate object
+        //! @tparam ExternDataT The type of the pointer given by the user
+        //! @note This class is used for both load / store transactions, so the ExternDataT
+        //! is intended to be opaque on the const-ness.
+        template <size_t Depth = 0, typename BufferT, typename Coord2d, typename ExternDataT>
         ROCWMMA_DEVICE static inline auto
-            unroll_impl(BuffT&& buff, ExternDataT* dataPtr, uint32_t ldm)
-        {
-            // Get the layout strides for the current depth
-            constexpr auto StrideSpace = pop_front<Depth>(MatrixLayout::strideCounts());
-            constexpr auto Strides     = pop_front<Depth>(MatrixLayout::strides());
-
-            // Ensure the buffer size is appropriate
-            using BufferTraits = VecTraits<decay_t<BuffT>>;
-            static_assert(BufferTraits::size() == reduce_mult(StrideSpace) * ChunkSize,
-                          "Invalid buffer size");
-
-            constexpr auto CurrentStride     = get_first(Strides);
-            auto           currentDataStride = DataLayout::fromMatrixCoord(CurrentStride, ldm);
-
-            // Last depth layer will invoke the chunk transfer
-            if constexpr((VecTraits<decay_t<decltype(StrideSpace)>>::size()) == 1u)
-            {
-                vector_mutate_for_each<ChunkSize>(
-                    forward<BuffT>(buff),
-                    [](auto&& v, auto idx, auto* dataPtr, auto dataStride) {
-                        uint32_t dataOffset = decay_t<decltype(idx)>::value * dataStride;
-                        Bearer::exec(v, dataPtr + dataOffset);
-                    },
-                    dataPtr,
-                    currentDataStride);
-            }
-            // Recurse to the next nested layer
-            else
-            {
-                constexpr auto NextStrideSpace  = pop_front(StrideSpace);
-                constexpr auto NextBufferStride = reduce_mult(NextStrideSpace) * ChunkSize;
-
-                vector_mutate_for_each<NextBufferStride>(
-                    forward<BuffT>(buff),
-                    [](auto&& v, auto idx, auto* dataPtr, auto ldm, auto dataStride) {
-                        uint32_t dataOffset = decay_t<decltype(idx)>::value * dataStride;
-                        unroll_impl<Depth + 1u>(v, dataPtr + dataOffset, ldm);
-                    },
-                    dataPtr,
-                    ldm,
-                    currentDataStride);
-            }
-        }
+            unroll_impl(BufferT&& buff, Coord2d&& baseOffset2d, ExternDataT* dataPtr, uint32_t ldm);
 
     public:
-        template <typename BuffT, typename ExternDataT>
-        ROCWMMA_DEVICE static void exec(BuffT&& buff, ExternDataT* dataPtr, uint32_t ldm)
-        {
-            // Arrange wave threads to starting matrix layout offsets.
-            auto baseOffset = MatrixLayout::baseOffset();
-
-            // Unroll transfer in each strided dimension
-            unroll_impl(
-                forward<BuffT>(buff), dataPtr + DataLayout::fromMatrixCoord(baseOffset, ldm), ldm);
-        }
+        //! @brief Interface driver for loop-unroll to cover all transactions described by MatrixLayout strides
+        //! @tparam BufferT The buffer full buffer segment for all transactions
+        //! @tparam ExternDataT The type of the pointer given by the user
+        //! @note This class is used for both load / store transactions, so the ExternDataT
+        //! is intended to be opaque on the const-ness.
+        template <typename BufferT, typename ExternDataT>
+        ROCWMMA_DEVICE static inline void exec(BufferT&& buff, ExternDataT* dataPtr, uint32_t ldm);
     };
 
 } // namespace rocwmma
+
+#include "io_bearer_impl.hpp"
 
 #endif // ROCWMMA_IO_BEARER_HPP

--- a/library/include/rocwmma/internal/io_bearer_impl.hpp
+++ b/library/include/rocwmma/internal/io_bearer_impl.hpp
@@ -1,0 +1,446 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef ROCWMMA_IO_BEARER_IMPL_HPP
+#define ROCWMMA_IO_BEARER_IMPL_HPP
+
+#include "layout/layout.hpp"
+#include "layout/layout_traits.hpp"
+#include "tuple.hpp"
+#include "utility/static_for.hpp"
+#include "utility/vector.hpp"
+
+namespace rocwmma
+{
+
+#define IOBearerTypesDecl                 \
+    class DataLayout, class MatrixLayout, \
+        template <typename, uint32_t>     \
+        class BearerPolicy, class BoundsCtrl
+#define IOBearerTypesImpl DataLayout, MatrixLayout, BearerPolicy, BoundsCtrl
+
+    // Operate on the given vector with expected partial values.
+    // Assumption: the original input vector size is a power of 2.
+    // Procedure: Starting from the beginning of the vector, recursively
+    // split the input vector into smaller powers of 2 until the
+    // transfers of PartialCount can be satisfied.
+    // Example:
+    // v = VecT<DataT, 8> PartialCount = 7
+    // Step1:
+    // - Input: v[0-7], PartialCount = 7
+    // - TransactionSize = (8 / 2) = 4
+    // - Chunks          = (7 / 4) = 1
+    // - Xfer v[0-3], Remain v[4-7]
+    // - NewPartialCount = 7 - (1 * 4) = 3
+    // Step2:
+    // - Input: v[4-7], PartialCount = 3
+    // - TransactionSize = (4 / 2) = 2
+    // - Chunks          = (3 / 2) = 1
+    // - Xfer v[4-5], Remain v[6-7]
+    // - NewPartialCount = 3 - (1 * 2) = 1
+    // Step3:
+    // - Input: v[6-7], PartialCount = 1
+    // - TransactionSize = (2 / 2) = 1
+    // - Chunks          = (1 / 1) = 1
+    // - Xfer v[6]
+    // - New PartialCount = 1 - (1 * 1) = 0
+    // </Done> v[7] is untouched
+    template <IOBearerTypesDecl>
+    template <uint32_t PartialCount, typename PBufferT, typename DataPtrT>
+    ROCWMMA_DEVICE inline auto IOBearer<IOBearerTypesImpl>::partial_impl(PBufferT&  buff,
+                                                                         DataPtrT&& dataPtr)
+    {
+        using VecTraits = VecTraits<decay_t<decltype(buff)>>;
+        static_assert(is_pow2(VecTraits::size()), "Buffer size must be a power of 2");
+
+        // Invalid case: pass-through
+        if constexpr(PartialCount == 0u || PartialCount > VecTraits::size())
+        {
+            // Normally this would be a static_assert(PartialCount <= VecTraits::size()),
+            // however some runtime dispatching may break the rule
+            return;
+        }
+        // Simple case: PartialCount is exactly the size of the vector
+        else if constexpr(PartialCount == VecTraits::size())
+        {
+            using Bearer = BearerPolicy<DataT, VecTraits::size()>;
+            Bearer::exec(buff, dataPtr);
+        }
+        // General case: split the vector in half and initiate transfer of smaller chunks.
+        else
+        {
+            constexpr uint32_t SplitVecSize = VecTraits::size() / 2u;
+
+            if constexpr(SplitVecSize > 0u)
+            {
+                constexpr auto PartialIterations = PartialCount / SplitVecSize;
+
+                if constexpr(PartialIterations > 0u)
+                {
+                    // Iterate over the input vector with split size
+                    vector_mutate_for_each<SplitVecSize>(
+                        forward<PBufferT>(buff),
+                        [](auto&& buff, auto&& idx, auto* dataPtr) {
+                            constexpr auto Idx = decay_t<decltype(idx)>::value;
+                            if constexpr(Idx < PartialIterations)
+                            {
+                                using Bearer = BearerPolicy<DataT, SplitVecSize>;
+                                Bearer::exec(buff, dataPtr + Idx * SplitVecSize);
+                            }
+                        },
+                        dataPtr);
+                }
+
+                // Check if there are more partials to process (e.g., the SplitVecSize is still too granular)
+                constexpr int32_t RemainingPartialCount
+                    = PartialCount - PartialIterations * SplitVecSize;
+                static_assert(RemainingPartialCount >= 0, "Invalid new PartialCount");
+
+                if constexpr(RemainingPartialCount > 0)
+                {
+                    // Perform the split again on data that has not been passed over
+                    partial_impl<RemainingPartialCount>(
+                        *makeVectorIterator<SplitVecSize>(buff).it(PartialIterations),
+                        dataPtr + PartialIterations * SplitVecSize);
+                }
+            }
+        }
+    }
+
+    // Operate on the given vector with expected partial values.
+    // Assumption: the original input vector size is a power of 2.
+    // Procedure: Starting from the end of the vector, recursively
+    // split the input vector into smaller powers of 2 until the
+    // BoundCount boundary conditions can be applied.
+    // Example:
+    // buff = VecT<DataT, 8> BoundCount = 7
+    // Step1:
+    // - Input: v[0-7], BoundCount = 7
+    // - TransactionSize = (8 / 2) = 4
+    // - Chunks          = (7 / 4) = 1
+    // - ApplyBounds v[4-7], Remain v[0-3]
+    // - NewBoundCount = 7 - (1 * 4) = 3
+    // Step2:
+    // - Input: v[0-3], BoundCount = 3
+    // - TransactionSize = (4 / 2) = 2
+    // - Chunks          = (3 / 2) = 1
+    // - ApplyBounds v[2-3], Remain v[0-1]
+    // - NewBoundCount = 3 - (1 * 2) = 1
+    // Step3:
+    // - Input: v[0-1], BoundCount = 1
+    // - TransactionSize = (2 / 2) = 1
+    // - Chunks          = (1 / 1) = 1
+    // - ApplyBounds v[1]
+    // - New BoundCount = 1 - (1 * 1) = 0
+    // </Done> v[0] is untouched
+    template <IOBearerTypesDecl>
+    template <uint32_t BoundCount, typename BBufferT, typename ScalarT>
+    ROCWMMA_DEVICE inline auto IOBearer<IOBearerTypesImpl>::bounds_impl(BBufferT& buff,
+                                                                        ScalarT&& clipVal)
+    {
+        using VecTraits = VecTraits<decay_t<decltype(buff)>>;
+        static_assert(is_pow2(VecTraits::size()), "Buffer size must be a power of 2");
+
+        // Invalid case: pass-through
+        if constexpr(BoundCount == 0u || BoundCount > VecTraits::size())
+        {
+            // Normally this would be a static_assert(BoundCount <= VecTraits::size()),
+            // however some runtime dispatching may break the rule
+            return;
+        }
+        // Simple case: BoundCount is exactly the size of the vector
+        else if constexpr(BoundCount == VecTraits::size())
+        {
+            BoundsCtrl::exec(buff, clipVal);
+        }
+        // General case: split the vector in half and initiate bounds control of smaller chunks.
+        else
+        {
+            // Split vecsize and determine if the split size can be used to fill the next chunk.
+            constexpr uint32_t SplitVecSize = VecTraits::size() / 2u;
+
+            if constexpr(SplitVecSize > 0u)
+            {
+                constexpr auto BoundIterations = BoundCount / SplitVecSize;
+
+                if constexpr(BoundIterations > 0u)
+                {
+                    // Iterate in reverse over the input vector with split size
+                    vector_mutate_for_each<SplitVecSize>(
+                        forward<BBufferT>(buff),
+                        [](auto&& buff, auto&& idx, auto&& clipVal) {
+                            constexpr auto Idx = decay_t<decltype(idx)>::value;
+                            if constexpr((VecTraits::size() / SplitVecSize - 1u - Idx)
+                                         < BoundIterations)
+                            {
+                                BoundsCtrl::exec(buff, clipVal);
+                            }
+                        },
+                        clipVal);
+                }
+
+                // Check if there are more partials to process (e.g., the SplitVecSize is still too granular)
+                constexpr int32_t RemainingBoundCount = BoundCount - BoundIterations * SplitVecSize;
+                static_assert(RemainingBoundCount >= 0, "Invalid new BoundCount");
+
+                if constexpr(RemainingBoundCount > 0)
+                {
+                    // Perform the split again on data that has not been passed over
+                    bounds_impl<RemainingBoundCount>(
+                        *makeVectorIterator<SplitVecSize>(buff).it(VecTraits::size() / SplitVecSize
+                                                                   - 1u - BoundIterations),
+                        clipVal);
+                }
+            }
+        }
+    }
+
+    // Outer loops = index 0, ..., N-2
+    // Inner loop  = index N-1
+    // Notes:
+    // - Assumption: MatrixLayout provides constexpr strideCounts and strides.
+    //   We can then use static unroll to eliminate looping.
+    // - Unroll model will use vector_mutate_for_each because the current bearers are implemented
+    //   as visitor patterns. They either write to, or read from an input vector object.
+    //   The vector needs to be mutable for loads, but the stores will cast as const reference.
+    //   vector_mutate_for_each provides a reference to raw vector data it is operating on, which
+    //   will satisfy both loading and storing visitation needs.
+    template <IOBearerTypesDecl>
+    template <size_t Depth /*= 0*/, typename BufferT, typename Coord2d, typename ExternDataT>
+    ROCWMMA_DEVICE inline auto IOBearer<IOBearerTypesImpl>::unroll_impl(BufferT&&    buff,
+                                                                        Coord2d&&    baseOffset2d,
+                                                                        ExternDataT* dataPtr,
+                                                                        uint32_t     ldm)
+    {
+        // Get the layout strides for the current depth
+        constexpr auto StrideSpace = pop_front<Depth>(MatrixLayout::strideCounts());
+        constexpr auto Strides     = pop_front<Depth>(MatrixLayout::strides());
+        constexpr auto ItCount     = reduce_mult(StrideSpace);
+
+        // Ensure the buffer size is appropriate
+        using BufferTraits = VecTraits<decay_t<BufferT>>;
+        static_assert(BufferTraits::size() == ItCount * TransactionSize, "Invalid buffer size");
+
+        // Replacement value for boundary violations
+        constexpr auto BoundsValue = 0u;
+
+        // Offset stride for current depth
+        constexpr auto CurrentStride2d = get_first(Strides);
+
+        // Recurse to the next nested layer
+        if constexpr((VecTraits<decay_t<decltype(StrideSpace)>>::size()) > 1u)
+        {
+            constexpr auto NextStrideSpace  = pop_front(StrideSpace);
+            constexpr auto NextBufferStride = reduce_mult(NextStrideSpace) * TransactionSize;
+
+            vector_mutate_for_each<NextBufferStride>(
+                forward<BufferT>(buff),
+                [](auto&& buff,
+                   auto&& idx,
+                   auto&& baseOffset2d,
+                   auto&& offsetStep2d,
+                   auto&& boundsValue,
+                   auto*  dataPtr,
+                   auto   ldm) {
+                    // Current offset from wave tile origin (0, 0)
+                    auto currentOffset2d
+                        = baseOffset2d + decay_t<decltype(idx)>::value * offsetStep2d;
+
+                    // Check bounds conditions for minimum 1x1 valid area. If the minimum area isn't valid,
+                    // there are no partials and entire transaction should be treated as boundary violation.
+                    constexpr auto dataSize2d = make_coord2d(1u, 1u);
+                    if(!BoundsCtrl::checkBounds(currentOffset2d, dataSize2d))
+                    {
+                        // Unroll to next layer
+                        unroll_impl<Depth + 1u>(buff, currentOffset2d, dataPtr, ldm);
+                    }
+                    else
+                    {
+                        // Boundary violation
+                        BoundsCtrl::exec(buff, boundsValue);
+                    }
+                },
+                baseOffset2d,
+                CurrentStride2d,
+                BoundsValue,
+                dataPtr,
+                ldm);
+        }
+        // Final depth layer will invoke the memory transactions
+        else
+        {
+            vector_mutate_for_each<TransactionSize>(
+                forward<BufferT>(buff),
+                [](auto&&   buff,
+                   auto&&   idx,
+                   auto&&   baseOffset2d,
+                   auto&&   offsetStep2d,
+                   auto&&   boundsValue,
+                   auto*    dataPtr,
+                   uint32_t ldm) {
+                    // Current offset from wave tile origin (0, 0)
+                    auto currentOffset2d
+                        = baseOffset2d + decay_t<decltype(idx)>::value * offsetStep2d;
+
+                    // Each load of the bearer is linear.
+                    // Expand into 2d offset area to check rectangular bounds
+                    constexpr auto dataSize2d = DataLayoutTraits::is_col_major
+                                                    ? make_coord2d(TransactionSize, 1u)
+                                                    : make_coord2d(1u, TransactionSize);
+
+                    // Cache 1d data address offset
+                    uint32_t dataOffset = DataLayout::fromMatrixCoord(currentOffset2d, ldm);
+
+                    // The outer loop layers guarantee that the currentOffset2d is at least within the boundary area,
+                    // and has at least one partial (1x1).
+                    // Assumptions:
+                    // - Partial count < VW
+                    // - Partial count + bound count == VW.
+                    // - Assume a minimum of 1 valid partial
+
+                    // Special case of VW == 1u
+                    if constexpr(TransactionSize == 1u)
+                    {
+                        // Note: Outer layer has already tested 1x1.
+                        // There are no possible boundary violations
+                        // because we already have 1 valid partial!
+
+                        // Flatten to 1d data address
+                        using Bearer = BearerPolicy<DataT, TransactionSize>;
+                        Bearer::exec(buff, dataPtr + dataOffset);
+                    }
+                    // Special case of VW == 2u
+                    else if constexpr(TransactionSize == 2u)
+                    {
+                        // Check bounds conditions.
+                        // Low mask means no boundary violation
+                        if(!BoundsCtrl::checkBounds(currentOffset2d, dataSize2d))
+                        {
+                            // Flatten to 1d data address
+                            using Bearer = BearerPolicy<DataT, TransactionSize>;
+                            Bearer::exec(buff, dataPtr + dataOffset);
+                        }
+                        // On high mask treat boundary violations
+                        else
+                        {
+                            // Note: Outer layer has already tested 1x1.
+                            // Because a boundary violation has been detected, we now have
+                            // at least 1 boundary violation, in addition to at least 1 partial.
+
+                            // Handle partial transaction
+                            partial_impl<1u>(buff, dataPtr + dataOffset);
+
+                            // Handle boundary violations
+                            bounds_impl<1u>(buff, boundsValue);
+                        }
+                    }
+                    // General case where we need to calculate partial and bound counts.
+                    else if constexpr(TransactionSize > 2u)
+                    {
+                        // Check bounds conditions.
+                        // Low mask means no boundary violation
+                        if(!BoundsCtrl::checkBounds(currentOffset2d, dataSize2d))
+                        {
+                            // Flatten to 1d data address
+                            using Bearer = BearerPolicy<DataT, TransactionSize>;
+                            Bearer::exec(buff, dataPtr + dataOffset);
+                        }
+                        // On high mask, we must treat boundary violations
+                        else
+                        {
+                            // Bounds violations are only possible due to the BearerPolicy, which is a linear transaction of size VW.
+                            // Therefore, calculate valid partials and boundary conditions based on data layout.
+                            auto partialCount = DataLayoutTraits::is_col_major
+                                                    ? (BoundsCtrl::BoundX - get<0>(baseOffset2d))
+                                                    : (BoundsCtrl::BoundY - get<1>(baseOffset2d));
+
+                            bool processed = false;
+
+                            // Caveat: partialCount is not a constexpr value due to dependency on per-thread baseOffset2d.
+                            // Dispatch the partialCount value at runtime to match it with templated PartialCount and BoundCount.
+                            // To minimize the dispatching search space, we can leverage the above assumption that there is at
+                            // least one partial in addition to at least one bounds violation.
+                            // The search space is therefore from [1, ..., VW) for partial counts.
+                            static_for<1u, TransactionSize, 1u>(
+                                [](auto&& idx,
+                                   auto&& buff,
+                                   auto&& partialCount,
+                                   auto&  processedFlag,
+                                   auto&& boundsValue,
+                                   auto&& dataPtr,
+                                   auto&& dataOffset) {
+                                    // Calculate potential partial and bound count match
+                                    constexpr auto PartialCount = decay_t<decltype(idx)>::value;
+                                    constexpr auto BoundCount   = TransactionSize - PartialCount;
+
+                                    // Test match
+                                    if(partialCount == PartialCount && !processedFlag)
+                                    {
+                                        // Handle partial transactions
+                                        partial_impl<PartialCount>(buff, dataPtr + dataOffset);
+
+                                        // Handle boundary violations
+                                        // Note: Give a value of 0 if ClipAndReplace is used
+                                        bounds_impl<BoundCount>(buff, boundsValue);
+
+                                        // Match is found
+                                        processedFlag = true;
+                                    }
+                                },
+                                buff,
+                                partialCount,
+                                processed,
+                                boundsValue,
+                                dataPtr,
+                                dataOffset);
+                        }
+                    }
+                },
+                baseOffset2d,
+                CurrentStride2d,
+                BoundsValue,
+                dataPtr,
+                ldm);
+        }
+    }
+
+    template <IOBearerTypesDecl>
+    template <typename BufferT, typename ExternDataT>
+    ROCWMMA_DEVICE inline void
+        IOBearer<IOBearerTypesImpl>::exec(BufferT&& buff, ExternDataT* dataPtr, uint32_t ldm)
+    {
+        // Current offset from wave tile origin (0, 0)
+        auto currentOffset2d = MatrixLayout::baseOffset();
+
+        // Start unrolling from the base offset of matrix layout
+        unroll_impl(forward<BufferT>(buff), currentOffset2d, dataPtr, ldm);
+    }
+
+#undef IOBearerTypesDecl
+#undef IOBearerTypesImpl
+
+} // namespace rocwmma
+
+#endif // ROCWMMA_IO_BEARER_IMPL_HPP

--- a/library/include/rocwmma/internal/io_bearer_impl.hpp
+++ b/library/include/rocwmma/internal/io_bearer_impl.hpp
@@ -313,77 +313,79 @@ namespace rocwmma
                     // Cache 1d data address offset
                     uint32_t dataOffset = DataLayout::fromMatrixCoord(currentOffset2d, ldm);
 
-                    // The outer loop layers guarantee that the currentOffset2d is at least within the boundary area,
+                    // The outer loop layers guarantee that the baseOffset2d is at least within the boundary area,
                     // and has at least one partial (1x1).
                     // Assumptions:
                     // - Partial count < VW
                     // - Partial count + bound count == VW.
                     // - Assume a minimum of 1 valid partial
 
-                    // Special case of VW == 1u
-                    if constexpr(TransactionSize == 1u)
+                    // Note: Outer layer has already tested 1x1 from baseOffset2d, which gives us
+                    // 1 valid partial.
+                    if constexpr(decay_t<decltype(idx)>::value == 0u && TransactionSize <= 2u)
                     {
-                        // Note: Outer layer has already tested 1x1.
-                        // There are no possible boundary violations
-                        // because we already have 1 valid partial!
-
-                        // Flatten to 1d data address
-                        using Bearer = BearerPolicy<DataT, TransactionSize>;
-                        Bearer::exec(buff, dataPtr + dataOffset);
-                    }
-                    // Special case of VW == 2u
-                    else if constexpr(TransactionSize == 2u)
-                    {
-                        // Check bounds conditions.
-                        // Low mask means no boundary violation
-                        if(!BoundsCtrl::checkBounds(currentOffset2d, dataSize2d))
+                        // Special case of VW == 1u on iteration 0
+                        if constexpr(TransactionSize == 1u)
                         {
-                            // Flatten to 1d data address
+                            // There are no possible boundary violations
+                            // because we already have 1 valid partial!
                             using Bearer = BearerPolicy<DataT, TransactionSize>;
                             Bearer::exec(buff, dataPtr + dataOffset);
                         }
-                        // On high mask treat boundary violations
-                        else
+                        // Special case of VW == 2u on iteration 0
+                        else if constexpr(TransactionSize == 2u)
                         {
-                            // Note: Outer layer has already tested 1x1.
-                            // Because a boundary violation has been detected, we now have
-                            // at least 1 boundary violation, in addition to at least 1 partial.
+                            // Check bounds conditions.
+                            // Low mask means no boundary violation
+                            if(!BoundsCtrl::checkBounds(currentOffset2d, dataSize2d))
+                            {
+                                using Bearer = BearerPolicy<DataT, TransactionSize>;
+                                Bearer::exec(buff, dataPtr + dataOffset);
+                            }
+                            // On high mask treat boundary violations
+                            else
+                            {
+                                // Because a boundary violation has been detected, we now have
+                                // at least 1 boundary violation, in addition to at least 1 partial.
 
-                            // Handle partial transaction
-                            partial_impl<1u>(buff, dataPtr + dataOffset);
+                                // Handle partial transaction
+                                partial_impl<1u>(buff, dataPtr + dataOffset);
 
-                            // Handle boundary violations
-                            bounds_impl<1u>(buff, boundsValue);
+                                // Handle boundary violations
+                                bounds_impl<1u>(buff, boundsValue);
+                            }
                         }
                     }
                     // General case where we need to calculate partial and bound counts.
-                    else if constexpr(TransactionSize > 2u)
+                    else
                     {
                         // Check bounds conditions.
                         // Low mask means no boundary violation
                         if(!BoundsCtrl::checkBounds(currentOffset2d, dataSize2d))
                         {
-                            // Flatten to 1d data address
                             using Bearer = BearerPolicy<DataT, TransactionSize>;
                             Bearer::exec(buff, dataPtr + dataOffset);
                         }
                         // On high mask, we must treat boundary violations
                         else
                         {
-                            // Bounds violations are only possible due to the BearerPolicy, which is a linear transaction of size VW.
-                            // Therefore, calculate valid partials and boundary conditions based on data layout.
-                            auto partialCount = DataLayoutTraits::is_col_major
-                                                    ? (BoundsCtrl::BoundX - get<0>(baseOffset2d))
-                                                    : (BoundsCtrl::BoundY - get<1>(baseOffset2d));
+                            // Bounds violations are possible by either:
+                            // 1. Offset step (currentOffset2d falls on boundary)
+                            // 2. Bearer transaction (currentOffset2d + size falls on boundary or beyond)
+                            // In col major: if diffY is positive, the violation is due to bearer, otherwise the coordinate is fully OOB.
+                            // In row major: if diffX is positive, the violation is due to bearer, otherwise the coordinate is fully OOB.
+                            // When coordinate is fully OOB, we have 0 partials and all bounds violations.
+                            int32_t diffX        = BoundsCtrl::BoundX - get<0>(currentOffset2d);
+                            int32_t diffY        = BoundsCtrl::BoundY - get<1>(currentOffset2d);
+                            auto    partialCount = DataLayoutTraits::is_col_major
+                                                    ? (diffY > 0u ? diffX : 0u)
+                                                    : (diffX > 0u ? diffY : 0u);
 
                             bool processed = false;
 
                             // Caveat: partialCount is not a constexpr value due to dependency on per-thread baseOffset2d.
                             // Dispatch the partialCount value at runtime to match it with templated PartialCount and BoundCount.
-                            // To minimize the dispatching search space, we can leverage the above assumption that there is at
-                            // least one partial in addition to at least one bounds violation.
-                            // The search space is therefore from [1, ..., VW) for partial counts.
-                            static_for<1u, TransactionSize, 1u>(
+                            static_for<0u, TransactionSize, 1u>(
                                 [](auto&& idx,
                                    auto&& buff,
                                    auto&& partialCount,

--- a/library/include/rocwmma/internal/io_bounds_ctrl.hpp
+++ b/library/include/rocwmma/internal/io_bounds_ctrl.hpp
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef ROCWMMA_IO_BOUNDS_CTRL_HPP
+#define ROCWMMA_IO_BOUNDS_CTRL_HPP
+
+#include "utility/vector.hpp"
+
+namespace rocwmma
+{
+    namespace IOBoundsCtrl
+    {
+        //! @struct Default
+        //! @brief Default behaviour policy is to not check or apply IO Bounds control
+        struct Default
+        {
+            static constexpr uint32_t BoundX = 0u;
+            static constexpr uint32_t BoundY = 0u;
+
+            template <typename... Ts>
+            ROCWMMA_DEVICE static constexpr inline auto checkBounds(Ts&&... ts)
+            {
+                // Pass-through
+                return false;
+            }
+
+            template <typename... Ts>
+            ROCWMMA_DEVICE static constexpr inline auto exec(Ts&&... ts)
+            {
+                // No action
+            }
+        };
+
+        //! @struct Clip2d
+        //! @brief Clipping policy checks rectangular bounds and takes no further action
+        //! @tparam ClipX Bounding box height
+        //! @tparam ClipY Bounding box width
+        template <uint32_t ClipX, uint32_t ClipY>
+        struct Clip2d
+        {
+            static constexpr uint32_t BoundX = ClipX;
+            static constexpr uint32_t BoundY = ClipY;
+
+            template <typename Coord2d, typename Size2d, typename... Ts>
+            ROCWMMA_DEVICE static constexpr inline auto
+                checkBounds(Coord2d&& baseOffset2d, Size2d&& size2d, Ts&&... ts)
+            {
+                // Mask high if the data area exceeds bounds.
+                return vector_reduce_or((baseOffset2d + size2d) > make_coord2d(BoundX, BoundY));
+            }
+
+            template <typename... Ts>
+            ROCWMMA_DEVICE static constexpr inline auto exec(Ts&&... ts)
+            {
+                // No action
+            }
+        };
+
+        //! @struct ClipAndReplace2d
+        //! @brief Clipping policy checks rectangular bounds and replaces the transaction buffer with a value
+        //! @tparam ClipX Bounding box height
+        //! @tparam ClipY Bounding box width
+        template <uint32_t ClipX, uint32_t ClipY>
+        struct ClipAndReplace2d : public Clip2d<ClipX, ClipY>
+        {
+        private:
+            // Static override of Clip2d
+            using Clip2d<ClipX, ClipY>::exec;
+
+        public:
+            template <typename BuffT, typename ScalarT, typename... Ts>
+            ROCWMMA_DEVICE static constexpr inline auto
+                exec(BuffT& buff, ScalarT&& clipVal, Ts&&... ts)
+            {
+                // Fill the buffer with clipVal
+                using BuffTraits = VecTraits<BuffT>;
+                buff             = BuffT{static_cast<typename BuffTraits::DataT>(clipVal)};
+            }
+        };
+
+    } // namespace IOBoundsCtrl
+
+} // namespace rocwmma
+
+#endif // ROCWMMA_IO_BOUNDS_CTRL_HPP

--- a/library/include/rocwmma/internal/io_config.hpp
+++ b/library/include/rocwmma/internal/io_config.hpp
@@ -72,7 +72,7 @@ namespace rocwmma
     {
         using IOShape = IOShape<MatrixT, BlockM, BlockN, BlockK>;
         using IOLayout
-            = IOLayout<MatrixT, IOShape::BlockDim, IOShape::KDim, DataT, DataLayoutT, 1u>;
+            = IOLayoutInt<MatrixT, IOShape::BlockDim, IOShape::KDim, DataT, DataLayoutT, 1u>;
         using IOTraits = IOTraits<IOShape::BlockDim, IOShape::KDim, DataT, IOLayout::VW>;
 
         using PackUtil    = PackUtil<DataT>;
@@ -104,10 +104,11 @@ namespace rocwmma
     template <uint32_t BlockM, uint32_t BlockN, uint32_t BlockK, typename DataT>
     struct IOConfig<accumulator, BlockM, BlockN, BlockK, DataT, void>
     {
-        using IOShape  = IOShape<accumulator, BlockM, BlockN, BlockK>;
-        using IOLayout = IOLayout<accumulator, IOShape::BlockDim, IOShape::KDim, DataT, void, 1u>;
-        using IOTraits = IOTraits<IOShape::BlockDim, IOShape::KDim, DataT>;
-        using PackUtil = PackUtil<DataT>;
+        using IOShape = IOShape<accumulator, BlockM, BlockN, BlockK>;
+        using IOLayout
+            = IOLayoutInt<accumulator, IOShape::BlockDim, IOShape::KDim, DataT, void, 1u>;
+        using IOTraits    = IOTraits<IOShape::BlockDim, IOShape::KDim, DataT>;
+        using PackUtil    = PackUtil<DataT>;
         using Broadcaster = Broadcast<DataT, IOTraits::UnpackedSize>;
 
         using PreMmaXForm = register_layout_transform<typename IOLayout::FragmentLayout,

--- a/library/include/rocwmma/internal/io_config.hpp
+++ b/library/include/rocwmma/internal/io_config.hpp
@@ -30,7 +30,9 @@
 #include "broadcast.hpp"
 #include "coop_load.hpp"
 #include "coop_store.hpp"
+#include "io_bounds_ctrl.hpp"
 #include "io_shape.hpp"
+#include "io_tile.hpp"
 #include "opaque_load.hpp"
 #include "opaque_store.hpp"
 #include "pack_util.hpp"
@@ -44,44 +46,70 @@ namespace rocwmma
      * @{
      */
 
-    /*! \struct IOConfig
-  *  \brief Definition of fragment input / output configurations
- *         in specific matrix context.
- *
- * @tparam Matrix fragment context
- * @tparam BlockM/N/K block dimensions
- * @tparam DataT data type
- * @tparam DataLayoutT in-memory layout as col_major or row_major
- * @param IOShape dimensional properties of the fragment
- * @param IOLayout 1d and 2d layouts of the fragment
- * @param IOTraits meta-properties for input and output of the fragment
- * @param PackUtil utility for packing / unpacking fragment data
- * @param Broadcaster utility for assigning a single value to entire fragment
- * @param MappingUtil global mapping utility for current fragment
- * @param Loader Issues load instructions for raw fragment data
- * @param Storer Issues store instructions for raw fragment data
- */
-
+    //! @struct IOConfig
+    //! @brief Definition of fragment input / output configurations in specific matrix context.
+    //!
+    //! @tparam Matrix fragment context
+    //! @tparam BlockM/N/K block dimensions
+    //! @tparam DataT data type
+    //! @tparam DataLayoutT in-memory layout as col_major or row_major
+    //! @param IOBounds Describes the boundaries given by the fragment
+    //! @param IOTile Describes the actual block tiling decomposition used based on the fragment size
+    //! @param IOShape Dimensional properties of the block tile
+    //! @param IOLayout 1d and 2d layouts of the block tile
+    //! @param IOTraits Meta-properties for input and output of the block tile
+    //! @param PackUtil Utility for packing / unpacking block tile data
+    //! @param Broadcaster Utility for broadcasting a single value to entire fragment
+    //! @param MappingUtil Global mapping utility for current fragment
+    //! @param IOBoundsCtrlLoad Bounds control for loading input
+    //! @param PostLoadXForm Register transform immediately after loading
+    //! @param Loader Issues load instructions for raw data
+    //! @param PreStoreXForm Register transform immediately before storing
+    //! @param IOBoundsCtrlStore Bounds control for storing output
+    //! @param Storer Issues store instructions for raw data
     template <typename MatrixT,
-              uint32_t BlockM,
-              uint32_t BlockN,
-              uint32_t BlockK,
+              uint32_t FragM,
+              uint32_t FragN,
+              uint32_t FragK,
               typename DataT,
               typename DataLayoutT>
     struct IOConfig
     {
-        using IOShape = IOShape<MatrixT, BlockM, BlockN, BlockK>;
+        // The specific size of the requested fragment
+        using IOBounds = IOShape<MatrixT, FragM, FragN, FragK>;
+
+        // Internally, block-wise decomposition dictates the need for quantized block dimensions.
+        // IOTile will determine ideal block size.
+        using IOTile  = IOTile<FragM, FragN, FragK, DataT>;
+        using IOShape = IOShape<MatrixT, IOTile::BlockM, IOTile::BlockN, IOTile::BlockK>;
+
+        // Bounds control is needed if the original frag size doesn't match block size quantizations.
+        static constexpr bool IOBoundsCtrlRequired
+            = (FragM != IOTile::BlockM) || (FragN != IOTile::BlockN) || (FragK != IOTile::BlockK);
+
+        // Using quantized block dimensions, determine the layout characteristics we will use with
+        // this fragment.
         using IOLayout
             = IOLayoutInt<MatrixT, IOShape::BlockDim, IOShape::KDim, DataT, DataLayoutT, 1u>;
+
         using IOTraits = IOTraits<IOShape::BlockDim, IOShape::KDim, DataT, IOLayout::VW>;
+
+        // Define functional classes used during fragment IO workflow operations such as loading / storing
+        using MappingUtil
+            = MappingUtil<IOShape::BlockHeight, IOShape::BlockWidth, DataT, DataLayoutT>;
 
         using PackUtil    = PackUtil<DataT>;
         using Broadcaster = Broadcast<DataT, IOTraits::UnpackedSize>;
 
-        using MappingUtil
-            = MappingUtil<IOShape::BlockHeight, IOShape::BlockWidth, DataT, DataLayoutT>;
+        // When loading for Mma, we need to replace clipped areas with 0's to ensure correctness.
+        using IOBoundsCtrlLoad = conditional_t<
+            IOBoundsCtrlRequired,
+            IOBoundsCtrl::ClipAndReplace2d<IOBounds::BlockHeight, IOBounds::BlockWidth>,
+            IOBoundsCtrl::Default>;
 
-        using Loader = OpaqueLoad<typename IOLayout::DataLayout, typename IOLayout::MatrixLayout>;
+        using Loader = OpaqueLoad<typename IOLayout::DataLayout,
+                                  typename IOLayout::MatrixLayout,
+                                  IOBoundsCtrlLoad>;
 
         using PostLoadXForm = register_layout_transform<typename IOLayout::StorageLayout,
                                                         typename IOLayout::FragmentLayout,
@@ -91,7 +119,15 @@ namespace rocwmma
                                                         typename IOLayout::StorageLayout,
                                                         1u>;
 
-        using Storer = OpaqueStore<typename IOLayout::DataLayout, typename IOLayout::MatrixLayout>;
+        // Storage requires only clipping.
+        using IOBoundsCtrlStore
+            = conditional_t<IOBoundsCtrlRequired,
+                            IOBoundsCtrl::Clip2d<IOBounds::BlockHeight, IOBounds::BlockWidth>,
+                            IOBoundsCtrl::Default>;
+
+        using Storer = OpaqueStore<typename IOLayout::DataLayout,
+                                   typename IOLayout::MatrixLayout,
+                                   IOBoundsCtrlStore>;
     };
 
     /************************************************
@@ -101,23 +137,16 @@ namespace rocwmma
  * general IOTraits, Pack/Unpack, Broadcast still available.
  *
  * */
-    template <uint32_t BlockM, uint32_t BlockN, uint32_t BlockK, typename DataT>
-    struct IOConfig<accumulator, BlockM, BlockN, BlockK, DataT, void>
+    template <uint32_t FragM, uint32_t FragN, uint32_t FragK, typename DataT>
+    struct IOConfig<accumulator, FragM, FragN, FragK, DataT, void>
     {
-        using IOShape = IOShape<accumulator, BlockM, BlockN, BlockK>;
+        using IOTile  = IOTile<FragM, FragN, FragK, DataT>;
+        using IOShape = IOShape<accumulator, IOTile::BlockM, IOTile::BlockN, IOTile::BlockK>;
         using IOLayout
             = IOLayoutInt<accumulator, IOShape::BlockDim, IOShape::KDim, DataT, void, 1u>;
         using IOTraits    = IOTraits<IOShape::BlockDim, IOShape::KDim, DataT>;
         using PackUtil    = PackUtil<DataT>;
         using Broadcaster = Broadcast<DataT, IOTraits::UnpackedSize>;
-
-        using PreMmaXForm = register_layout_transform<typename IOLayout::FragmentLayout,
-                                                      typename IOLayout::MmaLayout,
-                                                      1u>;
-
-        using PostMmaXForm = register_layout_transform<typename IOLayout::MmaLayout,
-                                                       typename IOLayout::FragmentLayout,
-                                                       1u>;
     };
     /** @}*/
 

--- a/library/include/rocwmma/internal/io_tile.hpp
+++ b/library/include/rocwmma/internal/io_tile.hpp
@@ -32,14 +32,12 @@
 
 namespace rocwmma
 {
-    /*! \struct IOTile
-    *  \brief Definition of fragment tiling quantization.
-    *
-    * @tparam Fragment M dimension
-    * @tparam Fragment N dimension
-    * @tparam Fragment K dimension
-    * @tparam DataT data type
-    */
+    //! @struct IOTile
+    //! @brief Definition of fragment tiling quantization.
+    //! @tparam FragM Fragment M dimension
+    //! @tparam FragN Fragment N dimension
+    //! @tparam FragK Fragment K dimension
+    //! @tparam DataT data type
     template <uint32_t FragM, uint32_t FragN, uint32_t FragK, typename DataT>
     struct IOTile
     {
@@ -67,11 +65,8 @@ namespace rocwmma
                                           || (FragN * FragK % MinElementsPerFrag)
                                           || (FragM * FragN % MinElementsPerFrag);
 
-        // Due to block-wise nature of the API, define the effective block shape for this fragment.
-        // Note: No matter if we get partial data in either BlockDim or KDim, we will have enough complete registers.
-        // - Effective BlockDim size is a multiple of the MinBlockDim
-        // - Effective KDim size to a multiple of the MinKDim
     public:
+        // Apply padding if necessary
         static constexpr uint32_t BlockM = doPadding ? PadBlockM : FragM;
         static constexpr uint32_t BlockN = doPadding ? PadBlockN : FragN;
         static constexpr uint32_t BlockK = doPadding ? PadBlockK : FragK;

--- a/library/include/rocwmma/internal/io_tile.hpp
+++ b/library/include/rocwmma/internal/io_tile.hpp
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+#ifndef ROCWMMA_IO_TILE_HPP
+#define ROCWMMA_IO_TILE_HPP
+
+#include "constants.hpp"
+#include "utility/algorithm.hpp"
+#include "utility/math.hpp"
+
+namespace rocwmma
+{
+    /*! \struct IOTile
+    *  \brief Definition of fragment tiling quantization.
+    *
+    * @tparam Fragment M dimension
+    * @tparam Fragment N dimension
+    * @tparam Fragment K dimension
+    * @tparam DataT data type
+    */
+    template <uint32_t FragM, uint32_t FragN, uint32_t FragK, typename DataT>
+    struct IOTile
+    {
+    private:
+        // Note: ALL of the mma implementations have support for minimum 1 packed register for each input A and B.
+        // The goal here is to pad out fragments to sizes that are conducive to mma.
+        // FragM and FragN should be multiples of base block sizes (hardware defined), and FragK needs to be
+        // a product of the lowest common multiple of the minimum registers required to fit the padded size.
+        static constexpr uint32_t MinBlockDim          = 16u;
+        static constexpr uint32_t MinElementsPerThread = ceil_div(sizeof(float), sizeof(DataT));
+        static constexpr uint32_t MinElementsPerFrag
+            = Constants::AMDGCN_WAVE_SIZE * MinElementsPerThread;
+
+        static constexpr uint32_t MinKDimM
+            = max(MinElementsPerThread, MinElementsPerFrag / next_multiple(FragM, MinBlockDim));
+        static constexpr uint32_t MinKDimN
+            = max(MinElementsPerThread, MinElementsPerFrag / next_multiple(FragN, MinBlockDim));
+        static constexpr uint32_t MinKDim = max(MinKDimM, MinKDimN);
+
+        static constexpr uint32_t PadBlockM = next_multiple(FragM, MinBlockDim);
+        static constexpr uint32_t PadBlockN = next_multiple(FragN, MinBlockDim);
+        static constexpr uint32_t PadBlockK = next_multiple(FragK, MinKDim);
+
+        static constexpr bool doPadding = (FragM * FragK % MinElementsPerFrag)
+                                          || (FragN * FragK % MinElementsPerFrag)
+                                          || (FragM * FragN % MinElementsPerFrag);
+
+        // Due to block-wise nature of the API, define the effective block shape for this fragment.
+        // Note: No matter if we get partial data in either BlockDim or KDim, we will have enough complete registers.
+        // - Effective BlockDim size is a multiple of the MinBlockDim
+        // - Effective KDim size to a multiple of the MinKDim
+    public:
+        static constexpr uint32_t BlockM = doPadding ? PadBlockM : FragM;
+        static constexpr uint32_t BlockN = doPadding ? PadBlockN : FragN;
+        static constexpr uint32_t BlockK = doPadding ? PadBlockK : FragK;
+    };
+
+} // namespace rocwmma
+
+#endif // ROCWMMA_IO_TILE_HPP

--- a/library/include/rocwmma/internal/io_traits.hpp
+++ b/library/include/rocwmma/internal/io_traits.hpp
@@ -29,7 +29,7 @@
 #include "constants.hpp"
 #include "pack_util.hpp"
 #include "types.hpp"
-#include "utils.hpp"
+#include "utility/math.hpp"
 
 namespace rocwmma
 {
@@ -52,19 +52,19 @@ namespace rocwmma
             ElementsPerIO = ThreadsPerIO * VectorWidth,
 
             // Number of BlockDim strides per I/O operation
-            KPerIO = ceilDiv(ElementsPerIO, BlockDim),
+            KPerIO = ceil_div(ElementsPerIO, BlockDim),
 
             // Total number of elements per for the entire block
             ElementCount = BlockDim * BlockK,
 
             // Total number of I/O operations needed for the entire block
-            IOCount = ceilDiv(ElementCount, ElementsPerIO),
+            IOCount = ceil_div(ElementCount, ElementsPerIO),
 
             // Per-thread c++ vector storage size required for:
             // Unpacked vector = raw I/O
             // Packed vector = packed raw I/O
-            UnpackedSize = ceilDiv(ElementCount, ThreadsPerIO),
-            PackedSize   = ceilDiv((uint32_t)UnpackedSize, (uint32_t)PackTraits<DataT>::PackRatio),
+            UnpackedSize = ceil_div(ElementCount, ThreadsPerIO),
+            PackedSize   = ceil_div((uint32_t)UnpackedSize, (uint32_t)PackTraits<DataT>::PackRatio),
 
             // Physical number of hardware vregs used to store packed data
             PackedVRegCount = ElementCount * sizeof(DataT) / Constants::AMDGCN_REGISTER_SIZE_BYTES,

--- a/library/include/rocwmma/internal/mma_config.hpp
+++ b/library/include/rocwmma/internal/mma_config.hpp
@@ -26,10 +26,10 @@
 #ifndef ROCWMMA_MMA_CONFIG_HPP
 #define ROCWMMA_MMA_CONFIG_HPP
 
-#include "layout/register_layout_transforms.hpp"
 #include "io_config.hpp"
-#include "mma_traits.hpp"
+#include "layout/register_layout_transforms.hpp"
 #include "mfma.hpp"
+#include "mma_traits.hpp"
 #include "pack_util.hpp"
 #include "types.hpp"
 #include "wmma.hpp"
@@ -64,8 +64,12 @@ namespace rocwmma
         using IOLayoutD = typename IOConfigD::IOLayout;
 
         // Sanity checks
-        static_assert(is_layout_same_v<typename IOLayoutA::MmaLayout, typename IOLayoutB::MmaLayout>, "Input fragment register layouts do not match");
-        static_assert(is_layout_same_v<typename IOLayoutC::MmaLayout, typename IOLayoutD::MmaLayout>, "Accumulator fragment register layouts do not match");
+        static_assert(
+            is_layout_same_v<typename IOLayoutA::MmaLayout, typename IOLayoutB::MmaLayout>,
+            "Input fragment register layouts do not match");
+        static_assert(
+            is_layout_same_v<typename IOLayoutC::MmaLayout, typename IOLayoutD::MmaLayout>,
+            "Accumulator fragment register layouts do not match");
 
         // Check valid mma layouts
         // TODO: eventually should enforce
@@ -108,12 +112,30 @@ namespace rocwmma
         // - MmaLayout for input A/B must match
         // - MmaLayout for accumulators must match
         static_assert(MmaDimM == MmaDimN, "MmaDims must match");
-        static_assert((MmaDimN == IOLayoutC::MmaDim) && (MmaDimN == IOLayoutD::MmaDim), "Mismatched accumulator MmaDim");
+        static_assert((MmaDimN == IOLayoutC::MmaDim) && (MmaDimN == IOLayoutD::MmaDim),
+                      "Mismatched accumulator MmaDim");
+
+        // Ensure to use padded tiles if necessary
+        using IOTile = IOTile<FragM, FragN, FragK, InputTA>;
 
         // Gfx9 uses MFMA, gfx11/12 uses WMMA
         using Mma = conditional_t<(bool)ROCWMMA_ARCH_GFX9,
-                                  Mfma<FragM, FragN, FragK, InputTA, InputTB, ComputeT, MmaDimM, MmaDimN>,
-                                  Wmma<FragM, FragN, FragK, InputTA, InputTB, ComputeT, MmaDimM, MmaDimN>>;
+                                  Mfma<IOTile::BlockM,
+                                       IOTile::BlockN,
+                                       IOTile::BlockK,
+                                       InputTA,
+                                       InputTB,
+                                       ComputeT,
+                                       MmaDimM,
+                                       MmaDimN>,
+                                  Wmma<IOTile::BlockM,
+                                       IOTile::BlockN,
+                                       IOTile::BlockK,
+                                       InputTA,
+                                       InputTB,
+                                       ComputeT,
+                                       MmaDimM,
+                                       MmaDimN>>;
     };
 
 } // namespace rocwmma

--- a/library/include/rocwmma/internal/opaque_load.hpp
+++ b/library/include/rocwmma/internal/opaque_load.hpp
@@ -63,8 +63,9 @@ namespace rocwmma
 
     } // namespace detail
 
-    template <class DataLayout, class MatrixLayout>
-    struct OpaqueLoad : public IOBearer<DataLayout, MatrixLayout, detail::OpaqueLoadBearer>
+    template <class DataLayout, class MatrixLayout, class BoundsCtrl = IOBoundsCtrl::Default>
+    struct OpaqueLoad
+        : public IOBearer<DataLayout, MatrixLayout, detail::OpaqueLoadBearer, BoundsCtrl>
     {
     };
 

--- a/library/include/rocwmma/internal/opaque_store.hpp
+++ b/library/include/rocwmma/internal/opaque_store.hpp
@@ -76,11 +76,12 @@ namespace rocwmma
 
     } // namespace detail
 
-    template <class DataLayout, class MatrixLayout>
-    struct OpaqueStore : public IOBearer<DataLayout, MatrixLayout, detail::OpaqueStoreBearer>
+    template <class DataLayout, class MatrixLayout, class BoundsCtrl = IOBoundsCtrl::Default>
+    struct OpaqueStore
+        : public IOBearer<DataLayout, MatrixLayout, detail::OpaqueStoreBearer, BoundsCtrl>
     {
     private:
-        using Base = IOBearer<DataLayout, MatrixLayout, detail::OpaqueStoreBearer>;
+        using Base = IOBearer<DataLayout, MatrixLayout, detail::OpaqueStoreBearer, BoundsCtrl>;
 
         // Don't expose the base implementation, we change arg forwarding order
         using Base::exec;

--- a/library/include/rocwmma/internal/types.hpp
+++ b/library/include/rocwmma/internal/types.hpp
@@ -60,6 +60,7 @@ namespace rocwmma
     using int64_t  = ::int64_t;
     using uint64_t = ::uint64_t;
     using index_t  = ::int32_t;
+    using size_t   = ::size_t;
 
 #else
 
@@ -72,6 +73,7 @@ namespace rocwmma
     using int64_t  = __hip_internal::int64_t;
     using uint64_t = __hip_internal::uint64_t;
     using index_t  = __hip_internal::int32_t;
+    using size_t   = __hip_internal::size_t;
 
 #endif // !defined(__HIPCC_RTC__)
 

--- a/library/include/rocwmma/internal/utility/math.hpp
+++ b/library/include/rocwmma/internal/utility/math.hpp
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#ifndef ROCWMMA_UTILITY_MATH_HPP
+#define ROCWMMA_UTILITY_MATH_HPP
+
+#include "../config.hpp"
+#include "type_traits.hpp"
+
+namespace rocwmma
+{
+    // Get the next multiple
+    template <typename IntT, typename = enable_if_integral_t<IntT>>
+    ROCWMMA_HOST_DEVICE static inline constexpr IntT next_multiple(const IntT val, const IntT lcm);
+
+    // Computes ceil(numerator/divisor) for integer types.
+    template <typename IntT0,
+              typename = enable_if_integral_t<IntT0>,
+              typename IntT1,
+              typename = enable_if_integral_t<IntT1>>
+    ROCWMMA_HOST_DEVICE static inline constexpr IntT0 ceil_div(const IntT0 numerator,
+                                                               const IntT1 divisor);
+
+    template <typename IntT, typename = enable_if_integral_t<IntT>>
+    ROCWMMA_HOST_DEVICE static inline constexpr IntT next_pow2(const IntT val);
+
+    // Computes if the integer is a power of 2.
+    template <typename IntT, typename = enable_if_integral_t<IntT>>
+    ROCWMMA_HOST_DEVICE static inline constexpr bool is_pow2(const IntT val);
+
+} // namespace rocwmma
+
+#include "math_impl.hpp"
+
+#endif // ROCWMMA_UTILITY_MATH_HPP

--- a/library/include/rocwmma/internal/utility/math.hpp
+++ b/library/include/rocwmma/internal/utility/math.hpp
@@ -51,6 +51,75 @@ namespace rocwmma
     template <typename IntT, typename = enable_if_integral_t<IntT>>
     ROCWMMA_HOST_DEVICE static inline constexpr bool is_pow2(const IntT val);
 
+    template <uint32_t x>
+    struct pow2
+    {
+        static constexpr uint32_t value = 2 * pow2<x - 1>::value;
+    };
+
+    template <>
+    struct pow2<1>
+    {
+        static constexpr uint32_t value = 2;
+    };
+
+    template <>
+    struct pow2<0>
+    {
+        static constexpr uint32_t value = 1;
+    };
+
+    // Calculate integer Log base 2
+    template <uint32_t x>
+    struct Log2
+    {
+        static constexpr uint32_t value = 1 + Log2<(x >> 1)>::value;
+        static_assert(x % 2 == 0, "Integer input must be a power of 2");
+    };
+
+    template <>
+    struct Log2<1>
+    {
+        static constexpr uint32_t value = 0;
+    };
+
+    template <>
+    struct Log2<0>
+    {
+        static constexpr uint32_t value = 0;
+    };
+
+    // Create a bitmask of size BitCount, starting from the LSB bit
+    template <uint32_t BitCount>
+    struct LsbMask;
+
+    template <>
+    struct LsbMask<1>
+    {
+        enum : uint32_t
+        {
+            value = 0x1
+        };
+    };
+
+    template <>
+    struct LsbMask<0>
+    {
+        enum : uint32_t
+        {
+            value = 0x0
+        };
+    };
+
+    template <uint32_t BitCount>
+    struct LsbMask
+    {
+        enum : uint32_t
+        {
+            value = LsbMask<1>::value << (BitCount - 1) | LsbMask<BitCount - 1>::value
+        };
+    };
+
 } // namespace rocwmma
 
 #include "math_impl.hpp"

--- a/library/include/rocwmma/internal/utility/math_impl.hpp
+++ b/library/include/rocwmma/internal/utility/math_impl.hpp
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#ifndef ROCWMMA_UTILITY_MATH_IMPL_HPP
+#define ROCWMMA_UTILITY_MATH_IMPL_HPP
+
+#include "math.hpp"
+
+namespace rocwmma
+{
+    // Get the next multiple
+    template <typename IntT, typename /*= enable_if_integral_t<IntT>*/>
+    ROCWMMA_HOST_DEVICE static inline constexpr IntT next_multiple(const IntT val, const IntT lcm)
+    {
+        return (val % lcm) ? (val + (lcm - val % lcm)) : val;
+    }
+
+    // Computes ceil(numerator/divisor) for integer types.
+    template <typename IntT0,
+              typename /*= enable_if_integral_t<IntT0>*/,
+              typename IntT1,
+              typename /*= enable_if_integral_t<IntT1>*/>
+    ROCWMMA_HOST_DEVICE static inline constexpr IntT0 ceil_div(const IntT0 numerator,
+                                                               const IntT1 divisor)
+    {
+        return (numerator + divisor - 1u) / divisor;
+    }
+
+    template <typename IntT, typename /*= enable_if_integral_t<IntT>*/>
+    ROCWMMA_HOST_DEVICE static inline constexpr IntT next_pow2(const IntT val)
+    {
+        // Precondition: x > 1.
+        return val > 1u ? (1u << (32u - __builtin_clz(val - 1u))) : val;
+    }
+
+    // Computes if the integer is a power of 2.
+    template <typename IntT, typename /*= enable_if_integral_t<IntT>*/>
+    ROCWMMA_HOST_DEVICE static inline constexpr bool is_pow2(const IntT val)
+    {
+        return val > 0u ? (val & (val - 1u)) == 0u : false;
+    }
+
+} // namespace rocwmma
+
+#endif // ROCWMMA_UTILITY_MATH_IMPL_HPP

--- a/library/include/rocwmma/internal/utility/static_for.hpp
+++ b/library/include/rocwmma/internal/utility/static_for.hpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#ifndef ROCWMMA_UTILITY_STATIC_FOR_HPP
+#define ROCWMMA_UTILITY_STATIC_FOR_HPP
+
+#include "static_for_impl.hpp"
+
+namespace rocwmma
+{
+    //! Statically unrolls an iterative for-loop sequence [from i = NBegin; i < NEnd; i += Increment]
+    //! Each iteration will invoke a Functor F with signature: F(I<i> it, args...), where I<i> is a
+    //! compile-time value of the current iterator i. It may be used with constexpr checks, where
+    //! you may access the value by decay_t<decltype(it)>::value
+    //! @param f Functor Functor F with signature: F(I<i> it, args...), where I<i> the iterator
+    //! @param args Additional arguments that are passed to functor
+    //! @tparam NBegin The start iterator value
+    //! @tparam NEnd The end iterator value
+    //! @tparam Increment The space between each iteration
+    //! @tparam F the type of input functor f
+    //! @tparam ArgsT the variadic list of additional input args to functor f.
+    template <index_t NBegin, index_t NEnd, index_t Increment, class F, typename... ArgsT>
+    ROCWMMA_HOST_DEVICE constexpr inline void static_for(F f, ArgsT&&... args)
+    {
+        detail::static_for<NBegin, NEnd, Increment>()(f, forward<ArgsT>(args)...);
+    }
+}
+
+#endif // ROCWMMA_UTILITY_STATIC_FOR_HPP

--- a/library/include/rocwmma/internal/utility/static_for_impl.hpp
+++ b/library/include/rocwmma/internal/utility/static_for_impl.hpp
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ *
+ * MIT License
+ *
+ * Copyright (C) 2021-2025 Advanced Micro Devices, Inc. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ *******************************************************************************/
+
+#ifndef ROCWMMA_UTILITY_STATIC_FOR_IMPL_HPP
+#define ROCWMMA_UTILITY_STATIC_FOR_IMPL_HPP
+
+#include "../types.hpp"
+#include "sequence.hpp"
+
+namespace rocwmma
+{
+    namespace detail
+    {
+
+        template <index_t NBegin, index_t NEnd, index_t Increment>
+        struct static_for
+        {
+            ROCWMMA_HOST_DEVICE constexpr static_for()
+            {
+                static_assert(Increment != 0 && (NEnd - NBegin) % Increment == 0,
+                              "Sequence length is not divisible by Increment");
+                static_assert((Increment > 0 && NBegin <= NEnd)
+                                  || (Increment < 0 && NBegin >= NEnd),
+                              "Invalid inputs");
+            }
+
+        private:
+            // F signature: F(I<Iter>)
+            template <class F, size_t... Indices, typename... ArgsT>
+            ROCWMMA_HOST_DEVICE constexpr void
+                impl(F f, index_sequence<Indices...>, ArgsT&&... args) const
+            {
+                ((f(I<Indices>{}, forward<ArgsT>(args)...), 0), ...);
+            }
+
+        public:
+            // F signature: F(I<Iter>)
+            template <class F, typename... ArgsT>
+            ROCWMMA_HOST_DEVICE constexpr void operator()(F f, ArgsT&&... args) const
+            {
+                impl(f,
+                     make_offset_index_sequence<(NEnd - NBegin) / Increment, NBegin, Increment>(),
+                     forward<ArgsT>(args)...);
+            }
+        };
+
+    } // namespace detail
+
+} // namespace rocwmma
+
+#endif // ROCWMMA_UTILITY_STATIC_FOR_IMPL_HPP

--- a/library/include/rocwmma/internal/utility/vector.hpp
+++ b/library/include/rocwmma/internal/utility/vector.hpp
@@ -76,6 +76,13 @@ namespace rocwmma
     template <typename VecT>
     ROCWMMA_HOST_DEVICE constexpr static inline auto vector_reduce_and(VecT&& v) noexcept;
 
+    /*! \brief Returns the reduction result of bit-wise and between all elements in the input vector
+    * @param v Input vector
+    * @tparam VecT Input vector type
+    */
+    template <typename VecT>
+    ROCWMMA_HOST_DEVICE constexpr static inline auto vector_reduce_or(VecT&& v) noexcept;
+
     /*! \brief Swaps elements in vector size of 2
     * @param v Input vector
     * @tparam VecT Templated input vector class
@@ -194,6 +201,16 @@ namespace rocwmma
               typename... ArgsT>
     ROCWMMA_HOST_DEVICE constexpr static inline auto
         vector_reduce2(VecT0&& v0, VecT1&& v1, Func&& func, ArgsT&&... args);
+
+    /*! \brief Creates a vector that contains a sequence of numbers starting at Start, incrementing
+    * by Stride for a VecSize number of steps.
+    * @tparam DataT Data type
+    * @tparam VecSize The size of the result vector
+    * @tparam Start The starting offset for the number set (Default = 0)
+    * @tparam Stride The step size between successive values (Default = 1)
+    */
+    template <typename DataT, uint32_t VecSize, uint32_t Start = 0u, uint32_t Stride = 1u>
+    ROCWMMA_HOST_DEVICE constexpr static inline auto make_vector_sequence();
 
 } // namespace rocwmma
 

--- a/library/include/rocwmma/internal/utility/vector_impl.hpp
+++ b/library/include/rocwmma/internal/utility/vector_impl.hpp
@@ -27,9 +27,9 @@
 #ifndef ROCWMMA_UTILITY_VECTOR_IMPL_HPP
 #define ROCWMMA_UTILITY_VECTOR_IMPL_HPP
 
-#include <rocwmma/internal/utility/get.hpp>
-#include <rocwmma/internal/utility/type_traits.hpp>
-#include <rocwmma/internal/vector_iterator.hpp>
+#include "../vector_iterator.hpp"
+#include "get.hpp"
+#include "type_traits.hpp"
 
 namespace rocwmma
 {
@@ -184,6 +184,12 @@ namespace rocwmma
     ROCWMMA_HOST_DEVICE constexpr static inline auto vector_reduce_and(VecT&& lhs) noexcept
     {
         return detail::vector_reduce<detail::BitwiseOp::And>(forward<VecT>(lhs));
+    }
+
+    template <typename VecT>
+    ROCWMMA_HOST_DEVICE constexpr static inline auto vector_reduce_or(VecT&& lhs) noexcept
+    {
+        return detail::vector_reduce<detail::BitwiseOp::Or>(forward<VecT>(lhs));
     }
 
     namespace detail
@@ -485,6 +491,21 @@ namespace rocwmma
     ROCWMMA_HOST_DEVICE constexpr static inline auto reduce_mult(VecT&& v0)
     {
         return apply([](auto&&... items) { return (items * ...); }, v0);
+    }
+
+    // Fwd declare
+    template <typename DataT, uint32_t VecSize>
+    struct vector_generator;
+
+    template <typename DataT, uint32_t VecSize, uint32_t Start /*= 0u*/, uint32_t Stride /*= 1u*/>
+    ROCWMMA_HOST_DEVICE constexpr static inline auto make_vector_sequence()
+    {
+        constexpr auto buildSeq = [](auto&& idx) {
+            constexpr auto Index = std::decay_t<decltype(idx)>::value;
+            return static_cast<DataT>(Start + Index * Stride);
+        };
+
+        return vector_generator<DataT, VecSize>()(buildSeq);
     }
 
 } // namespace rocwmma

--- a/library/include/rocwmma/internal/utils.hpp
+++ b/library/include/rocwmma/internal/utils.hpp
@@ -137,57 +137,6 @@ namespace std
 
 namespace rocwmma
 {
-    // Calculate integer Log base 2
-    template <uint32_t x>
-    struct Log2
-    {
-        static constexpr uint32_t value = 1 + Log2<(x >> 1)>::value;
-        static_assert(x % 2 == 0, "Integer input must be a power of 2");
-    };
-
-    template <>
-    struct Log2<1>
-    {
-        static constexpr uint32_t value = 0;
-    };
-
-    template <>
-    struct Log2<0>
-    {
-        static constexpr uint32_t value = 0;
-    };
-
-    // Create a bitmask of size BitCount, starting from the LSB bit
-    template <uint32_t BitCount>
-    struct LsbMask;
-
-    template <>
-    struct LsbMask<1>
-    {
-        enum : uint32_t
-        {
-            value = 0x1
-        };
-    };
-
-    template <>
-    struct LsbMask<0>
-    {
-        enum : uint32_t
-        {
-            value = 0x0
-        };
-    };
-
-    template <uint32_t BitCount>
-    struct LsbMask
-    {
-        enum : uint32_t
-        {
-            value = LsbMask<1>::value << (BitCount - 1) | LsbMask<BitCount - 1>::value
-        };
-    };
-
     // Helper for string representations of types
     template <typename DataT>
     constexpr const char* dataTypeToString();

--- a/library/include/rocwmma/internal/utils.hpp
+++ b/library/include/rocwmma/internal/utils.hpp
@@ -137,16 +137,6 @@ namespace std
 
 namespace rocwmma
 {
-    // Computes ceil(numerator/divisor) for integer types.
-    template <typename intT1,
-              class = typename enable_if<is_integral<intT1>::value>::type,
-              typename intT2,
-              class = typename enable_if<is_integral<intT2>::value>::type>
-    static constexpr intT1 ceilDiv(const intT1 numerator, const intT2 divisor)
-    {
-        return (numerator + divisor - 1) / divisor;
-    }
-
     // Calculate integer Log base 2
     template <uint32_t x>
     struct Log2

--- a/library/include/rocwmma/internal/vector.hpp
+++ b/library/include/rocwmma/internal/vector.hpp
@@ -29,6 +29,7 @@
 
 #include "types.hpp"
 #include "utility/forward.hpp"
+#include "utility/math.hpp"
 #include "utility/type_traits.hpp"
 
 /**
@@ -105,11 +106,6 @@
  *
  */
 
-inline constexpr auto next_pow2(uint32_t x)
-{
-    // Precondition: x > 1.
-    return x > 1u ? (1u << (32u - __builtin_clz(x - 1u))) : x;
-}
 namespace rocwmma
 {
     template <typename T, unsigned int Rank>
@@ -336,7 +332,7 @@ namespace rocwmma
     template <typename T, unsigned int Rank, enable_if_integral_t<T>* = nullptr>
     ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
         operator>>(non_native_vector_base<T, Rank> const& x,
-                  non_native_vector_base<T, Rank> const& y) noexcept;
+                   non_native_vector_base<T, Rank> const& y) noexcept;
 
     template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* = nullptr>
     ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
@@ -349,7 +345,7 @@ namespace rocwmma
     template <typename T, unsigned int Rank, enable_if_integral_t<T>* = nullptr>
     ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
         operator<<(non_native_vector_base<T, Rank> const& x,
-                  non_native_vector_base<T, Rank> const& y) noexcept;
+                   non_native_vector_base<T, Rank> const& y) noexcept;
 
     template <typename T, unsigned int Rank, typename U, enable_if_integral_t<T>* = nullptr>
     ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>

--- a/library/include/rocwmma/internal/vector_impl.hpp
+++ b/library/include/rocwmma/internal/vector_impl.hpp
@@ -239,6 +239,7 @@ namespace rocwmma
         // Helpers for expression expansion, specific to non_native_vector_base
         template <uint32_t... ns>
         using SeqT = integer_sequence<uint32_t, ns...>;
+
         template <uint32_t Rank>
         using Seq = make_integer_sequence<uint32_t, Rank>;
 
@@ -351,8 +352,8 @@ namespace rocwmma
     }
 
     template <typename T, unsigned int Rank>
-    ROCWMMA_HOST_DEVICE constexpr inline auto
-        non_native_vector_base<T, Rank>::operator++() noexcept -> VecT&
+    ROCWMMA_HOST_DEVICE constexpr inline auto non_native_vector_base<T, Rank>::operator++() noexcept
+        -> VecT&
     {
         return *this += VecT{static_cast<T>(1.0f)};
     }
@@ -367,8 +368,8 @@ namespace rocwmma
     }
 
     template <typename T, unsigned int Rank>
-    ROCWMMA_HOST_DEVICE constexpr inline auto
-        non_native_vector_base<T, Rank>::operator--() noexcept -> VecT&
+    ROCWMMA_HOST_DEVICE constexpr inline auto non_native_vector_base<T, Rank>::operator--() noexcept
+        -> VecT&
     {
         return *this -= VecT{static_cast<T>(1.0f)};
     }
@@ -662,7 +663,7 @@ namespace rocwmma
     template <typename T, unsigned int Rank, enable_if_integral_t<T>* /* = nullptr */>
     ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
         operator>>(non_native_vector_base<T, Rank> const& x,
-                  non_native_vector_base<T, Rank> const& y) noexcept
+                   non_native_vector_base<T, Rank> const& y) noexcept
     {
         return non_native_vector_base<T, Rank>{x} >>= y;
     }
@@ -684,7 +685,7 @@ namespace rocwmma
     template <typename T, unsigned int Rank, enable_if_integral_t<T>* /* = nullptr */>
     ROCWMMA_HOST_DEVICE inline constexpr non_native_vector_base<T, Rank>
         operator<<(non_native_vector_base<T, Rank> const& x,
-                  non_native_vector_base<T, Rank> const& y) noexcept
+                   non_native_vector_base<T, Rank> const& y) noexcept
     {
         return non_native_vector_base<T, Rank>{x} <<= y;
     }
@@ -772,7 +773,7 @@ namespace rocwmma
 #define ROCWMMA_HIP_NON_NATIVE_VECTOR_STORAGE_IMPL(TYPE, RANK)       \
     using Native_vec_ = rocwmma::non_native_vector_base<TYPE, RANK>; \
                                                                      \
-    union alignas(next_pow2(RANK * sizeof(TYPE)))                    \
+    union alignas(rocwmma::next_pow2(RANK * sizeof(TYPE)))           \
     {                                                                \
         Native_vec_ data;                                            \
         ROCWMMA_HIP_ACCESSOR_ALIAS_IMPL_RANK##RANK(TYPE);            \

--- a/library/include/rocwmma/internal/wmma_impl.hpp
+++ b/library/include/rocwmma/internal/wmma_impl.hpp
@@ -133,6 +133,66 @@ namespace rocwmma
                            float32_t,
                            16u,
                            16u,
+                           4u,
+                           GfxTargetId,
+                           enable_gfx11_t<GfxTargetId>>
+        {
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
+
+            // Packed register types
+            using ARegsT = VRegF32x2;
+            using BRegsT = VRegF32x2;
+            using CRegsT = AccRegF32x8;
+            using DRegsT = AccRegF32x8;
+
+            ROCWMMA_DEVICE static inline auto
+                exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
+            {
+                return amdgcn_wmma<float16_t, float16_t, float32_t, 16u, 16u, 8u, GfxTargetId>::
+                    exec(concat(regsA, ARegsT{0}),
+                         concat(regsB, BRegsT{0}),
+                         forward<CRegsT const&>(regsC));
+            }
+        };
+
+        template <uint32_t GfxTargetId>
+        struct amdgcn_wmma<float16_t,
+                           float16_t,
+                           float32_t,
+                           16u,
+                           16u,
+                           8u,
+                           GfxTargetId,
+                           enable_gfx11_t<GfxTargetId>>
+        {
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
+
+            // Packed register types
+            using ARegsT = VRegF32x4;
+            using BRegsT = VRegF32x4;
+            using CRegsT = AccRegF32x8;
+            using DRegsT = AccRegF32x8;
+
+            ROCWMMA_DEVICE static inline auto
+                exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
+            {
+                return amdgcn_wmma<float16_t, float16_t, float32_t, 16u, 16u, 16u, GfxTargetId>::
+                    exec(concat(regsA, ARegsT{0}),
+                         concat(regsB, BRegsT{0}),
+                         forward<CRegsT const&>(regsC));
+            }
+        };
+
+        template <uint32_t GfxTargetId>
+        struct amdgcn_wmma<float16_t,
+                           float16_t,
+                           float32_t,
+                           16u,
+                           16u,
                            16u,
                            GfxTargetId,
                            enable_gfx11_t<GfxTargetId>>
@@ -154,6 +214,66 @@ namespace rocwmma
                 result.data = {
                     __builtin_amdgcn_wmma_f32_16x16x16_f16_w32(regsA.data, regsB.data, regsC.data)};
                 return result;
+            }
+        };
+
+        template <uint32_t GfxTargetId>
+        struct amdgcn_wmma<float16_t,
+                           float16_t,
+                           float16_t,
+                           16u,
+                           16u,
+                           4u,
+                           GfxTargetId,
+                           enable_gfx11_t<GfxTargetId>>
+        {
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
+
+            // Packed register types
+            using ARegsT = VRegF32x2;
+            using BRegsT = VRegF32x2;
+            using CRegsT = AccRegF32x8;
+            using DRegsT = AccRegF32x8;
+
+            ROCWMMA_DEVICE static inline auto
+                exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
+            {
+                return amdgcn_wmma<float16_t, float16_t, float16_t, 16u, 16u, 8u, GfxTargetId>::
+                    exec(concat(regsA, ARegsT{0}),
+                         concat(regsB, BRegsT{0}),
+                         forward<CRegsT const&>(regsC));
+            }
+        };
+
+        template <uint32_t GfxTargetId>
+        struct amdgcn_wmma<float16_t,
+                           float16_t,
+                           float16_t,
+                           16u,
+                           16u,
+                           8u,
+                           GfxTargetId,
+                           enable_gfx11_t<GfxTargetId>>
+        {
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
+
+            // Packed register types
+            using ARegsT = VRegF32x4;
+            using BRegsT = VRegF32x4;
+            using CRegsT = AccRegF32x8;
+            using DRegsT = AccRegF32x8;
+
+            ROCWMMA_DEVICE static inline auto
+                exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
+            {
+                return amdgcn_wmma<float16_t, float16_t, float16_t, 16u, 16u, 16u, GfxTargetId>::
+                    exec(concat(regsA, ARegsT{0}),
+                         concat(regsB, BRegsT{0}),
+                         forward<CRegsT const&>(regsC));
             }
         };
 
@@ -193,6 +313,66 @@ namespace rocwmma
                            float32_t,
                            16u,
                            16u,
+                           4u,
+                           GfxTargetId,
+                           enable_gfx11_t<GfxTargetId>>
+        {
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
+
+            // Packed register types
+            using ARegsT = VRegF32x2;
+            using BRegsT = VRegF32x2;
+            using CRegsT = AccRegF32x8;
+            using DRegsT = AccRegF32x8;
+
+            ROCWMMA_DEVICE static inline auto
+                exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
+            {
+                return amdgcn_wmma<bfloat16_t, bfloat16_t, float32_t, 16u, 16u, 8u, GfxTargetId>::
+                    exec(concat(regsA, ARegsT{0}),
+                         concat(regsB, BRegsT{0}),
+                         forward<CRegsT const&>(regsC));
+            }
+        };
+
+        template <uint32_t GfxTargetId>
+        struct amdgcn_wmma<bfloat16_t,
+                           bfloat16_t,
+                           float32_t,
+                           16u,
+                           16u,
+                           8u,
+                           GfxTargetId,
+                           enable_gfx11_t<GfxTargetId>>
+        {
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
+
+            // Packed register types
+            using ARegsT = VRegF32x4;
+            using BRegsT = VRegF32x4;
+            using CRegsT = AccRegF32x8;
+            using DRegsT = AccRegF32x8;
+
+            ROCWMMA_DEVICE static inline auto
+                exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
+            {
+                return amdgcn_wmma<bfloat16_t, bfloat16_t, float32_t, 16u, 16u, 16u, GfxTargetId>::
+                    exec(concat(regsA, ARegsT{0}),
+                         concat(regsB, BRegsT{0}),
+                         forward<CRegsT const&>(regsC));
+            }
+        };
+
+        template <uint32_t GfxTargetId>
+        struct amdgcn_wmma<bfloat16_t,
+                           bfloat16_t,
+                           float32_t,
+                           16u,
+                           16u,
                            16u,
                            GfxTargetId,
                            enable_gfx11_t<GfxTargetId>>
@@ -223,6 +403,66 @@ namespace rocwmma
                            bfloat16_t,
                            16u,
                            16u,
+                           4u,
+                           GfxTargetId,
+                           enable_gfx11_t<GfxTargetId>>
+        {
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
+
+            // Packed register types
+            using ARegsT = VRegF32x2;
+            using BRegsT = VRegF32x2;
+            using CRegsT = AccRegF32x8;
+            using DRegsT = AccRegF32x8;
+
+            ROCWMMA_DEVICE static inline auto
+                exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
+            {
+                return amdgcn_wmma<bfloat16_t, bfloat16_t, bfloat16_t, 16u, 16u, 8u, GfxTargetId>::
+                    exec(concat(regsA, ARegsT{0}),
+                         concat(regsB, BRegsT{0}),
+                         forward<CRegsT const&>(regsC));
+            }
+        };
+
+        template <uint32_t GfxTargetId>
+        struct amdgcn_wmma<bfloat16_t,
+                           bfloat16_t,
+                           bfloat16_t,
+                           16u,
+                           16u,
+                           8u,
+                           GfxTargetId,
+                           enable_gfx11_t<GfxTargetId>>
+        {
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
+
+            // Packed register types
+            using ARegsT = VRegF32x4;
+            using BRegsT = VRegF32x4;
+            using CRegsT = AccRegF32x8;
+            using DRegsT = AccRegF32x8;
+
+            ROCWMMA_DEVICE static inline auto
+                exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
+            {
+                return amdgcn_wmma<bfloat16_t, bfloat16_t, bfloat16_t, 16u, 16u, 16u, GfxTargetId>::
+                    exec(concat(regsA, ARegsT{0}),
+                         concat(regsB, BRegsT{0}),
+                         forward<CRegsT const&>(regsC));
+            }
+        };
+
+        template <uint32_t GfxTargetId>
+        struct amdgcn_wmma<bfloat16_t,
+                           bfloat16_t,
+                           bfloat16_t,
+                           16u,
+                           16u,
                            16u,
                            GfxTargetId,
                            enable_gfx11_t<GfxTargetId>>
@@ -244,6 +484,36 @@ namespace rocwmma
                 result.data = {__builtin_amdgcn_wmma_bf16_16x16x16_bf16_w32(
                     regsA.data, regsB.data, regsC.data, (bool)AccumBits)};
                 return result;
+            }
+        };
+
+        template <uint32_t GfxTargetId>
+        struct amdgcn_wmma<int8_t,
+                           int8_t,
+                           int32_t,
+                           16u,
+                           16u,
+                           8u,
+                           GfxTargetId,
+                           enable_gfx11_t<GfxTargetId>>
+        {
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
+
+            // Packed register types
+            using ARegsT = VRegI32x2;
+            using BRegsT = VRegI32x2;
+            using CRegsT = AccRegI32x8;
+            using DRegsT = AccRegI32x8;
+
+            ROCWMMA_DEVICE static inline auto
+                exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
+            {
+                return amdgcn_wmma<int8_t, int8_t, int32_t, 16u, 16u, 16u, GfxTargetId>::exec(
+                    concat(regsA, ARegsT{0}),
+                    concat(regsB, BRegsT{0}),
+                    forward<CRegsT const&>(regsC));
             }
         };
 
@@ -288,6 +558,66 @@ namespace rocwmma
                            float32_t,
                            16u,
                            16u,
+                           4u,
+                           GfxTargetId,
+                           enable_gfx12_t<GfxTargetId>>
+        {
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
+
+            // Packed register types
+            using ARegsT = VRegF32x1;
+            using BRegsT = VRegF32x1;
+            using CRegsT = AccRegF32x8;
+            using DRegsT = AccRegF32x8;
+
+            ROCWMMA_DEVICE static inline auto
+                exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
+            {
+                return amdgcn_wmma<float16_t, float16_t, float32_t, 16u, 16u, 8u, GfxTargetId>::
+                    exec(concat(regsA, ARegsT{0}),
+                         concat(regsB, BRegsT{0}),
+                         forward<CRegsT const&>(regsC));
+            }
+        };
+
+        template <uint32_t GfxTargetId>
+        struct amdgcn_wmma<float16_t,
+                           float16_t,
+                           float32_t,
+                           16u,
+                           16u,
+                           8u,
+                           GfxTargetId,
+                           enable_gfx12_t<GfxTargetId>>
+        {
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
+
+            // Packed register types
+            using ARegsT = VRegF32x2;
+            using BRegsT = VRegF32x2;
+            using CRegsT = AccRegF32x8;
+            using DRegsT = AccRegF32x8;
+
+            ROCWMMA_DEVICE static inline auto
+                exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
+            {
+                return amdgcn_wmma<float16_t, float16_t, float32_t, 16u, 16u, 16u, GfxTargetId>::
+                    exec(concat(regsA, ARegsT{0}),
+                         concat(regsB, BRegsT{0}),
+                         forward<CRegsT const&>(regsC));
+            }
+        };
+
+        template <uint32_t GfxTargetId>
+        struct amdgcn_wmma<float16_t,
+                           float16_t,
+                           float32_t,
+                           16u,
+                           16u,
                            16u,
                            GfxTargetId,
                            enable_gfx12_t<GfxTargetId>>
@@ -309,6 +639,66 @@ namespace rocwmma
                 result.data = {__builtin_amdgcn_wmma_f32_16x16x16_f16_w32_gfx12(
                     regsA.data, regsB.data, regsC.data)};
                 return result;
+            }
+        };
+
+        template <uint32_t GfxTargetId>
+        struct amdgcn_wmma<float16_t,
+                           float16_t,
+                           float16_t,
+                           16u,
+                           16u,
+                           4u,
+                           GfxTargetId,
+                           enable_gfx12_t<GfxTargetId>>
+        {
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
+
+            // Packed register types
+            using ARegsT = VRegF32x1;
+            using BRegsT = VRegF32x1;
+            using CRegsT = AccRegF32x4;
+            using DRegsT = AccRegF32x4;
+
+            ROCWMMA_DEVICE static inline auto
+                exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
+            {
+                return amdgcn_wmma<float16_t, float16_t, float16_t, 16u, 16u, 8u, GfxTargetId>::
+                    exec(concat(regsA, ARegsT{0}),
+                         concat(regsB, BRegsT{0}),
+                         forward<CRegsT const&>(regsC));
+            }
+        };
+
+        template <uint32_t GfxTargetId>
+        struct amdgcn_wmma<float16_t,
+                           float16_t,
+                           float16_t,
+                           16u,
+                           16u,
+                           8u,
+                           GfxTargetId,
+                           enable_gfx12_t<GfxTargetId>>
+        {
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
+
+            // Packed register types
+            using ARegsT = VRegF32x2;
+            using BRegsT = VRegF32x2;
+            using CRegsT = AccRegF32x4;
+            using DRegsT = AccRegF32x4;
+
+            ROCWMMA_DEVICE static inline auto
+                exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
+            {
+                return amdgcn_wmma<float16_t, float16_t, float16_t, 16u, 16u, 16u, GfxTargetId>::
+                    exec(concat(regsA, ARegsT{0}),
+                         concat(regsB, BRegsT{0}),
+                         forward<CRegsT const&>(regsC));
             }
         };
 
@@ -348,6 +738,66 @@ namespace rocwmma
                            float32_t,
                            16u,
                            16u,
+                           4u,
+                           GfxTargetId,
+                           enable_gfx12_t<GfxTargetId>>
+        {
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
+
+            // Packed register types
+            using ARegsT = VRegF32x1;
+            using BRegsT = VRegF32x1;
+            using CRegsT = AccRegF32x8;
+            using DRegsT = AccRegF32x8;
+
+            ROCWMMA_DEVICE static inline auto
+                exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
+            {
+                return amdgcn_wmma<bfloat16_t, bfloat16_t, float32_t, 16u, 16u, 8u, GfxTargetId>::
+                    exec(concat(regsA, ARegsT{0}),
+                         concat(regsB, BRegsT{0}),
+                         forward<CRegsT const&>(regsC));
+            }
+        };
+
+        template <uint32_t GfxTargetId>
+        struct amdgcn_wmma<bfloat16_t,
+                           bfloat16_t,
+                           float32_t,
+                           16u,
+                           16u,
+                           8u,
+                           GfxTargetId,
+                           enable_gfx12_t<GfxTargetId>>
+        {
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
+
+            // Packed register types
+            using ARegsT = VRegF32x2;
+            using BRegsT = VRegF32x2;
+            using CRegsT = AccRegF32x8;
+            using DRegsT = AccRegF32x8;
+
+            ROCWMMA_DEVICE static inline auto
+                exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
+            {
+                return amdgcn_wmma<bfloat16_t, bfloat16_t, float32_t, 16u, 16u, 16u, GfxTargetId>::
+                    exec(concat(regsA, ARegsT{0}),
+                         concat(regsB, BRegsT{0}),
+                         forward<CRegsT const&>(regsC));
+            }
+        };
+
+        template <uint32_t GfxTargetId>
+        struct amdgcn_wmma<bfloat16_t,
+                           bfloat16_t,
+                           float32_t,
+                           16u,
+                           16u,
                            16u,
                            GfxTargetId,
                            enable_gfx12_t<GfxTargetId>>
@@ -369,6 +819,66 @@ namespace rocwmma
                 result.data = {__builtin_amdgcn_wmma_f32_16x16x16_bf16_w32_gfx12(
                     regsA.data, regsB.data, regsC.data)};
                 return result;
+            }
+        };
+
+        template <uint32_t GfxTargetId>
+        struct amdgcn_wmma<bfloat16_t,
+                           bfloat16_t,
+                           bfloat16_t,
+                           16u,
+                           16u,
+                           4u,
+                           GfxTargetId,
+                           enable_gfx12_t<GfxTargetId>>
+        {
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
+
+            // Packed register types
+            using ARegsT = VRegF32x1;
+            using BRegsT = VRegF32x1;
+            using CRegsT = VRegF32x4;
+            using DRegsT = VRegF32x4;
+
+            ROCWMMA_DEVICE static inline auto
+                exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
+            {
+                return amdgcn_wmma<bfloat16_t, bfloat16_t, bfloat16_t, 16u, 16u, 8u, GfxTargetId>::
+                    exec(concat(regsA, ARegsT{0}),
+                         concat(regsB, BRegsT{0}),
+                         forward<CRegsT const&>(regsC));
+            }
+        };
+
+        template <uint32_t GfxTargetId>
+        struct amdgcn_wmma<bfloat16_t,
+                           bfloat16_t,
+                           bfloat16_t,
+                           16u,
+                           16u,
+                           8u,
+                           GfxTargetId,
+                           enable_gfx12_t<GfxTargetId>>
+        {
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
+
+            // Packed register types
+            using ARegsT = VRegF32x2;
+            using BRegsT = VRegF32x2;
+            using CRegsT = VRegF32x4;
+            using DRegsT = VRegF32x4;
+
+            ROCWMMA_DEVICE static inline auto
+                exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
+            {
+                return amdgcn_wmma<bfloat16_t, bfloat16_t, bfloat16_t, 16u, 16u, 16u, GfxTargetId>::
+                    exec(concat(regsA, ARegsT{0}),
+                         concat(regsB, BRegsT{0}),
+                         forward<CRegsT const&>(regsC));
             }
         };
 
@@ -408,6 +918,36 @@ namespace rocwmma
                            int32_t,
                            16u,
                            16u,
+                           8u,
+                           GfxTargetId,
+                           enable_gfx12_t<GfxTargetId>>
+        {
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
+
+            // Packed register types
+            using ARegsT = VRegI32x1;
+            using BRegsT = VRegI32x1;
+            using CRegsT = AccRegI32x8;
+            using DRegsT = AccRegI32x8;
+
+            ROCWMMA_DEVICE static inline auto
+                exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
+            {
+                return amdgcn_wmma<int8_t, int8_t, int32_t, 16u, 16u, 16u, GfxTargetId>::exec(
+                    concat(regsA, ARegsT{0}),
+                    concat(regsB, BRegsT{0}),
+                    forward<CRegsT const&>(regsC));
+            }
+        };
+
+        template <uint32_t GfxTargetId>
+        struct amdgcn_wmma<int8_t,
+                           int8_t,
+                           int32_t,
+                           16u,
+                           16u,
                            16u,
                            GfxTargetId,
                            enable_gfx12_t<GfxTargetId>>
@@ -433,6 +973,36 @@ namespace rocwmma
                                                                                 regsC.data,
                                                                                 (bool)AccumSign)};
                 return result;
+            }
+        };
+
+        template <uint32_t GfxTargetId>
+        struct amdgcn_wmma<float8_t,
+                           float8_t,
+                           float32_t,
+                           16u,
+                           16u,
+                           8u,
+                           GfxTargetId,
+                           enable_gfx12_t<GfxTargetId>>
+        {
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
+
+            // Packed register types
+            using ARegsT = VRegF32x1;
+            using BRegsT = VRegF32x1;
+            using CRegsT = AccRegF32x8;
+            using DRegsT = AccRegF32x8;
+
+            ROCWMMA_DEVICE static inline auto
+                exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
+            {
+                return amdgcn_wmma<float8_t, float8_t, float32_t, 16u, 16u, 16u, GfxTargetId>::exec(
+                    concat(regsA, ARegsT{0}),
+                    concat(regsB, BRegsT{0}),
+                    forward<CRegsT const&>(regsC));
             }
         };
 
@@ -482,6 +1052,36 @@ namespace rocwmma
                            float32_t,
                            16u,
                            16u,
+                           8u,
+                           GfxTargetId,
+                           enable_gfx12_t<GfxTargetId>>
+        {
+            constexpr static WmmaCtrlFlags InputSign = WmmaCtrlFlags::SIGNED;
+            constexpr static WmmaCtrlFlags AccumBits = WmmaCtrlFlags::LOW;
+            constexpr static WmmaCtrlFlags AccumSign = WmmaCtrlFlags::SIGNED;
+
+            // Packed register types
+            using ARegsT = VRegF32x1;
+            using BRegsT = VRegF32x1;
+            using CRegsT = AccRegF32x8;
+            using DRegsT = AccRegF32x8;
+
+            ROCWMMA_DEVICE static inline auto
+                exec(ARegsT const& regsA, BRegsT const& regsB, CRegsT const& regsC) -> DRegsT
+            {
+                return amdgcn_wmma<bfloat8_t, bfloat8_t, float32_t, 16u, 16u, 16u, GfxTargetId>::
+                    exec(concat(regsA, ARegsT{0}),
+                         concat(regsB, BRegsT{0}),
+                         forward<CRegsT const&>(regsC));
+            }
+        };
+
+        template <uint32_t GfxTargetId>
+        struct amdgcn_wmma<bfloat8_t,
+                           bfloat8_t,
+                           float32_t,
+                           16u,
+                           16u,
                            16u,
                            GfxTargetId,
                            enable_gfx12_t<GfxTargetId>>
@@ -517,29 +1117,29 @@ namespace rocwmma
         };
 
         // Derivative implementations
-        template <uint32_t GfxTargetId>
+        template <uint32_t GfxTargetId, uint32_t BlockK>
         struct amdgcn_wmma<hfloat16_t,
                            hfloat16_t,
                            float32_t,
                            16u,
                            16u,
-                           16u,
+                           BlockK,
                            GfxTargetId,
                            enable_gfx11_gfx12_t<GfxTargetId, !(bool)ROCWMMA_NO_HALF>>
-            : public amdgcn_wmma<float16_t, float16_t, float32_t, 16u, 16u, 16u, GfxTargetId>
+            : public amdgcn_wmma<float16_t, float16_t, float32_t, 16u, 16u, BlockK, GfxTargetId>
         {
         };
 
-        template <uint32_t GfxTargetId>
+        template <uint32_t GfxTargetId, uint32_t BlockK>
         struct amdgcn_wmma<hfloat16_t,
                            hfloat16_t,
                            hfloat16_t,
                            16u,
                            16u,
-                           16u,
+                           BlockK,
                            GfxTargetId,
                            enable_gfx11_gfx12_t<GfxTargetId, !(bool)ROCWMMA_NO_HALF>>
-            : public amdgcn_wmma<float16_t, float16_t, float16_t, 16u, 16u, 16u, GfxTargetId>
+            : public amdgcn_wmma<float16_t, float16_t, float16_t, 16u, 16u, BlockK, GfxTargetId>
         {
         };
 

--- a/library/include/rocwmma/rocwmma_transforms_impl.hpp
+++ b/library/include/rocwmma/rocwmma_transforms_impl.hpp
@@ -135,6 +135,12 @@ namespace rocwmma
             using IOConfigA = GetIOConfig_t<FragA>;
             using IOConfigB = GetIOConfig_t<FragB>;
 
+            static_assert(IOConfigA::IOBounds::BlockHeight == IOConfigB::IOBounds::BlockWidth);
+            static_assert(IOConfigB::IOBounds::BlockHeight == IOConfigA::IOBounds::BlockWidth);
+
+            static_assert(IOConfigA::IOTile::BlockM == IOConfigB::IOTile::BlockN);
+            static_assert(IOConfigB::IOTile::BlockM == IOConfigA::IOTile::BlockN);
+
             // Assumptions check
             static_assert(IOConfigA::IOShape::BlockDim == IOConfigB::IOShape::BlockDim,
                           "BlockDim of transposed frag doesn't match");
@@ -211,9 +217,9 @@ namespace rocwmma
                 using DstLayout =
                     typename GetCoopIOConfig_t<DstFrag, WaveCount>::IOLayout::FragmentLayout;
 
-                auto result = DstFrag{};
-                result.mAccess
-                    = register_layout_transform<SrcLayout, DstLayout, WaveCount>::exec(frag.mAccess);
+                auto result    = DstFrag{};
+                result.mAccess = register_layout_transform<SrcLayout, DstLayout, WaveCount>::exec(
+                    frag.mAccess);
                 return result;
             }
         };
@@ -233,7 +239,12 @@ namespace rocwmma
             constexpr static const uint32_t registerFileWidth = Constants::AMDGCN_WAVE_SIZE;
 
         public:
-            using Type = fragment<matrix_b, 1, registerFileWidth, FragT::size(), DataT, DataLayout>;
+            using Type = fragment<matrix_b,
+                                  registerFileWidth,
+                                  registerFileWidth,
+                                  FragT::size(),
+                                  DataT,
+                                  DataLayout>;
         };
 
     } // namespace detail

--- a/samples/hipRTC_gemm.cpp
+++ b/samples/hipRTC_gemm.cpp
@@ -275,8 +275,8 @@ int main()
     CHECK_HIP_ERROR(hipMemcpy(d_d, matrixD.data(), bytesD, hipMemcpyHostToDevice));
 
     auto blockDim = dim3(T_BLOCK_X, T_BLOCK_Y);
-    auto gridDim  = dim3(rocwmma::ceilDiv(m, ROCWMMA_M * T_BLOCK_X / WAVE_SIZE),
-                        rocwmma::ceilDiv(n, ROCWMMA_N * T_BLOCK_Y));
+    auto gridDim  = dim3(rocwmma::ceil_div(m, ROCWMMA_M * T_BLOCK_X / WAVE_SIZE),
+                        rocwmma::ceil_div(n, ROCWMMA_N * T_BLOCK_Y));
 
     struct
     {

--- a/samples/perf_dgemm.cpp
+++ b/samples/perf_dgemm.cpp
@@ -733,8 +733,8 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, ComputeT alpha, 
     CHECK_HIP_ERROR(hipMemcpy(d_d, matrixD.data(), bytesD, hipMemcpyHostToDevice));
 
     auto blockDim = dim3(TBLOCK_X, TBLOCK_Y);
-    auto gridDim  = dim3(rocwmma::ceilDiv(m, get<0>(macroTileSize)),
-                        rocwmma::ceilDiv(n, get<1>(macroTileSize)));
+    auto gridDim  = dim3(rocwmma::ceil_div(m, get<0>(macroTileSize)),
+                        rocwmma::ceil_div(n, get<1>(macroTileSize)));
 
     std::cout << "Launching GEMM kernel..." << std::endl;
     std::cout << "gridDim (" << gridDim.x << " " << gridDim.y << ")"

--- a/samples/perf_hgemm.cpp
+++ b/samples/perf_hgemm.cpp
@@ -68,32 +68,32 @@
 * they march through the K dimension.
 *
 * Block size:      (BlockM x BlockN)
-* Warp tile size:  (BlocksX * BlockSize.x) x (BlocksY * BlockSize.y)
-* Macro Tile size: (TBlock.x * WarpTileSize.x) x (TBlock.y * WarpTileSize.y)
+* Warp tile size:  (BlocksM * BlockSize.x) x (BlocksN * BlockSize.y)
+* Macro Tile size: (TBlock.x / WarpSize * WarpTileSize.x) x (TBlock.y * WarpTileSize.y)
 *
 * Wave data share input A: same row
 * Wave data share input B: same col
 *
-* Global D layout & warp assignment for BlocksX = BlocksY = 2, 2x2 Warps
+* Global D layout & warp assignment for BlocksM = BlocksN = 2, 2x2 Warps
 *
 * W (X, Y) = wave row X, col Y
-*                                     |--------- Macro Tile Y-------------|
-*                                     |-- Wave Tile Y --|
+*                                     |--------- Macro Tile N-------------|
+*                                     |-- Wave Tile N --|
 *                                     |-BlockN-|
 *
-*                                      BlockN x BlocksY   BlockN x BlocksY
-*                                     |<--------------->|<--------------->|
+*                                       BlockN x BlocksN   BlockN x BlocksN
+*                                      |<--------------->|<--------------->|
 *      _ _   _ _      _ _          ___  ________ ________ ________ ________
 *       |     |        |            ^  |        |        |        |        |
 *       | Wave| BlockM |   BlockM   |  |        W        |        W        |
 *       | Tile|       _|_     x     |  |__   (0, 0)    __|__   (0, 1)    __|
-*       |  X  |            BlocksX  |  |                 |                 |
+*       |  M  |            BlocksM  |  |                 |                 |
 * Macro |     |                     |  |                 |                 |
 *  Tile |    _|_                   _v_ |________|________|________|________|
-*   X   |                           ^  |        |        |        |        |
+*   M   |                           ^  |        |        |        |        |
 *       |                  BlockM   |  |        W        |        W        |
 *       |                     x     |  |__   (1, 0)    __|__   (1, 1)    __|
-*       |                  BlocksX  |  |                 |                 |
+*       |                  BlocksM  |  |                 |                 |
 *       |                           |  |                 |                 |
 *      _|_                         _v_ |________|________|________|________|
 *
@@ -171,7 +171,7 @@
 *          |         |   |    |    |                  |      |
 *          |         |   |    |    |                  |      |
 *  Macro   |  BlockM |   | C0 | C1 | C2               | Ck-1 |   A0
-*  Tile X  |         |   |    |    |                  |      |
+*  Tile M  |         |   |    |    |                  |      |
 *          |         --> |___ |___ |____    ...       |______|
 *          |         .
 *          |         .          ...  ...  ...  ...          AX-1
@@ -180,21 +180,17 @@
 *          |         |   |    |    |                  |      |
 *          |         |   |    |    |                  |      |
 *  Macro   |  BlockN |   | R0 | R1 | R2               | Rk-1 |   B0 (T)
-*  Tile Y  |         |   |    |    |                  |      |
+*  Tile N  |         |   |    |    |                  |      |
 *          |         --> |___ |___ |____    ...       |______|
 *          |         .
 *          |         .          ...  ...  ...  ...        BY-1 (T)
-*          -->                                           (MacroTileX + MacroTileY - 1, BlockK -1)
+*          -->                                           (MacroTileM + MacroTileN - 1, BlockK -1)
 *
 * Depending on the locality of the block being processed, warps load the corresponding
 * A and B inputs from LDS buffer and use them for the accumulation of AxB calculations.
 */
 
 using namespace rocwmma;
-
-///
-/// Parameter configuration
-///
 
 /* Depending on the GPU architecture this sample is run on, the following kernel parameters need to
 *  be modified in order to obtain high performance.
@@ -228,8 +224,8 @@ namespace gfx9Params
         ROCWMMA_M = 32u,
         ROCWMMA_N = 32u,
         ROCWMMA_K = 16u,
-        BLOCKS_X  = 2u,
-        BLOCKS_Y  = 2u,
+        BLOCKS_M  = 2u,
+        BLOCKS_N  = 2u,
         TBLOCK_X  = 128u,
         TBLOCK_Y  = 2u,
         WARP_SIZE = Constants::AMDGCN_WAVE_SIZE_64
@@ -243,10 +239,10 @@ namespace gfx11Params
         ROCWMMA_M = 16u,
         ROCWMMA_N = 16u,
         ROCWMMA_K = 16u,
-        BLOCKS_X  = 4u,
-        BLOCKS_Y  = 2u,
+        BLOCKS_M  = 4u,
+        BLOCKS_N  = 2u,
         TBLOCK_X  = 64u,
-        TBLOCK_Y  = 4u,
+        TBLOCK_Y  = 2u,
         WARP_SIZE = Constants::AMDGCN_WAVE_SIZE_32
     };
 }
@@ -257,10 +253,7 @@ using namespace gfx9Params;
 using namespace gfx11Params;
 #endif // defined(ROCWMMA_ARCH_GFX9)
 
-///
-/// Types and Data Layouts
-///
-
+// Types and Data Layouts
 using InputT   = float16_t;
 using OutputT  = float16_t;
 using ComputeT = float32_t;
@@ -270,250 +263,57 @@ using DataLayoutB   = row_major;
 using DataLayoutC   = row_major;
 using DataLayoutLds = col_major;
 
-///
-/// Fragment types
-///
-
-// #if (ROCWMMA_ARCH_GFX9 || ROCWMMA_ARCH_GFX11)
 // Warp tile: computed by each warp
-constexpr uint32_t WARP_TILE_X = BLOCKS_X * ROCWMMA_M;
-constexpr uint32_t WARP_TILE_Y = BLOCKS_Y * ROCWMMA_N;
+constexpr uint32_t WARP_TILE_M = BLOCKS_M * ROCWMMA_M;
+constexpr uint32_t WARP_TILE_N = BLOCKS_N * ROCWMMA_N;
+constexpr uint32_t WARP_TILE_K = ROCWMMA_K;
 
 // Macro Tile: computed by each thread block (workgroup)
-// Note: TBLOCK_X must be multiple of WARP_SIZE.
-constexpr uint32_t WARPS_X      = TBLOCK_X / WARP_SIZE;
-constexpr uint32_t WARPS_Y      = TBLOCK_Y;
-constexpr uint32_t MACRO_TILE_X = WARPS_X * WARP_TILE_X;
-constexpr uint32_t MACRO_TILE_Y = WARPS_Y * WARP_TILE_Y;
+// Note: TBLOCK_M must be multiple of WARP_SIZE.
+constexpr uint32_t WARPS_M      = TBLOCK_X / WARP_SIZE;
+constexpr uint32_t WARPS_N      = TBLOCK_Y;
+constexpr uint32_t WARP_COUNT   = WARPS_M * WARPS_N;
+constexpr uint32_t MACRO_TILE_M = WARPS_M * WARP_TILE_M;
+constexpr uint32_t MACRO_TILE_N = WARPS_N * WARP_TILE_N;
+constexpr uint32_t MACRO_TILE_K = ROCWMMA_K;
 
-// Mfma frags
-using MfmaFragA   = fragment<matrix_a, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, InputT, DataLayoutA>;
-using MfmaFragB   = fragment<matrix_b, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, InputT, DataLayoutB>;
-using MfmaFragC   = fragment<accumulator, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, OutputT, DataLayoutC>;
-using MfmaFragD   = MfmaFragC;
-using MfmaFragAcc = fragment<accumulator, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, ComputeT>;
+// Mma frags (warp tile)
+using MmaFragA = fragment<matrix_a, WARP_TILE_M, WARP_TILE_N, WARP_TILE_K, InputT, DataLayoutA>;
+using MmaFragB = fragment<matrix_b, WARP_TILE_M, WARP_TILE_N, WARP_TILE_K, InputT, DataLayoutB>;
+using MmaFragC = fragment<accumulator, WARP_TILE_M, WARP_TILE_N, WARP_TILE_K, OutputT, DataLayoutC>;
+using MmaFragD = MmaFragC;
+using MmaFragAcc = fragment<accumulator, WARP_TILE_M, WARP_TILE_N, WARP_TILE_K, ComputeT>;
 
 // Global read (macro tile)
-using GRBuffA = fragment<matrix_a, MACRO_TILE_X, ROCWMMA_N, ROCWMMA_K, InputT, DataLayoutA>;
-using GRBuffB = fragment<matrix_b, ROCWMMA_M, MACRO_TILE_Y, ROCWMMA_K, InputT, DataLayoutB>;
+using GRFragA = fragment<matrix_a, MACRO_TILE_M, MACRO_TILE_N, MACRO_TILE_K, InputT, DataLayoutA>;
+using GRFragB = fragment<matrix_b, MACRO_TILE_M, MACRO_TILE_N, MACRO_TILE_K, InputT, DataLayoutB>;
 
 // Local write of global buffers (macro tile)
 // - Must match Lds data layout.
 // - Lds has transposed B frags.
-using LWBuffA = ApplyDataLayout_t<GRBuffA, DataLayoutLds>;
-using LWBuffB = ApplyDataLayout_t<ApplyTranspose_t<GRBuffB>, DataLayoutLds>;
+using LWFragA = ApplyDataLayout_t<GRFragA, DataLayoutLds>;
+using LWFragB = ApplyDataLayout_t<ApplyTranspose_t<GRFragB>, DataLayoutLds>;
+
+// Transform helpers
+constexpr auto transformGRFragAToLWFragA
+    = [](GRFragA const& grFragA) { return applyDataLayout<DataLayoutLds, WARP_COUNT>(grFragA); };
+
+constexpr auto transformGRFragBToLWFragB = [](GRFragB const& grFragB) {
+    return applyDataLayout<DataLayoutLds, WARP_COUNT>(applyTranspose(grFragB));
+};
 
 // Local read (mfma frags)
 // - Must match Lds data layout.
 // - Lds has transposed B frags.
-using LRFragA = ApplyDataLayout_t<MfmaFragA, DataLayoutLds>;
-using LRFragB = ApplyDataLayout_t<ApplyTranspose_t<MfmaFragB>, DataLayoutLds>;
-// #endif // (ROCWMMA_ARCH_GFX9 || ROCWMMA_ARCH_GFX11)
+using LRFragA = ApplyDataLayout_t<MmaFragA, DataLayoutLds>;
+using LRFragB = ApplyDataLayout_t<ApplyTranspose_t<MmaFragB>, DataLayoutLds>;
 
-///
-/// Wrapper functions: repeat mfma tile operations across entire warp tile.
-///
+// Transform helpers
+constexpr auto transformLRFragAToMmaFragA
+    = [](LRFragA const& lrFragA) { return applyDataLayout<DataLayoutA>(lrFragA); };
 
-// Cooperative global read / local write (Macro tile data movement)
-// Loads / stores a global data fragment cooperatively across warps. Each participating warp is
-// responsible for only a portion of the whole fragment.
-//
-// The cooperative operation is split into work items (SplitCount). Work items are consumed in
-// a round robin fashion by warps in the range of [0, WaveCount). The wave index determines the
-// order of the current wave in the collaboration pool.
-//
-// WaveCount, SplitCount and waveIndex parameters must match successive coop load / store calls
-// to ensure the entire fragment remains coherent.
-
-// Global A reads in cooperative mode (macro tile)
-template <uint32_t WaveCountA>
-ROCWMMA_DEVICE static inline void
-    globalReadCoopA(GRBuffA& grBuffA, InputT const* gAddrA, uint32_t lda, uint32_t waveIndexA)
-{
-    load_matrix_coop_sync<WaveCountA>(grBuffA, gAddrA, lda, waveIndexA);
-}
-
-// Global B reads in cooperative mode (macro tile)
-template <uint32_t WaveCountB>
-ROCWMMA_DEVICE static inline void
-    globalReadCoopB(GRBuffB& grBuffB, InputT const* gAddrB, uint32_t ldb, uint32_t waveIndexB)
-{
-    load_matrix_coop_sync<WaveCountB>(grBuffB, gAddrB, ldb, waveIndexB);
-}
-
-// Local A writes in cooperative mode (macro tile)
-template <uint32_t WaveCountA>
-ROCWMMA_DEVICE static inline void
-    localWriteCoopA(InputT* ldsAddr, GRBuffA const& grBuffA, uint32_t ldsld, uint32_t waveIndexA)
-{
-    // No transpose, but apply the lds data layout
-    store_matrix_coop_sync<WaveCountA>(
-        ldsAddr, applyDataLayout<DataLayoutLds, WaveCountA>(grBuffA), ldsld, waveIndexA);
-}
-
-// Local B writes in cooperative mode (macro tile)
-template <uint32_t WaveCountB>
-ROCWMMA_DEVICE static inline void
-    localWriteCoopB(InputT* ldsAddr, GRBuffB const& grBuffB, uint32_t ldsld, uint32_t waveIndexB)
-{
-    // Transpose B and then apply lds data layout
-    store_matrix_coop_sync<WaveCountB>(
-        ldsAddr,
-        applyDataLayout<DataLayoutLds, WaveCountB>(applyTranspose(grBuffB)),
-        ldsld,
-        waveIndexB);
-}
-
-// Local A reads for warp tile gemm, non-cooperative
-ROCWMMA_DEVICE static inline void
-    localReadA(MfmaFragA (&fragsA)[BLOCKS_X], InputT const* ldsAddrA, uint32_t ldsld)
-{
-    using FragShape = GetIOShape_t<LRFragA>;
-    using Mapper1d  = GetDataLayout_t<LRFragA>;
-
-    // Each A block is stacked vertically in LDS
-    auto blockStep = Mapper1d::fromMatrixCoord(make_coord2d(FragShape::BlockHeight, 0u), ldsld);
-
-#pragma unroll
-    for(int i = 0; i < BLOCKS_X; i++)
-    {
-        LRFragA tmp;
-        load_matrix_sync(tmp, ldsAddrA, ldsld);
-        fragsA[i] = applyDataLayout<DataLayoutA>(tmp);
-
-        ldsAddrA += blockStep;
-    }
-}
-
-// Local B reads for warp tile gemm, non-cooperative
-ROCWMMA_DEVICE static inline void
-    localReadB(MfmaFragB (&fragsB)[BLOCKS_Y], InputT const* ldsAddrB, uint32_t ldsld)
-{
-    using FragShape = GetIOShape_t<LRFragB>;
-    using Mapper1d  = GetDataLayout_t<LRFragB>;
-
-    // Each B block is stacked vertically in LDS
-    auto blockStep = Mapper1d::fromMatrixCoord(make_coord2d(FragShape::BlockHeight, 0u), ldsld);
-
-#pragma unroll
-    for(int i = 0; i < BLOCKS_Y; i++)
-    {
-        LRFragB tmp;
-        load_matrix_sync(tmp, ldsAddrB, ldsld);
-
-        // Transform back to MFMA tile
-        fragsB[i] = applyDataLayout<DataLayoutB>(applyTranspose(tmp));
-
-        ldsAddrB += blockStep;
-    }
-}
-
-// Global C reads for warp tile gemm, non-cooperative
-ROCWMMA_DEVICE static inline void
-    globalReadC(MfmaFragC (&fragC)[BLOCKS_X][BLOCKS_Y], OutputT const* gAddrC, uint32_t ldc)
-{
-    using FragShape = GetIOShape_t<MfmaFragC>;
-    using Mapper1d  = GetDataLayout_t<MfmaFragC>;
-
-    // Iterative offsets for each C block in the wave tile
-    auto blockStepX = Mapper1d::fromMatrixCoord(make_coord2d(FragShape::BlockHeight, 0u), ldc);
-    auto blockStepY = Mapper1d::fromMatrixCoord(make_coord2d(0u, FragShape::BlockWidth), ldc);
-
-#pragma unroll
-    for(int i = 0; i < BLOCKS_X; i++)
-    {
-        auto offsetY = 0u;
-#pragma unroll
-        for(int j = 0; j < BLOCKS_Y; j++)
-        {
-            load_matrix_sync(fragC[i][j], gAddrC + offsetY, ldc);
-            offsetY += blockStepY;
-        }
-        gAddrC += blockStepX;
-    }
-}
-
-// Global D reads for warp tile gemm, non-cooperative
-ROCWMMA_DEVICE static inline void
-    globalWriteD(OutputT* gAddrD, MfmaFragD const (&fragsD)[BLOCKS_X][BLOCKS_Y], uint32_t ldd)
-{
-    using FragShape = GetIOShape_t<MfmaFragD>;
-    using Mapper1d  = GetDataLayout_t<MfmaFragD>;
-
-    // Iterative offsets for each D block in the warp tile
-    auto blockStepX = Mapper1d::fromMatrixCoord(make_coord2d(FragShape::BlockHeight, 0u), ldd);
-    auto blockStepY = Mapper1d::fromMatrixCoord(make_coord2d(0u, FragShape::BlockWidth), ldd);
-
-#pragma unroll
-    for(int i = 0; i < BLOCKS_X; i++)
-    {
-        auto offsetY = 0u;
-#pragma unroll
-        for(int j = 0; j < BLOCKS_Y; j++)
-        {
-            store_matrix_sync(gAddrD + offsetY, fragsD[i][j], ldd);
-            offsetY += blockStepY;
-        }
-        gAddrD += blockStepX;
-    }
-}
-
-// Broadcast value to fragments in warp tile
-template <typename FragT>
-ROCWMMA_DEVICE static inline void fill(FragT (&frags)[BLOCKS_X][BLOCKS_Y],
-                                       GetDataType_t<FragT> value)
-{
-#pragma unroll
-    for(int i = 0; i < BLOCKS_X; i++)
-    {
-#pragma unroll
-        for(int j = 0; j < BLOCKS_Y; j++)
-        {
-            fill_fragment(frags[i][j], value);
-        }
-    }
-}
-
-// Performs warp tile mfma
-ROCWMMA_DEVICE static inline void mfma(MfmaFragAcc (&fragsAccOut)[BLOCKS_X][BLOCKS_Y],
-                                       MfmaFragA const (&fragsA)[BLOCKS_X],
-                                       MfmaFragB const (&fragsB)[BLOCKS_Y],
-                                       MfmaFragAcc const (&fragsAccIn)[BLOCKS_X][BLOCKS_Y])
-{
-#pragma unroll
-    for(int i = 0; i < BLOCKS_X; i++)
-    {
-#pragma unroll
-        for(int j = 0; j < BLOCKS_Y; j++)
-        {
-            mma_sync(fragsAccOut[i][j], fragsA[i], fragsB[j], fragsAccIn[i][j]);
-        }
-    }
-}
-
-// Uniform multiply - add (FMA)
-// Performs D = alpha * acc + beta * C, where alpha, beta are uniform scalars
-ROCWMMA_DEVICE static inline void uniformFma(MfmaFragD (&fragsD)[BLOCKS_X][BLOCKS_Y],
-                                             ComputeT alpha,
-                                             MfmaFragAcc const (&fragsAcc)[BLOCKS_X][BLOCKS_Y],
-                                             ComputeT beta,
-                                             MfmaFragC const (&fragsC)[BLOCKS_X][BLOCKS_Y])
-{
-#pragma unroll
-    for(int i = 0; i < BLOCKS_X; i++)
-    {
-#pragma unroll
-        for(int j = 0; j < BLOCKS_Y; j++)
-        {
-            for(int k = 0; k < fragsD[i][j].num_elements; k++)
-            {
-                // Perform computation in ComputeT and cast back to OutputT
-                fragsD[i][j].x[k] = static_cast<OutputT>(
-                    alpha * fragsAcc[i][j].x[k] + beta * static_cast<ComputeT>(fragsC[i][j].x[k]));
-            }
-        }
-    }
-}
+constexpr auto transformLRFragBToMmaFragB
+    = [](LRFragB const& lrFragB) { return applyDataLayout<DataLayoutB>(applyTranspose(lrFragB)); };
 
 ROCWMMA_KERNEL void __launch_bounds__(256) gemm_rocwmma_d(uint32_t       m,
                                                           uint32_t       n,
@@ -529,188 +329,179 @@ ROCWMMA_KERNEL void __launch_bounds__(256) gemm_rocwmma_d(uint32_t       m,
                                                           ComputeT       alpha,
                                                           ComputeT       beta)
 {
-    if constexpr(!ROCWMMA_ARCH_HOST)
+    // Tile Sizes
+    constexpr auto warpTileSize  = make_coord2d(WARP_TILE_M, WARP_TILE_M);
+    constexpr auto macroTileSize = make_coord2d(MACRO_TILE_M, MACRO_TILE_M);
+
+    // Local warp coordinate relative to current threadblock (wg).
+    constexpr auto warpDims        = make_coord2d(WARPS_M, WARPS_N);
+    auto           localWarpCoord  = make_coord2d(threadIdx.x / WARP_SIZE, threadIdx.y);
+    auto           localWarpOffset = localWarpCoord * warpTileSize;
+
+    // Global matrix coordinates for C/D
+    auto macroTileCoord = make_coord2d(blockIdx.x, blockIdx.y) * macroTileSize;
+    auto warpTileCoord  = macroTileCoord + localWarpOffset;
+
+    // Bounds check
+    auto warpTileBound = warpTileCoord + warpTileSize;
+    if(get<0>(warpTileBound) > m || get<1>(warpTileBound) > n)
     {
-        ///
-        /// 2D matrix coordinate setup
-        ///
+        return;
+    }
 
-        // Tile Sizes
-        constexpr auto warpTileSize  = make_coord2d(WARP_TILE_X, WARP_TILE_Y);
-        constexpr auto macroTileSize = make_coord2d(MACRO_TILE_X, MACRO_TILE_Y);
+    // 1D global read coordinate transform
+    using GRFragAMap1d = GetDataLayout_t<GRFragA>;
+    using GRFragBMap1d = GetDataLayout_t<GRFragB>;
 
-        // Local warp coordinate relative to current threadblock (wg).
-        constexpr auto warpDims        = make_coord2d(WARPS_X, WARPS_Y);
-        auto           localWarpCoord  = make_coord2d(threadIdx.x / WARP_SIZE, threadIdx.y);
-        auto           localWarpOffset = localWarpCoord * warpTileSize;
+    // Initial global read address offsets
+    auto globalReadOffsetA
+        = GRFragAMap1d::fromMatrixCoord(make_coord2d(get<0>(macroTileCoord), 0u), lda);
+    auto globalReadOffsetB
+        = GRFragBMap1d::fromMatrixCoord(make_coord2d(0u, get<1>(macroTileCoord)), ldb);
 
-        // Global matrix coordinates for C/D
-        auto macroTileCoord = make_coord2d(blockIdx.x, blockIdx.y) * macroTileSize;
-        auto warpTileCoord  = macroTileCoord + localWarpOffset;
+    // Incremental global read address offsets
+    auto kStepOffsetA = GRFragAMap1d::fromMatrixCoord(make_coord2d(0u, MACRO_TILE_K), lda);
+    auto kStepOffsetB = GRFragBMap1d::fromMatrixCoord(make_coord2d(MACRO_TILE_K, 0u), ldb);
 
-        // Bounds check
-        auto warpTileBound = warpTileCoord + warpTileSize;
-        if(get<0>(warpTileBound) > m || get<1>(warpTileBound) > n)
-        {
-            return;
-        }
+    // Cooperative scheduling warp order is analogous to row major priority.
+    // E.g. Wg = (128, 2) = 2x2 warps
+    // (0, 0)   (0, 1)   Share Schedule: w0 = (0, 0), w1 = (0, 1),
+    // (1, 0)   (1, 1)                   w2 = (1, 0), w3 = (1, 1), count = 4
+    const auto warpIndex = get<0>(localWarpCoord) * get<1>(warpDims) + get<1>(localWarpCoord);
 
-        ///
-        /// 1D global read coordinate setup
-        ///
-        using GRBuffAMap1d = GetDataLayout_t<GRBuffA>;
-        using GRBuffBMap1d = GetDataLayout_t<GRBuffB>;
+    // Perform initial global pre-fetch
+    GRFragA grFragA;
+    GRFragB grFragB;
 
-        // Initial globa read address offsets
-        auto globalReadOffsetA
-            = GRBuffAMap1d::fromMatrixCoord(make_coord2d(get<0>(macroTileCoord), 0u), lda);
-        auto globalReadOffsetB
-            = GRBuffBMap1d::fromMatrixCoord(make_coord2d(0u, get<1>(macroTileCoord)), ldb);
+    load_matrix_coop_sync<WARP_COUNT>(grFragA, a + globalReadOffsetA, lda, warpIndex);
+    load_matrix_coop_sync<WARP_COUNT>(grFragB, b + globalReadOffsetB, ldb, warpIndex);
 
-        // Incremental global read address offsets
-        auto kStepOffsetA = GRBuffAMap1d::fromMatrixCoord(make_coord2d(0u, ROCWMMA_K), lda);
-        auto kStepOffsetB = GRBuffBMap1d::fromMatrixCoord(make_coord2d(ROCWMMA_K, 0u), ldb);
+    globalReadOffsetA += kStepOffsetA;
+    globalReadOffsetB += kStepOffsetB;
 
-        ///
-        /// Cooperative config for global read A / B
-        ///
+    // Setup LDS addressing
+    // This kernel will use 2 separate LDS blocks for pipelining
+    // the input prefetching during the accumulation loop
+    HIP_DYNAMIC_SHARED(void*, localMemPtr);
+    using LWFragAShape = GetIOShape_t<LWFragA>;
+    using LWFragBShape = GetIOShape_t<LWFragB>;
+    using LWFragAMap1d = GetDataLayout_t<LWFragA>;
+    using LWFragBMap1d = GetDataLayout_t<LWFragB>;
 
-        // WorkItems will be split up by minimum IOCount to perform either global read or local write.
-        // These are inputs to cooperative functions.
-        constexpr auto warpCount = get<0>(warpDims) * get<1>(warpDims);
+    constexpr uint32_t ldsWidth  = ROCWMMA_K;
+    constexpr uint32_t ldsHeight = LWFragAShape::BlockHeight + LWFragBShape::BlockHeight;
+    constexpr uint32_t sizeLds   = ldsHeight * ldsWidth;
+    constexpr uint32_t ldsld     = std::is_same_v<DataLayoutLds, row_major> ? ldsWidth : ldsHeight;
 
-        // Scheduling warp order is analogous to row major priority.
-        // E.g. Wg = (128, 2) = 2x2 warps
-        // (0, 0)   (0, 1)   Share Schedule: w0 = (0, 0), w1 = (0, 1),
-        // (1, 0)   (1, 1)                   w2 = (1, 0), w3 = (1, 1), count = 4
-        const auto warpIndex = get<0>(localWarpCoord) * get<1>(warpDims) + get<1>(localWarpCoord);
+    auto* ldsPtrLo = reinterpret_cast<InputT*>(localMemPtr);
+    auto* ldsPtrHi = ldsPtrLo + sizeLds;
 
-        ///
-        /// Perform initial global pre-fetch
-        ///
+    // Local write offsets to start of A / B data
+    auto ldsWriteOffsetA = 0u;
+    auto ldsWriteOffsetB
+        = LWFragAMap1d::fromMatrixCoord(make_coord2d(LWFragAShape::BlockHeight, 0u), ldsld);
 
-        GRBuffA grBuffA;
-        GRBuffB grBuffB;
+    // Local read offsets for mma frags
+    auto ldsReadOffsetA
+        = ldsWriteOffsetA
+          + LWFragAMap1d::fromMatrixCoord(make_coord2d(get<0>(localWarpOffset), 0u), ldsld);
+    auto ldsReadOffsetB
+        = ldsWriteOffsetB
+          + LWFragBMap1d::fromMatrixCoord(make_coord2d(get<1>(localWarpOffset), 0u), ldsld);
 
-        globalReadCoopA<warpCount>(grBuffA, a + globalReadOffsetA, lda, warpIndex);
-        globalReadCoopB<warpCount>(grBuffB, b + globalReadOffsetB, ldb, warpIndex);
+    // Write prefetch to local
+    store_matrix_coop_sync<WARP_COUNT>(
+        ldsPtrLo + ldsWriteOffsetA, transformGRFragAToLWFragA(grFragA), ldsld, warpIndex);
+    store_matrix_coop_sync<WARP_COUNT>(
+        ldsPtrLo + ldsWriteOffsetB, transformGRFragBToLWFragB(grFragB), ldsld, warpIndex);
 
+    // Initialize accumulation frags
+    MmaFragAcc mmaFragAcc;
+    fill_fragment(mmaFragAcc, 0.0f);
+
+    // Synchronize states
+    synchronize_workgroup();
+
+    // Accumulate A * B for all mfma frags in warp tile
+    for(uint32_t currentK = ROCWMMA_K; currentK < k; currentK += ROCWMMA_K)
+    {
+        // Local read mma frags from first LDS buffer.
+        LRFragA lrFragA;
+        LRFragB lrFragB;
+        load_matrix_sync(lrFragA, ldsPtrLo + ldsReadOffsetA, ldsld);
+        load_matrix_sync(lrFragB, ldsPtrLo + ldsReadOffsetB, ldsld);
+
+        // Prefetch next round of global frags
+        load_matrix_coop_sync<WARP_COUNT>(grFragA, a + globalReadOffsetA, lda, warpIndex);
+        load_matrix_coop_sync<WARP_COUNT>(grFragB, b + globalReadOffsetB, ldb, warpIndex);
+
+        // Advance offsets to next k step
         globalReadOffsetA += kStepOffsetA;
         globalReadOffsetB += kStepOffsetB;
 
-        ///
-        /// Setup LDS addressing
-        /// This kernel will use 2 separate LDS blocks for pipelining
-        /// the input prefetching during the accumulation loop
-        ///
+        // Matrix mult-accum(A * B)
+        mma_sync(mmaFragAcc,
+                 transformLRFragAToMmaFragA(lrFragA),
+                 transformLRFragBToMmaFragB(lrFragB),
+                 mmaFragAcc);
 
-        HIP_DYNAMIC_SHARED(void*, localMemPtr);
-        using LWBuffAShape = GetIOShape_t<LWBuffA>;
-        using LWBuffBShape = GetIOShape_t<LWBuffB>;
-        using LWBuffAMap1d = GetDataLayout_t<LWBuffA>;
-        using LWBuffBMap1d = GetDataLayout_t<LWBuffB>;
+        // Write prefetch to second LDS buffer
+        store_matrix_coop_sync<WARP_COUNT>(
+            ldsPtrHi + ldsWriteOffsetA, transformGRFragAToLWFragA(grFragA), ldsld, warpIndex);
+        store_matrix_coop_sync<WARP_COUNT>(
+            ldsPtrHi + ldsWriteOffsetB, transformGRFragBToLWFragB(grFragB), ldsld, warpIndex);
 
-        constexpr uint32_t ldsWidth  = ROCWMMA_K;
-        constexpr uint32_t ldsHeight = LWBuffAShape::BlockHeight + LWBuffBShape::BlockHeight;
-        constexpr uint32_t sizeLds   = ldsHeight * ldsWidth;
-        constexpr uint32_t ldsld = std::is_same_v<DataLayoutLds, row_major> ? ldsWidth : ldsHeight;
-
-        auto* ldsPtrLo = reinterpret_cast<InputT*>(localMemPtr);
-        auto* ldsPtrHi = ldsPtrLo + sizeLds;
-
-        // Local write offsets to start of A / B data
-        auto ldsWriteOffsetA = 0u;
-        auto ldsWriteOffsetB
-            = LWBuffAMap1d::fromMatrixCoord(make_coord2d(LWBuffAShape::BlockHeight, 0u), ldsld);
-
-        // Local read offsets for mfma frags
-        auto ldsReadOffsetA
-            = ldsWriteOffsetA
-              + LWBuffAMap1d::fromMatrixCoord(make_coord2d(get<0>(localWarpOffset), 0u), ldsld);
-        auto ldsReadOffsetB
-            = ldsWriteOffsetB
-              + LWBuffBMap1d::fromMatrixCoord(make_coord2d(get<1>(localWarpOffset), 0u), ldsld);
-
-        ///
-        /// Write prefetch to local
-        ///
-        localWriteCoopA<warpCount>(ldsPtrLo + ldsWriteOffsetA, grBuffA, ldsld, warpIndex);
-        localWriteCoopB<warpCount>(ldsPtrLo + ldsWriteOffsetB, grBuffB, ldsld, warpIndex);
-
-        ///
-        /// Initialize accumulation frags
-        ///
-        MfmaFragAcc fragsAcc[BLOCKS_X][BLOCKS_Y];
-        fill(fragsAcc, 0.0f);
-
-        ///
-        /// Synchronize warps and memory
-        ///
+        // Make sure that all waves have finished reading / writing to lds for currentK.
         synchronize_workgroup();
 
-        ///
-        /// Accumulate A * B for all mfma frags in warp tile
-        ///
-        for(uint32_t currentK = ROCWMMA_K; currentK < k; currentK += ROCWMMA_K)
-        {
-            MfmaFragA fragsA[BLOCKS_X];
-            MfmaFragB fragsB[BLOCKS_Y];
-
-            // Local read mfma frags from first LDS buffer
-            localReadA(fragsA, ldsPtrLo + ldsReadOffsetA, ldsld);
-            localReadB(fragsB, ldsPtrLo + ldsReadOffsetB, ldsld);
-
-            // Prefetch next round of global frags
-            globalReadCoopA<warpCount>(grBuffA, a + globalReadOffsetA, lda, warpIndex);
-            globalReadCoopB<warpCount>(grBuffB, b + globalReadOffsetB, ldb, warpIndex);
-
-            // Advance offsets to next k step
-            globalReadOffsetA += kStepOffsetA;
-            globalReadOffsetB += kStepOffsetB;
-
-            // accum(A * B)
-            mfma(fragsAcc, fragsA, fragsB, fragsAcc);
-
-            // Write prefetch to second LDS buffer
-            localWriteCoopA<warpCount>(ldsPtrHi + ldsWriteOffsetA, grBuffA, ldsld, warpIndex);
-            localWriteCoopB<warpCount>(ldsPtrHi + ldsWriteOffsetB, grBuffB, ldsld, warpIndex);
-
-            // Make sure that all waves have finished reading / writing to lds for currentK.
-            synchronize_workgroup();
-
-            // Swap Lds buffers
-            auto* tmp = ldsPtrLo;
-            ldsPtrLo  = ldsPtrHi;
-            ldsPtrHi  = tmp;
-        }
-
-        ///
-        /// Start loading C
-        ///
-        using MfmaFragCMap1d = GetDataLayout_t<MfmaFragC>;
-        using MfmaFragDMap1d = GetDataLayout_t<MfmaFragD>;
-
-        MfmaFragC fragsC[BLOCKS_X][BLOCKS_Y];
-        globalReadC(fragsC, c + MfmaFragCMap1d::fromMatrixCoord(warpTileCoord, ldc), ldc);
-
-        ///
-        /// Clean up tail A * B
-        ///
-        MfmaFragA fragsA[BLOCKS_X];
-        MfmaFragB fragsB[BLOCKS_Y];
-
-        // Local read mfma frags
-        localReadA(fragsA, ldsPtrLo + ldsReadOffsetA, ldsld);
-        localReadB(fragsB, ldsPtrLo + ldsReadOffsetB, ldsld);
-        mfma(fragsAcc, fragsA, fragsB, fragsAcc);
-
-        ///
-        /// D = alpha * accum + beta * C
-        ///
-        MfmaFragD fragsD[BLOCKS_X][BLOCKS_Y];
-        uniformFma(fragsD, alpha, fragsAcc, beta, fragsC);
-        globalWriteD(d + MfmaFragDMap1d::fromMatrixCoord(warpTileCoord, ldd), fragsD, ldd);
+        // Swap Lds buffers
+        auto* tmp = ldsPtrLo;
+        ldsPtrLo  = ldsPtrHi;
+        ldsPtrHi  = tmp;
     }
+
+    // Start loading C
+    using MmaFragCMap1d = GetDataLayout_t<MmaFragC>;
+    using MmaFragDMap1d = GetDataLayout_t<MmaFragD>;
+
+    MmaFragC mmaFragC;
+    load_matrix_sync(mmaFragC, c + MmaFragCMap1d::fromMatrixCoord(warpTileCoord, ldc), ldc);
+
+    // Clean up tail A * B
+    LRFragA lrFragA;
+    LRFragB lrFragB;
+    load_matrix_sync(lrFragA, ldsPtrLo + ldsReadOffsetA, ldsld);
+    load_matrix_sync(lrFragB, ldsPtrLo + ldsReadOffsetB, ldsld);
+    mma_sync(mmaFragAcc,
+             transformLRFragAToMmaFragA(lrFragA),
+             transformLRFragBToMmaFragB(lrFragB),
+             mmaFragAcc);
+
+    // D = alpha * accum + beta * C
+
+    // MmaFragD is a wave tile that can be large.
+    // Unroll the operation in chunks to save registers.
+    MmaFragD           mmaFragD;
+    constexpr uint32_t chunkSize = 8u;
+    constexpr uint32_t chunks    = mmaFragD.num_elements / chunkSize;
+    constexpr uint32_t remain    = mmaFragD.num_elements % chunkSize;
+
+    auto uniform_fma_unroll_chunk = [&](uint32_t start_idx, uint32_t size) {
+        for(int i = start_idx; i < start_idx + size; i++)
+        {
+            mmaFragD.x[i] = static_cast<OutputT>(alpha * mmaFragAcc.x[i]
+                                                 + beta * static_cast<ComputeT>(mmaFragC.x[i]));
+        }
+    };
+
+    for(uint32_t c = 0u; c < chunks; c++)
+    {
+        uniform_fma_unroll_chunk(c * chunkSize, chunkSize);
+    }
+    uniform_fma_unroll_chunk(chunks * chunkSize, remain);
+
+    // Final store of completed warp tile
+    store_matrix_sync(d + MmaFragDMap1d::fromMatrixCoord(warpTileCoord, ldd), mmaFragD, ldd);
 }
 
 ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, ComputeT alpha, ComputeT beta)
@@ -718,18 +509,18 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, ComputeT alpha, 
     // Runtime checks for host parameters
     uint32_t hTBLOCK_X    = isGfx9() ? gfx9Params::TBLOCK_X : gfx11Params::TBLOCK_X;
     uint32_t hTBLOCK_Y    = isGfx9() ? gfx9Params::TBLOCK_Y : gfx11Params::TBLOCK_Y;
-    uint32_t hBLOCKS_X    = isGfx9() ? gfx9Params::BLOCKS_X : gfx11Params::BLOCKS_X;
-    uint32_t hBLOCKS_Y    = isGfx9() ? gfx9Params::BLOCKS_Y : gfx11Params::BLOCKS_Y;
+    uint32_t hBLOCKS_M    = isGfx9() ? gfx9Params::BLOCKS_M : gfx11Params::BLOCKS_M;
+    uint32_t hBLOCKS_N    = isGfx9() ? gfx9Params::BLOCKS_N : gfx11Params::BLOCKS_N;
     uint32_t hROCWMMA_M   = isGfx9() ? gfx9Params::ROCWMMA_M : gfx11Params::ROCWMMA_M;
     uint32_t hROCWMMA_N   = isGfx9() ? gfx9Params::ROCWMMA_N : gfx11Params::ROCWMMA_N;
     uint32_t hROCWMMA_K   = isGfx9() ? gfx9Params::ROCWMMA_K : gfx11Params::ROCWMMA_K;
-    uint32_t hWARP_TILE_X = hBLOCKS_X * hROCWMMA_M;
-    uint32_t hWARP_TILE_Y = hBLOCKS_Y * hROCWMMA_N;
+    uint32_t hWARP_TILE_M = hBLOCKS_M * hROCWMMA_M;
+    uint32_t hWARP_TILE_N = hBLOCKS_N * hROCWMMA_N;
 
     // Runtime warp calculation (host code needs to query warpsize dynamically)
     auto warpSize = getWarpSize();
     auto macroTileSize
-        = rocwmma::make_coord2d(hTBLOCK_X / warpSize * hWARP_TILE_X, hTBLOCK_Y * hWARP_TILE_Y);
+        = rocwmma::make_coord2d(hTBLOCK_X / warpSize * hWARP_TILE_M, hTBLOCK_Y * hWARP_TILE_N);
 
     // Device check for supported block and wave sizes
     if((isGfx11() || isGfx12()) && (hROCWMMA_M != 16 || hROCWMMA_N != 16))
@@ -819,7 +610,7 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, ComputeT alpha, 
     int ldsusage
         = 2u * sizeof(InputT) * (get<0>(macroTileSize) + get<1>(macroTileSize)) * hROCWMMA_K;
 
-    ////
+    // Kernel caller
     auto rocwmmaKernel = [&]() {
         hipExtLaunchKernelGGL(gemm_rocwmma_d,
                               gridDim,
@@ -885,7 +676,7 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, ComputeT alpha, 
               << "beta, ldc, ldd, "
               << "elapsedMs, Problem Size(GFlops), TFlops/s" << std::endl;
 
-    std::cout << hTBLOCK_X << ", " << hTBLOCK_Y << ", " << hBLOCKS_X << ", " << hBLOCKS_Y << ", "
+    std::cout << hTBLOCK_X << ", " << hTBLOCK_Y << ", " << hBLOCKS_M << ", " << hBLOCKS_N << ", "
               << hROCWMMA_M << ", " << hROCWMMA_N << ", " << hROCWMMA_K << ", " << m << ", " << n
               << ", " << k << ", " << alpha << ", " << lda << ", " << ldb << ", " << beta << ", "
               << ldc << ", " << ldd << ", " << elapsedTimeMs << ", " << gFlops << ", "

--- a/samples/perf_hgemm.cpp
+++ b/samples/perf_hgemm.cpp
@@ -599,8 +599,8 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, ComputeT alpha, 
     CHECK_HIP_ERROR(hipMemcpy(d_d, matrixD.data(), bytesD, hipMemcpyHostToDevice));
 
     auto blockDim = dim3(hTBLOCK_X, hTBLOCK_Y);
-    auto gridDim  = dim3(rocwmma::ceilDiv(m, get<0>(macroTileSize)),
-                        rocwmma::ceilDiv(n, get<1>(macroTileSize)));
+    auto gridDim  = dim3(rocwmma::ceil_div(m, get<0>(macroTileSize)),
+                        rocwmma::ceil_div(n, get<1>(macroTileSize)));
 
     std::cout << "Launching GEMM kernel..." << std::endl;
     std::cout << "gridDim (" << gridDim.x << " " << gridDim.y << ")"

--- a/samples/perf_sgemm.cpp
+++ b/samples/perf_sgemm.cpp
@@ -442,7 +442,6 @@ ROCWMMA_DEVICE static inline void mfma(MfmaFragAcc (&fragsAccOut)[BLOCKS_X][BLOC
     }
 
 #endif // ROCWMMA_ARCH_GFX9
-
 }
 
 // Uniform multiply - add (FMA)
@@ -470,18 +469,18 @@ ROCWMMA_DEVICE static inline void uniformFma(MfmaFragD (&fragsD)[BLOCKS_X][BLOCK
 }
 
 ROCWMMA_KERNEL void __launch_bounds__(256) sgemm_rocwmma_d(uint32_t       m,
-                                                          uint32_t       n,
-                                                          uint32_t       k,
-                                                          InputT const*  a,
-                                                          InputT const*  b,
-                                                          OutputT const* c,
-                                                          OutputT*       d,
-                                                          uint32_t       lda,
-                                                          uint32_t       ldb,
-                                                          uint32_t       ldc,
-                                                          uint32_t       ldd,
-                                                          ComputeT       alpha,
-                                                          ComputeT       beta)
+                                                           uint32_t       n,
+                                                           uint32_t       k,
+                                                           InputT const*  a,
+                                                           InputT const*  b,
+                                                           OutputT const* c,
+                                                           OutputT*       d,
+                                                           uint32_t       lda,
+                                                           uint32_t       ldb,
+                                                           uint32_t       ldc,
+                                                           uint32_t       ldd,
+                                                           ComputeT       alpha,
+                                                           ComputeT       beta)
 {
     ///
     /// 2D matrix coordinate setup
@@ -565,7 +564,7 @@ ROCWMMA_KERNEL void __launch_bounds__(256) sgemm_rocwmma_d(uint32_t       m,
     constexpr uint32_t ldsWidth  = ROCWMMA_K;
     constexpr uint32_t ldsHeight = LWBuffAShape::BlockHeight + LWBuffBShape::BlockHeight;
     constexpr uint32_t sizeLds   = ldsHeight * ldsWidth;
-    constexpr uint32_t ldsld = std::is_same_v<DataLayoutLds, row_major> ? ldsWidth : ldsHeight;
+    constexpr uint32_t ldsld     = std::is_same_v<DataLayoutLds, row_major> ? ldsWidth : ldsHeight;
 
     auto* ldsPtrLo = reinterpret_cast<InputT*>(localMemPtr);
     auto* ldsPtrHi = ldsPtrLo + sizeLds;
@@ -578,10 +577,10 @@ ROCWMMA_KERNEL void __launch_bounds__(256) sgemm_rocwmma_d(uint32_t       m,
     // Local read offsets for mfma frags
     auto ldsReadOffsetA
         = ldsWriteOffsetA
-            + LWBuffAMap1d::fromMatrixCoord(make_coord2d(get<0>(localWarpOffset), 0u), ldsld);
+          + LWBuffAMap1d::fromMatrixCoord(make_coord2d(get<0>(localWarpOffset), 0u), ldsld);
     auto ldsReadOffsetB
         = ldsWriteOffsetB
-            + LWBuffBMap1d::fromMatrixCoord(make_coord2d(get<1>(localWarpOffset), 0u), ldsld);
+          + LWBuffBMap1d::fromMatrixCoord(make_coord2d(get<1>(localWarpOffset), 0u), ldsld);
 
     ///
     /// Write prefetch to local
@@ -662,7 +661,6 @@ ROCWMMA_KERNEL void __launch_bounds__(256) sgemm_rocwmma_d(uint32_t       m,
     MfmaFragD fragsD[BLOCKS_X][BLOCKS_Y];
     uniformFma(fragsD, alpha, fragsAcc, beta, fragsC);
     globalWriteD(d + MfmaFragDMap1d::fromMatrixCoord(warpTileCoord, ldd), fragsD, ldd);
-
 }
 
 ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, ComputeT alpha, ComputeT beta)
@@ -742,8 +740,8 @@ ROCWMMA_HOST void gemm_test(uint32_t m, uint32_t n, uint32_t k, ComputeT alpha, 
     CHECK_HIP_ERROR(hipMemcpy(d_d, matrixD.data(), bytesD, hipMemcpyHostToDevice));
 
     auto blockDim = dim3(TBLOCK_X, TBLOCK_Y);
-    auto gridDim  = dim3(rocwmma::ceilDiv(m, get<0>(macroTileSize)),
-                        rocwmma::ceilDiv(n, get<1>(macroTileSize)));
+    auto gridDim  = dim3(rocwmma::ceil_div(m, get<0>(macroTileSize)),
+                        rocwmma::ceil_div(n, get<1>(macroTileSize)));
 
     std::cout << "Launching GEMM kernel..." << std::endl;
     std::cout << "gridDim (" << gridDim.x << " " << gridDim.y << ")"

--- a/samples/simple_dgemm.cpp
+++ b/samples/simple_dgemm.cpp
@@ -190,8 +190,8 @@ __host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, float64_t alpha, flo
     CHECK_HIP_ERROR(hipMemcpy(d_d, matrixD.data(), bytesD, hipMemcpyHostToDevice));
 
     auto blockDim = dim3(T_BLOCK_X, T_BLOCK_Y);
-    auto gridDim  = dim3(rocwmma::ceilDiv(m, ROCWMMA_M * T_BLOCK_X / WAVE_SIZE),
-                        rocwmma::ceilDiv(n, ROCWMMA_N * T_BLOCK_Y));
+    auto gridDim  = dim3(rocwmma::ceil_div(m, ROCWMMA_M * T_BLOCK_X / WAVE_SIZE),
+                        rocwmma::ceil_div(n, ROCWMMA_N * T_BLOCK_Y));
 
     std::cout << "Launching GEMM kernel..." << std::endl;
 

--- a/samples/simple_dgemv.cpp
+++ b/samples/simple_dgemv.cpp
@@ -196,8 +196,8 @@ __host__ void dgemv_test(uint32_t m, uint32_t n, uint32_t k, float64_t alpha, fl
     CHECK_HIP_ERROR(hipMemcpy(d_c, matrixC.data(), bytesC, hipMemcpyHostToDevice));
 
     auto blockDim = dim3(T_BLOCK_X, T_BLOCK_Y);
-    auto gridDim  = dim3(rocwmma::ceilDiv(m, ROCWMMA_M * T_BLOCK_X / WAVE_SIZE),
-                        rocwmma::ceilDiv(n, ROCWMMA_N * T_BLOCK_Y));
+    auto gridDim  = dim3(rocwmma::ceil_div(m, ROCWMMA_M * T_BLOCK_X / WAVE_SIZE),
+                        rocwmma::ceil_div(n, ROCWMMA_N * T_BLOCK_Y));
 
     std::cout << "Launching dgemv kernel..." << std::endl;
     hipEvent_t startEvent, stopEvent;

--- a/samples/simple_dlrm.cpp
+++ b/samples/simple_dlrm.cpp
@@ -501,8 +501,8 @@ __host__ void dlrm_test(uint32_t m, uint32_t k, uint32_t b, DlrmDirection_t pass
     if(passDirection == DlrmDirection_t::Forward)
     {
         dlrmKernel = [d_input, d_output, d_accFwd, m, k, b]() {
-            auto gridDim  = dim3(rocwmma::ceilDiv(m, TILE_DIM * T_BLOCK_X / WAVE_SIZE),
-                                rocwmma::ceilDiv(m, TILE_DIM),
+            auto gridDim  = dim3(rocwmma::ceil_div(m, TILE_DIM * T_BLOCK_X / WAVE_SIZE),
+                                rocwmma::ceil_div(m, TILE_DIM),
                                 b);
             auto blockDim = dim3(T_BLOCK_X);
 
@@ -532,7 +532,7 @@ __host__ void dlrm_test(uint32_t m, uint32_t k, uint32_t b, DlrmDirection_t pass
     else
     {
         dlrmKernel = [d_input, d_upstreamGrad, d_grad, d_bottomMlpGrad, d_accBwd, m, k, b]() {
-            auto gridDim  = dim3(rocwmma::ceilDiv(m * m, T_BLOCK_X), 1, b);
+            auto gridDim  = dim3(rocwmma::ceil_div(m * m, T_BLOCK_X), 1, b);
             auto blockDim = dim3(T_BLOCK_X);
 
             uint inputBatchOffset    = m * k;
@@ -559,8 +559,8 @@ __host__ void dlrm_test(uint32_t m, uint32_t k, uint32_t b, DlrmDirection_t pass
             CHECK_HIP_ERROR(hipEventRecord(syncEvent));
             CHECK_HIP_ERROR(hipEventSynchronize(syncEvent));
 
-            gridDim = dim3(rocwmma::ceilDiv(m, TILE_DIM * T_BLOCK_X / WAVE_SIZE),
-                           rocwmma::ceilDiv(k, TILE_DIM),
+            gridDim = dim3(rocwmma::ceil_div(m, TILE_DIM * T_BLOCK_X / WAVE_SIZE),
+                           rocwmma::ceil_div(k, TILE_DIM),
                            b);
 
             hipExtLaunchKernelGGL((dlrmDotBwd),

--- a/samples/simple_hgemm.cpp
+++ b/samples/simple_hgemm.cpp
@@ -190,8 +190,8 @@ __host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha, flo
     CHECK_HIP_ERROR(hipMemcpy(d_d, matrixD.data(), bytesD, hipMemcpyHostToDevice));
 
     auto blockDim = dim3(T_BLOCK_X, T_BLOCK_Y);
-    auto gridDim  = dim3(rocwmma::ceilDiv(m, ROCWMMA_M * T_BLOCK_X / WAVE_SIZE),
-                        rocwmma::ceilDiv(n, ROCWMMA_N * T_BLOCK_Y));
+    auto gridDim  = dim3(rocwmma::ceil_div(m, ROCWMMA_M * T_BLOCK_X / WAVE_SIZE),
+                        rocwmma::ceil_div(n, ROCWMMA_N * T_BLOCK_Y));
 
     std::cout << "Launching GEMM kernel..." << std::endl;
 

--- a/samples/simple_sgemm.cpp
+++ b/samples/simple_sgemm.cpp
@@ -190,8 +190,8 @@ __host__ void gemm_test(uint32_t m, uint32_t n, uint32_t k, float32_t alpha, flo
     CHECK_HIP_ERROR(hipMemcpy(d_d, matrixD.data(), bytesD, hipMemcpyHostToDevice));
 
     auto blockDim = dim3(T_BLOCK_X, T_BLOCK_Y);
-    auto gridDim  = dim3(rocwmma::ceilDiv(m, ROCWMMA_M * T_BLOCK_X / WAVE_SIZE),
-                        rocwmma::ceilDiv(n, ROCWMMA_N * T_BLOCK_Y));
+    auto gridDim  = dim3(rocwmma::ceil_div(m, ROCWMMA_M * T_BLOCK_X / WAVE_SIZE),
+                        rocwmma::ceil_div(n, ROCWMMA_N * T_BLOCK_Y));
 
     std::cout << "Launching GEMM kernel..." << std::endl;
 

--- a/samples/simple_sgemv.cpp
+++ b/samples/simple_sgemv.cpp
@@ -196,8 +196,8 @@ __host__ void sgemv_test(uint32_t m, uint32_t n, uint32_t k, float alpha, float 
     CHECK_HIP_ERROR(hipMemcpy(d_c, matrixC.data(), bytesC, hipMemcpyHostToDevice));
 
     auto blockDim = dim3(T_BLOCK_X, T_BLOCK_Y);
-    auto gridDim  = dim3(rocwmma::ceilDiv(m, ROCWMMA_M * T_BLOCK_X / WAVE_SIZE),
-                        rocwmma::ceilDiv(n, ROCWMMA_N * T_BLOCK_Y));
+    auto gridDim  = dim3(rocwmma::ceil_div(m, ROCWMMA_M * T_BLOCK_X / WAVE_SIZE),
+                        rocwmma::ceil_div(n, ROCWMMA_N * T_BLOCK_Y));
 
     std::cout << "Launching sgemv kernel..." << std::endl;
     hipEvent_t startEvent, stopEvent;

--- a/test/common.hpp
+++ b/test/common.hpp
@@ -75,11 +75,12 @@ namespace rocwmma
     ROCWMMA_DEVICE inline bool isFirstThread()
     {
         return (threadIdx.x == 0) && (threadIdx.y == 0) && (threadIdx.z == 0) && (blockIdx.x == 0)
-                && (blockIdx.y == 0) && (blockIdx.z == 0);
+               && (blockIdx.y == 0) && (blockIdx.z == 0);
     }
 
     template <typename Lhs, typename Rhs>
-    ROCWMMA_DEVICE bool expectEqual(Lhs&& testL, Rhs&& testR, bool debugOnFail, const char* file, uint32_t line)
+    ROCWMMA_DEVICE bool
+        expectEqual(Lhs&& testL, Rhs&& testR, bool debugOnFail, const char* file, uint32_t line)
     {
         bool compare_result = (testL == testR);
         if(!compare_result && debugOnFail && isFirstThread())
@@ -98,7 +99,8 @@ namespace rocwmma
     }
 
     template <typename Lhs, typename Rhs>
-    ROCWMMA_DEVICE bool expectNotEqual(Lhs&& testL, Rhs&& testR, bool debugOnFail, const char* file, uint32_t line)
+    ROCWMMA_DEVICE bool
+        expectNotEqual(Lhs&& testL, Rhs&& testR, bool debugOnFail, const char* file, uint32_t line)
     {
         bool compare_result = (testL != testR);
         if(!compare_result && debugOnFail && isFirstThread())
@@ -243,8 +245,8 @@ namespace rocwmma
                         // Count up in integers, in ascending order for each row.
                         auto value = ((i - padM) * n + (j - padN)) % 5;
                         mat[idx]   = ((value % 3) && std::is_signed<DataT>::value)
-                                         ? -static_cast<DataT>(value)
-                                         : static_cast<DataT>(value);
+                                       ? -static_cast<DataT>(value)
+                                       : static_cast<DataT>(value);
                     }
                 }
             }
@@ -270,7 +272,7 @@ namespace rocwmma
             const auto limitN = n + 2 * padN;
 
             auto blockDim = dim3(1024, 1, 1);
-            auto gridDim  = dim3(ceilDiv(limitM * limitN, blockDim.x), 1, 1);
+            auto gridDim  = dim3(ceil_div(limitM * limitN, blockDim.x), 1, 1);
             hipLaunchKernelGGL((fillWithPaddingKernel<DataT, Layout>),
                                gridDim,
                                blockDim,
@@ -303,8 +305,8 @@ namespace rocwmma
                     auto value = (i * n + j) % 5;
                     auto idx   = index(i, j, ld);
                     mat[idx]   = ((value % 3) && std::is_signed<DataT>::value)
-                                     ? -static_cast<DataT>(value)
-                                     : static_cast<DataT>(value);
+                                   ? -static_cast<DataT>(value)
+                                   : static_cast<DataT>(value);
                 }
             }
         }
@@ -339,7 +341,7 @@ namespace rocwmma
         __host__ static inline void fillLaunchKernel(DataT* d_mat, uint32_t m, uint32_t n)
         {
             auto blockDim = dim3(1024, 1, 1);
-            auto gridDim  = dim3(ceilDiv(m * n, blockDim.x), 1, 1);
+            auto gridDim  = dim3(ceil_div(m * n, blockDim.x), 1, 1);
             hipLaunchKernelGGL((fillKernel<DataT, Layout>), gridDim, blockDim, 0, 0, d_mat, m, n);
         }
 
@@ -349,7 +351,7 @@ namespace rocwmma
             fillLaunchKernel(DataT* d_mat, uint32_t m, uint32_t k, uint32_t b)
         {
             auto blockDim = dim3(1024, 1, 1);
-            auto gridDim  = dim3(ceilDiv(m * k, blockDim.x), 1, b);
+            auto gridDim  = dim3(ceil_div(m * k, blockDim.x), 1, b);
             hipLaunchKernelGGL(
                 (fillKernel<DataT, Layout>), gridDim, blockDim, 0, 0, d_mat, m, k, b);
         }
@@ -360,7 +362,7 @@ namespace rocwmma
             fillValLaunchKernel(DataT* d_mat, uint32_t m, uint32_t n, DataT value)
         {
             auto blockDim = dim3(1024, 1, 1);
-            auto gridDim  = dim3(ceilDiv(m * n, blockDim.x), 1, 1);
+            auto gridDim  = dim3(ceil_div(m * n, blockDim.x), 1, 1);
             hipLaunchKernelGGL(
                 (fillValKernel<DataT, Layout>), gridDim, blockDim, 0, 0, d_mat, m, n, value);
         }
@@ -370,7 +372,7 @@ namespace rocwmma
         __host__ static inline void fillIdxLaunchKernel(DataT* d_mat, uint32_t m, uint32_t n)
         {
             auto blockDim = dim3(1024, 1, 1);
-            auto gridDim  = dim3(ceilDiv(m * n, blockDim.x), 1, 1);
+            auto gridDim  = dim3(ceil_div(m * n, blockDim.x), 1, 1);
             hipLaunchKernelGGL(
                 (fillIdxKernel<DataT, Layout>), gridDim, blockDim, 0, 0, d_mat, m, n);
         }
@@ -609,7 +611,7 @@ namespace rocwmma
         uint32_t ldb = std::is_same<LayoutB, row_major>::value ? n : m;
 
         auto blockDim = dim3(1024, 1, 1);
-        auto gridDim  = dim3(ceilDiv(m * n, blockDim.x), 1, 1);
+        auto gridDim  = dim3(ceil_div(m * n, blockDim.x), 1, 1);
 
         double* d_relativeError;
         double  maxRelativeError;
@@ -639,9 +641,9 @@ namespace rocwmma
         uint32_t maxElements = 1024;
         uint32_t offset      = 1;
 
-        for(uint32_t i = m * n; i > 1; i = ceilDiv(i, maxElements))
+        for(uint32_t i = m * n; i > 1; i = ceil_div(i, maxElements))
         {
-            gridDim       = dim3(ceilDiv(i, maxElements), 1, 1);
+            gridDim       = dim3(ceil_div(i, maxElements), 1, 1);
             auto elements = i > maxElements ? maxElements : i;
 
             hipLaunchKernelGGL((maxReduceKernel),
@@ -691,7 +693,7 @@ namespace rocwmma
         TypeA* matrixA, TypeB* matrixB, uint32_t m, uint32_t k, uint32_t b, double tolerance = 10.0)
     {
         auto blockDim = dim3(1024, 1, 1);
-        auto gridDim  = dim3(ceilDiv(m * k, blockDim.x), 1, b);
+        auto gridDim  = dim3(ceil_div(m * k, blockDim.x), 1, b);
 
         double* d_relativeError;
         double  maxRelativeError;
@@ -720,9 +722,9 @@ namespace rocwmma
         uint32_t maxElements = 1024;
         uint32_t offset      = 1;
 
-        for(uint32_t i = m * k * b; i > 1; i = ceilDiv(i, maxElements))
+        for(uint32_t i = m * k * b; i > 1; i = ceil_div(i, maxElements))
         {
-            gridDim       = dim3(ceilDiv(i, maxElements), 1, 1);
+            gridDim       = dim3(ceil_div(i, maxElements), 1, 1);
             auto elements = i > maxElements ? maxElements : i;
 
             hipLaunchKernelGGL((maxReduceKernel),

--- a/test/dlrm/dlrm_kernel_base_impl.hpp
+++ b/test/dlrm/dlrm_kernel_base_impl.hpp
@@ -81,14 +81,14 @@ namespace rocwmma
 
         if(passDirection == DlrmDirection_t::Forward)
         {
-            return dim3(ceilDiv(mMPadded, TileSize * mTBlockX / device->warpSize()),
-                        ceilDiv(mM, TileSize),
+            return dim3(ceil_div(mMPadded, TileSize * mTBlockX / device->warpSize()),
+                        ceil_div(mM, TileSize),
                         mB);
         }
         else
         {
-            return dim3(ceilDiv(mMPadded, TileSize * mTBlockX / device->warpSize()),
-                        ceilDiv(mK, TileSize),
+            return dim3(ceil_div(mMPadded, TileSize * mTBlockX / device->warpSize()),
+                        ceil_div(mK, TileSize),
                         mB);
         }
     }
@@ -251,8 +251,8 @@ namespace rocwmma
                        static_cast<uint32_t const&>(std::get<1>(problem.problemSize)),
                        static_cast<uint32_t const&>(std::get<2>(problem.problemSize)));
 
-        mMPadded = ceilDiv(mM, TileSize) * TileSize;
-        mKPadded = ceilDiv(mK, TileSize) * TileSize;
+        mMPadded = ceil_div(mM, TileSize) * TileSize;
+        mKPadded = ceil_div(mK, TileSize) * TileSize;
 
         // Determine whether to run forward or backward pass
         passDirection = problem.passDirection;
@@ -347,7 +347,7 @@ namespace rocwmma
                     dlrmKernel = [this, inputBatchOffset, upstreamBatchOffset, accBatchOffset]() {
                         auto& dataInstance = DataStorage::instance();
                         auto  trilGridDim
-                            = dim3(ceilDiv(mM * mM, static_cast<uint32_t>(mTBlockX)), 1, mB);
+                            = dim3(ceil_div(mM * mM, static_cast<uint32_t>(mTBlockX)), 1, mB);
 
                         hipEvent_t syncEvent;
                         CHECK_HIP_ERROR(hipEventCreate(&syncEvent));

--- a/test/dlrm/lds_mapping_util.hpp
+++ b/test/dlrm/lds_mapping_util.hpp
@@ -5,6 +5,7 @@
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <rocwmma/rocwmma.hpp>
 #include <rocwmma/rocwmma_coop.hpp>
+#include <rocwmma/rocwmma_transforms.hpp>
 #pragma GCC diagnostic pop
 
 #include <rocwmma/internal/io_config.hpp>
@@ -138,10 +139,8 @@ namespace rocwmma
 
         // Local Write
         // Vertical register file fulfilled by matrix_b with BlockN = 64
-        using LocalWriteFragA
-            = fragment<matrix_b, 1, registerFileWidth, GlobalReadFragA::size(), DataT, LayoutLds>;
-        using LocalWriteFragB
-            = fragment<matrix_b, 1, registerFileWidth, GlobalReadFragB::size(), DataT, LayoutLds>;
+        using LocalWriteFragA = ApplyDataLayout_t<ApplyRegisterFile_t<GlobalReadFragA>, LayoutLds>;
+        using LocalWriteFragB = ApplyDataLayout_t<ApplyRegisterFile_t<GlobalReadFragB>, LayoutLds>;
 
         // Sanity checks
         static_assert(GlobalReadFragA::size() == LocalWriteFragA::size(),

--- a/test/gemm/gemm_PGR0_LB0_MP0_MB_NC/detail/kernel_impl.hpp
+++ b/test/gemm/gemm_PGR0_LB0_MP0_MB_NC/detail/kernel_impl.hpp
@@ -122,10 +122,10 @@ namespace rocwmma
 
         dim3 gridDim() const final
         {
-            return dim3(ceilDiv(Base::mM,
-                                BlockM * BlocksX * Base::mTBlockX
-                                    / Base::DeviceInfo::instance()->warpSize()),
-                        ceilDiv(Base::mN, BlockN * BlocksY * Base::mTBlockY));
+            return dim3(ceil_div(Base::mM,
+                                 BlockM * BlocksX * Base::mTBlockX
+                                     / Base::DeviceInfo::instance()->warpSize()),
+                        ceil_div(Base::mN, BlockN * BlocksY * Base::mTBlockY));
         }
 
         bool checkSizes() const final

--- a/test/gemm/gemm_PGR1_LB2_MP0_MB_CP/detail/kernel_impl.hpp
+++ b/test/gemm/gemm_PGR1_LB2_MP0_MB_CP/detail/kernel_impl.hpp
@@ -133,10 +133,10 @@ namespace rocwmma
 
         dim3 gridDim() const final
         {
-            return dim3(ceilDiv(Base::mM,
-                                BlockM * BlocksX * Base::mTBlockX
-                                    / Base::DeviceInfo::instance()->warpSize()),
-                        ceilDiv(Base::mN, BlockN * BlocksY * Base::mTBlockY));
+            return dim3(ceil_div(Base::mM,
+                                 BlockM * BlocksX * Base::mTBlockX
+                                     / Base::DeviceInfo::instance()->warpSize()),
+                        ceil_div(Base::mN, BlockN * BlocksY * Base::mTBlockY));
         }
 
         bool checkSizes() const final

--- a/test/gemm/gemm_kernel_base_impl.hpp
+++ b/test/gemm/gemm_kernel_base_impl.hpp
@@ -224,8 +224,8 @@ namespace rocwmma
                         LayoutC,
                         LayoutD>::gridDim() const
     {
-        return dim3(ceilDiv(mM, BlockM * mTBlockX / DeviceInfo::instance()->warpSize()),
-                    ceilDiv(mN, BlockN * mTBlockY));
+        return dim3(ceil_div(mM, BlockM * mTBlockX / DeviceInfo::instance()->warpSize()),
+                    ceil_div(mN, BlockN * mTBlockY));
     }
 
     template <uint32_t BlockM,
@@ -726,10 +726,11 @@ namespace rocwmma
 
                         auto& dataInstance = DataStorage::instance();
 
-                        static_assert((!std::is_same_v<InputT, float8_t>
-                                       && !std::is_same_v<InputT, bfloat8_t>)
-                                          || std::is_same_v<ComputeT, float32_t>,
-                                      "f8 types must have f32 compute type");
+                        static_assert(
+                            (!std::is_same_v<InputT,
+                                             float8_t> && !std::is_same_v<InputT, bfloat8_t>)
+                                || std::is_same_v<ComputeT, float32_t>,
+                            "f8 types must have f32 compute type");
 
                         CHECK_ROCBLAS_ERROR(
                             dispatch_rocBLAS(handle,

--- a/test/gemm/gemm_test_traits.hpp
+++ b/test/gemm/gemm_test_traits.hpp
@@ -76,16 +76,16 @@ namespace rocwmma
             DWord       = 4u,
 
             TileA
-            = ceilDiv((uint32_t)TileSizes::A_Size * sizeof(InputT), Granularity* WaveSize* DWord)
+            = ceil_div((uint32_t)TileSizes::A_Size * sizeof(InputT), Granularity* WaveSize* DWord)
               * Granularity,
             TileB
-            = ceilDiv((uint32_t)TileSizes::B_Size * sizeof(InputT), Granularity* WaveSize* DWord)
+            = ceil_div((uint32_t)TileSizes::B_Size * sizeof(InputT), Granularity* WaveSize* DWord)
               * Granularity,
             TileC
-            = ceilDiv((uint32_t)TileSizes::C_Size * sizeof(ComputeT), Granularity* WaveSize* DWord)
+            = ceil_div((uint32_t)TileSizes::C_Size * sizeof(ComputeT), Granularity* WaveSize* DWord)
               * Granularity,
             TileD
-            = ceilDiv((uint32_t)TileSizes::D_Size * sizeof(OutputT), Granularity* WaveSize* DWord)
+            = ceil_div((uint32_t)TileSizes::D_Size * sizeof(OutputT), Granularity* WaveSize* DWord)
               * Granularity,
         };
 

--- a/test/unit/pack_util_test/device/pack_util.hpp
+++ b/test/unit/pack_util_test/device/pack_util.hpp
@@ -34,12 +34,10 @@
 
 static constexpr bool DebugOnFail = false;
 
-#define PACK_UTIL_EXPECT_EQ(LHS, RHS) \
-    ROCWMMA_EXPECT_EQUAL(LHS, RHS, DebugOnFail);
+#define PACK_UTIL_EXPECT_EQ(LHS, RHS) ROCWMMA_EXPECT_EQUAL(LHS, RHS, DebugOnFail);
 
 namespace rocwmma
 {
-
 
     template <typename DataT, uint32_t VecSize>
     ROCWMMA_DEVICE static inline DataT get(VecT<DataT, VecSize> const& v, uint32_t idx)
@@ -48,22 +46,11 @@ namespace rocwmma
     }
 
     template <typename DataT, uint32_t VecSize>
-    ROCWMMA_DEVICE static inline auto generateSeqVec()
-    {
-        auto buildSeq = [](auto&& idx) {
-            constexpr auto Index = std::decay_t<decltype(idx)>::value;
-            return static_cast<DataT>(Index);
-        };
-
-        return vector_generator<DataT, VecSize>()(buildSeq);
-    }
-
-    template <typename DataT, uint32_t VecSize>
     ROCWMMA_DEVICE static inline bool packUtilTestBasic()
     {
         bool err = false;
 
-        auto res = generateSeqVec<DataT, VecSize>();
+        auto res = make_vector_sequence<DataT, VecSize>();
 
         for(uint32_t i = 0; i < VecSize; i++)
         {
@@ -85,7 +72,7 @@ namespace rocwmma
         using PackUtil = rocwmma::PackUtil<DataT>;
 
         bool err = false;
-        auto res = generateSeqVec<DataT, VecSize>();
+        auto res = make_vector_sequence<DataT, VecSize>();
 
         if constexpr(PackUtil::Traits::PackRatio == 1)
         {
@@ -97,13 +84,15 @@ namespace rocwmma
             using UnpackedT = typename PackUtil::Traits::UnpackedT;
 
             auto paddedData = PackUtil::pad(res);
-            err |= !PACK_UTIL_EXPECT_EQ((std::is_same_v<decltype(paddedData), VecT<PackedT, VecSize>>), true);
+            err |= !PACK_UTIL_EXPECT_EQ(
+                (std::is_same_v<decltype(paddedData), VecT<PackedT, VecSize>>), true);
             for(uint32_t i = 0; i < VecSize; i++)
             {
                 auto value = get(paddedData, i);
 
                 // unpadded data is at idx 0 in the padded data by default
-                err |= !PACK_UTIL_EXPECT_EQ(*reinterpret_cast<DataT*>(&value), static_cast<DataT>((float)i));
+                err |= !PACK_UTIL_EXPECT_EQ(*reinterpret_cast<DataT*>(&value),
+                                            static_cast<DataT>((float)i));
             }
         }
 
@@ -122,7 +111,7 @@ namespace rocwmma
         using PackUtil = rocwmma::PackUtil<DataT>;
 
         bool err = false;
-        auto res = generateSeqVec<DataT, VecSize>();
+        auto res = make_vector_sequence<DataT, VecSize>();
 
         if constexpr(PackUtil::Traits::PackRatio == 1)
         {
@@ -135,11 +124,13 @@ namespace rocwmma
 
             // padIdx == 1 which is valid for 8 bits and 16 bits
             auto paddedData = PackUtil::template pad<1>(res);
-            err |= !PACK_UTIL_EXPECT_EQ((std::is_same_v<decltype(paddedData), VecT<PackedT, VecSize>>), true);
+            err |= !PACK_UTIL_EXPECT_EQ(
+                (std::is_same_v<decltype(paddedData), VecT<PackedT, VecSize>>), true);
             for(uint32_t i = 0u; i < VecSize; i++)
             {
                 PackedT value = get(paddedData, i);
-                err |= !PACK_UTIL_EXPECT_EQ(*(reinterpret_cast<UnpackedT*>(&value) + 1u), static_cast<UnpackedT>(i));
+                err |= !PACK_UTIL_EXPECT_EQ(*(reinterpret_cast<UnpackedT*>(&value) + 1u),
+                                            static_cast<UnpackedT>(i));
             }
         }
 
@@ -163,7 +154,7 @@ namespace rocwmma
 
         if constexpr(PackUtil::Traits::PackRatio == 1)
         {
-            auto res = generateSeqVec<PackedT, VecSize>();
+            auto res = make_vector_sequence<PackedT, VecSize>();
             err |= !PACK_UTIL_EXPECT_EQ(res, PackUtil::unpad(res));
         }
         else
@@ -176,8 +167,9 @@ namespace rocwmma
             }
 
             auto unpaddedData = PackUtil::unpad(res);
-            err |= !PACK_UTIL_EXPECT_EQ((std::is_same_v<decltype(unpaddedData), VecT<UnpackedT, VecSize>>), true);
-            err |= !PACK_UTIL_EXPECT_EQ(unpaddedData, (generateSeqVec<DataT, VecSize>()));
+            err |= !PACK_UTIL_EXPECT_EQ(
+                (std::is_same_v<decltype(unpaddedData), VecT<UnpackedT, VecSize>>), true);
+            err |= !PACK_UTIL_EXPECT_EQ(unpaddedData, (make_vector_sequence<DataT, VecSize>()));
         }
 
         return err;
@@ -200,7 +192,7 @@ namespace rocwmma
 
         if constexpr(PackUtil::Traits::PackRatio == 1)
         {
-            auto res = generateSeqVec<PackedT, VecSize>();
+            auto res = make_vector_sequence<PackedT, VecSize>();
             err |= !PACK_UTIL_EXPECT_EQ(res, PackUtil::unpad(res));
         }
         else
@@ -213,8 +205,9 @@ namespace rocwmma
             }
 
             auto unpaddedData = PackUtil::template unpad<1>(res);
-            err |= !PACK_UTIL_EXPECT_EQ((std::is_same_v<decltype(unpaddedData), VecT<UnpackedT, VecSize>>), true);
-            err |= !PACK_UTIL_EXPECT_EQ(unpaddedData, (generateSeqVec<DataT, VecSize>()));
+            err |= !PACK_UTIL_EXPECT_EQ(
+                (std::is_same_v<decltype(unpaddedData), VecT<UnpackedT, VecSize>>), true);
+            err |= !PACK_UTIL_EXPECT_EQ(unpaddedData, (make_vector_sequence<DataT, VecSize>()));
         }
 
         return err;
@@ -232,14 +225,17 @@ namespace rocwmma
         // required by pack(): VecSize % PackUtil::Traits::PackRatio == 0
         if constexpr(VecSize % PackUtil::Traits::PackRatio == 0)
         {
-            auto res = generateSeqVec<UnpackedT, VecSize>();
+            auto res = make_vector_sequence<UnpackedT, VecSize>();
 
             // pack() cast VecT<UnpackedT, VecSize> const &  to VecT<PackedT, VecSize / PackRatio> const &
-            err |= !PACK_UTIL_EXPECT_EQ((std::is_same_v<decltype(PackUtil::pack(res)),
-                                   VecT<PackedT, VecSize / PackUtil::Traits::PackRatio> const&>), true);
+            err |= !PACK_UTIL_EXPECT_EQ(
+                (std::is_same_v<decltype(PackUtil::pack(res)),
+                                VecT<PackedT, VecSize / PackUtil::Traits::PackRatio> const&>),
+                true);
 
             // argument and return of pack() point to the same addr
-            err |= !PACK_UTIL_EXPECT_EQ(reinterpret_cast<void const*>(&PackUtil::pack(res)), reinterpret_cast<void const*>(&res));
+            err |= !PACK_UTIL_EXPECT_EQ(reinterpret_cast<void const*>(&PackUtil::pack(res)),
+                                        reinterpret_cast<void const*>(&res));
         }
 
         return err;
@@ -254,15 +250,17 @@ namespace rocwmma
 
         bool err = false;
 
-        auto res = generateSeqVec<PackedT, VecSize>();
+        auto res = make_vector_sequence<PackedT, VecSize>();
 
         // pack() cast VecT<PackedT, VecSize> const &  to VecT<UnpackedT, VecSize * PackRatio> const &
-        err |= !PACK_UTIL_EXPECT_EQ((std::is_same_v<decltype(PackUtil::unpack(res)),
-                               VecT<UnpackedT, VecSize * PackUtil::Traits::PackRatio> const&>), true);
+        err |= !PACK_UTIL_EXPECT_EQ(
+            (std::is_same_v<decltype(PackUtil::unpack(res)),
+                            VecT<UnpackedT, VecSize * PackUtil::Traits::PackRatio> const&>),
+            true);
 
         // argument and return of pack() point to the same addr
         err |= !PACK_UTIL_EXPECT_EQ(reinterpret_cast<void const*>(&PackUtil::unpack(res)),
-               reinterpret_cast<void const*>(&res));
+                                    reinterpret_cast<void const*>(&res));
 
         return err;
     }
@@ -275,14 +273,16 @@ namespace rocwmma
         using UnpackedT = typename PackUtil::Traits::UnpackedT;
 
         bool err = false;
-        auto res = generateSeqVec<UnpackedT, VecSize>();
+        auto res = make_vector_sequence<UnpackedT, VecSize>();
 
         if constexpr(VecSize % PackUtil::Traits::PackRatio == 0)
         {
-            err |= !PACK_UTIL_EXPECT_EQ((std::is_same_v<decltype(PackUtil::paddedPack(res)),
-                                   VecT<PackedT, VecSize / PackUtil::Traits::PackRatio> const&>), true);
+            err |= !PACK_UTIL_EXPECT_EQ(
+                (std::is_same_v<decltype(PackUtil::paddedPack(res)),
+                                VecT<PackedT, VecSize / PackUtil::Traits::PackRatio> const&>),
+                true);
             err |= !PACK_UTIL_EXPECT_EQ(reinterpret_cast<void const*>(&PackUtil::paddedPack(res)),
-                    reinterpret_cast<void const*>(&res));
+                                        reinterpret_cast<void const*>(&res));
         }
         else if constexpr(VecSize * 2 == PackUtil::Traits::PackRatio)
         {
@@ -309,7 +309,8 @@ namespace rocwmma
                     auto value = get(paddedData, i);
 
                     // unpadded data is at idx 0 in the padded data by default
-                    err |= !PACK_UTIL_EXPECT_EQ(*reinterpret_cast<DataT*>(&value), static_cast<DataT>((float)i));
+                    err |= !PACK_UTIL_EXPECT_EQ(*reinterpret_cast<DataT*>(&value),
+                                                static_cast<DataT>((float)i));
                 }
             }
         }
@@ -328,11 +329,14 @@ namespace rocwmma
 
         if constexpr(VecSize % PackUtil::Traits::PackRatio == 0)
         {
-            auto res = generateSeqVec<PackedT, VecSize / PackUtil::Traits::PackRatio>();
-            err |= !PACK_UTIL_EXPECT_EQ((std::is_same_v<decltype(PackUtil::template paddedUnpack<VecSize>(res)),
-                                   VecT<UnpackedT, VecSize> const&>), true);
-            err |= !PACK_UTIL_EXPECT_EQ(reinterpret_cast<void const*>(&PackUtil::template paddedUnpack<VecSize>(res)),
-                    reinterpret_cast<void const*>(&res));
+            auto res = make_vector_sequence<PackedT, VecSize / PackUtil::Traits::PackRatio>();
+            err |= !PACK_UTIL_EXPECT_EQ(
+                (std::is_same_v<decltype(PackUtil::template paddedUnpack<VecSize>(res)),
+                                VecT<UnpackedT, VecSize> const&>),
+                true);
+            err |= !PACK_UTIL_EXPECT_EQ(
+                reinterpret_cast<void const*>(&PackUtil::template paddedUnpack<VecSize>(res)),
+                reinterpret_cast<void const*>(&res));
         }
         return err;
     }
@@ -350,12 +354,13 @@ namespace rocwmma
         {
             auto constexpr packSize = std::max(1u, VecSize / PackUtil::Traits::PackRatio);
             auto res                = VecT<PackedT, packSize>(0);
-            auto expectedData       = generateSeqVec<UnpackedT, VecSize>();
+            auto expectedData       = make_vector_sequence<UnpackedT, VecSize>();
             for(uint32_t i = 0; i < VecSize; i++)
             {
                 *(reinterpret_cast<VecT<UnpackedT, VecSize>*>(&res.data) + i) = expectedData;
             }
-            err |= !PACK_UTIL_EXPECT_EQ(PackUtil::template paddedUnpack<VecSize>(res), expectedData);
+            err |= !PACK_UTIL_EXPECT_EQ(PackUtil::template paddedUnpack<VecSize>(res),
+                                        expectedData);
         }
         return err;
     }
@@ -375,7 +380,8 @@ namespace rocwmma
             auto expectedData = VecT<UnpackedT, 1>(static_cast<UnpackedT>(1.0F));
             (*(reinterpret_cast<VecT<UnpackedT, VecSize>*>(&res.data))).data[0]
                 = expectedData.data[0];
-            err |= !PACK_UTIL_EXPECT_EQ(PackUtil::template paddedUnpack<VecSize>(res), expectedData);
+            err |= !PACK_UTIL_EXPECT_EQ(PackUtil::template paddedUnpack<VecSize>(res),
+                                        expectedData);
         }
         return err;
     }

--- a/test/unit/unit_kernel_base_impl.hpp
+++ b/test/unit/unit_kernel_base_impl.hpp
@@ -69,8 +69,8 @@ namespace rocwmma
         }
 
         // There will be a divide by zero error if `BlockM * mTBlockX < DeviceInfo::instance()->warpSize()`
-        return dim3(ceilDiv(mM, BlockM * mTBlockX / DeviceInfo::instance()->warpSize()),
-                    ceilDiv(mN, BlockN * mTBlockY));
+        return dim3(ceil_div(mM, BlockM * mTBlockX / DeviceInfo::instance()->warpSize()),
+                    ceil_div(mN, BlockN * mTBlockY));
     }
 
     template <uint32_t BlockM, uint32_t BlockN, typename DataT, typename Layout>

--- a/test/unit/unit_test_traits.hpp
+++ b/test/unit/unit_test_traits.hpp
@@ -60,7 +60,7 @@ namespace rocwmma
             DWord       = 4u,
 
             PackedTile
-            = ceilDiv((uint32_t)Sizes::TileSize, Granularity* WaveSize* DWord) * Granularity,
+            = ceil_div((uint32_t)Sizes::TileSize, Granularity* WaveSize* DWord) * Granularity,
             UnpackedTile = PackedTile * PackTraits<DataT>::PackRatio,
         };
 

--- a/test/unit/vector_util_test/device/vector_util.hpp
+++ b/test/unit/vector_util_test/device/vector_util.hpp
@@ -37,23 +37,12 @@ namespace rocwmma
         return v.data[idx];
     }
 
-    template <typename DataT, uint32_t VecSize, uint32_t Start = 0>
-    ROCWMMA_DEVICE static inline auto generateSeqVec()
-    {
-        auto buildSeq = [](auto&& idx) {
-            constexpr auto Index = std::decay_t<decltype(idx)>::value;
-            return static_cast<DataT>(Index) + static_cast<DataT>(Start);
-        };
-
-        return vector_generator<DataT, VecSize>()(buildSeq);
-    }
-
     template <typename DataT, uint32_t VecSize>
     ROCWMMA_DEVICE static inline bool vectorGeneratorTestBasic()
     {
         bool err = false;
 
-        auto res = generateSeqVec<DataT, VecSize>();
+        auto res = make_vector_sequence<DataT, VecSize>();
 
         for(uint32_t i = 0; i < VecSize; i++)
         {
@@ -91,7 +80,7 @@ namespace rocwmma
     {
         bool err = false;
 
-        auto v   = generateSeqVec<DataT, VecSize>();
+        auto v   = make_vector_sequence<DataT, VecSize>();
         auto res = extractEven(v);
 
         // Handle the general case
@@ -116,7 +105,7 @@ namespace rocwmma
     {
         bool err = false;
 
-        auto v   = generateSeqVec<DataT, VecSize>();
+        auto v   = make_vector_sequence<DataT, VecSize>();
         auto res = extractOdd(v);
 
         // Handle general case
@@ -143,7 +132,7 @@ namespace rocwmma
         using PackTraits = typename PackUtil::Traits;
         bool err         = false;
 
-        auto v   = generateSeqVec<DataT, VecSize>();
+        auto v   = make_vector_sequence<DataT, VecSize>();
         auto res = reorderEvenOdd(v);
 
         // Handle general case
@@ -177,7 +166,7 @@ namespace rocwmma
         using PackTraits = typename PackUtil::Traits;
         bool err         = false;
 
-        auto v   = generateSeqVec<DataT, VecSize>();
+        auto v   = make_vector_sequence<DataT, VecSize>();
         auto res = reorderOddEven(v);
 
         // Handle general case
@@ -209,7 +198,7 @@ namespace rocwmma
     {
         bool err = false;
 
-        auto v   = generateSeqVec<DataT, VecSize>();
+        auto v   = make_vector_sequence<DataT, VecSize>();
         auto res = extractLo(v);
 
         if constexpr(VecSize > 1)
@@ -232,7 +221,7 @@ namespace rocwmma
     {
         bool err = false;
 
-        auto v   = generateSeqVec<DataT, VecSize>();
+        auto v   = make_vector_sequence<DataT, VecSize>();
         auto res = extractHi(v);
 
         if constexpr(VecSize > 1)
@@ -255,7 +244,7 @@ namespace rocwmma
     {
         bool err = false;
 
-        auto v   = generateSeqVec<DataT, VecSize>();
+        auto v   = make_vector_sequence<DataT, VecSize>();
         auto res = concat(v, v);
 
         for(uint32_t i = 0; i < VecSize * 2; i++)
@@ -273,8 +262,8 @@ namespace rocwmma
         using PackTraits = typename PackUtil::Traits;
         bool err         = false;
 
-        auto v0  = generateSeqVec<DataT, VecSize>();
-        auto v1  = generateSeqVec<DataT, VecSize, VecSize>();
+        auto v0  = make_vector_sequence<DataT, VecSize>();
+        auto v1  = make_vector_sequence<DataT, VecSize, VecSize>();
         auto res = zip(v0, v1);
 
         for(uint32_t i = 0; i < VecSize; i++)
@@ -290,8 +279,8 @@ namespace rocwmma
     {
         bool err = false;
 
-        auto v0  = generateSeqVec<DataT, VecSize>();
-        auto v1  = generateSeqVec<DataT, VecSize, VecSize>();
+        auto v0  = make_vector_sequence<DataT, VecSize>();
+        auto v1  = make_vector_sequence<DataT, VecSize, VecSize>();
         auto res = unpackLo(v0, v1);
 
         // 0, VecSize , 1, VecSize + 1, ...
@@ -308,8 +297,8 @@ namespace rocwmma
     {
         bool err = false;
 
-        auto v0  = generateSeqVec<DataT, VecSize>();
-        auto v1  = generateSeqVec<DataT, VecSize, VecSize>();
+        auto v0  = make_vector_sequence<DataT, VecSize>();
+        auto v1  = make_vector_sequence<DataT, VecSize, VecSize>();
         auto res = unpackHi(v0, v1);
 
         // VecSize / 2, VecSize / 2 + VecSize , VecSize / 2 + 1, VecSize / 2 + VecSize + 1, ...


### PR DESCRIPTION
- Added class IOTile: Calculates minimum padded BlockMNK values from input FragMNK sizes.
- Added namespace for IOBoundsCtrl: contains classes with bounds detection and handling:
  - Default: No bounds check, no handling
  - Clip2d: Bounds check, skip transaction
  - ClipAndReplace2d: Bounds check, bounds violations overwrite buffer with value
- Added IOBoundsCtrl classes to io_bearer and coop_io_bearer:
  - IOBearer now uses IOBoundsCtrl policies to check bounds and handle violations
- Added math/_impl.hpp to consolidate integral math functionality:
  - next_multiple(val, lcm): Gives the next multiple of lcm from the given val
  - ceil_div(num, div) # renamed from ceilDiv for consistency # : ceiling division
  - next_pow2(val): gives the next power of 2 from val
  - is_pow2(val): returns whether val is a power of 2
- Added static_for functionality:
  - Static loop unrolling
  - Functor forwarding with arguments
- Added make_vector_sequence to utility/vector: create a vector sequence represented by start, increment and element count
- Added reduce_vector_or to utility/vector: reduce vector elements to a single scalar via bitwise or