### PR TITLE
Fix warning from symbol clash. Fix compile errors

### DIFF
--- a/library/include/rocwmma/internal/float8.hpp
+++ b/library/include/rocwmma/internal/float8.hpp
@@ -154,19 +154,19 @@ namespace ROCWMMA_TYPE_TRAITS_IMPL_NAMESPACE
 
 #if defined(__HIPCC_RTC__)
 #if ROCWMMA_FP8_FNUZ
-#define ENABLE_FNUZ_HIPRTC 1
+#define ROCWMMA_ENABLE_FNUZ_HIPRTC 1
 #else
-#define ENABLE_FNUZ_HIPRTC 0
+#define ROCWMMA_ENABLE_FNUZ_HIPRTC 0
 #endif
 
 #if ROCWMMA_FP8_OCP
-#define ENABLE_OCP_HIPRTC 1
+#define ROCWMMA_ENABLE_OCP_HIPRTC 1
 #else
-#define ENABLE_OCP_HIPRTC 0
+#define ROCWMMA_ENABLE_OCP_HIPRTC 0
 #endif
 #endif
 
-#if !defined(ENABLE_OCP_HIPRTC) || ENABLE_OCP_HIPRTC
+#if !defined(ROCWMMA_ENABLE_OCP_HIPRTC) || ROCWMMA_ENABLE_OCP_HIPRTC
 ROCWMMA_FP8_VISIBILITY constexpr inline hip_fp8_e4m3
     make_hip_fp8_e4m3_from_bits(__hip_fp8_storage_t bits)
 {
@@ -646,14 +646,14 @@ namespace ROCWMMA_NUMERIC_LIMITS_IMPL_NAMESPACE
         }
     };
 }
-#endif // ENABLE_OCP_HIPRTC
+#endif // ROCWMMA_ENABLE_OCP_HIPRTC
 //////////////////////////////////////////
 ///  FNUZ f8 / bf8 operator overloads  ///
 //////////////////////////////////////////
 
 using rocwmma::uint8_t;
 
-#if !defined(ENABLE_FNUZ_HIPRTC) || ENABLE_FNUZ_HIPRTC
+#if !defined(ROCWMMA_ENABLE_FNUZ_HIPRTC) || ROCWMMA_ENABLE_FNUZ_HIPRTC
 ROCWMMA_FP8_FNUZ_VISIBILITY constexpr inline auto
     make_hip_fp8_e4m3_fnuz_from_bits(__hip_fp8_storage_t bits)
 {
@@ -1109,6 +1109,6 @@ namespace ROCWMMA_NUMERIC_LIMITS_IMPL_NAMESPACE
     //@endcond
 
 } // namespace ROCWMMA_NUMERIC_LIMITS_IMPL_NAMESPACE
-#endif // ENABLE_FNUZ_HIPRTC
+#endif // ROCWMMA_ENABLE_FNUZ_HIPRTC
 
 #endif // ROCWMMA_FLOAT8_HPP

--- a/library/include/rocwmma/internal/types.hpp
+++ b/library/include/rocwmma/internal/types.hpp
@@ -73,7 +73,6 @@ namespace rocwmma
     using int64_t  = __hip_internal::int64_t;
     using uint64_t = __hip_internal::uint64_t;
     using index_t  = __hip_internal::int32_t;
-    using size_t   = __hip_internal::size_t;
 
 #endif // !defined(__HIPCC_RTC__)
 

--- a/library/include/rocwmma/internal/utility/vector_impl.hpp
+++ b/library/include/rocwmma/internal/utility/vector_impl.hpp
@@ -501,7 +501,7 @@ namespace rocwmma
     ROCWMMA_HOST_DEVICE constexpr static inline auto make_vector_sequence()
     {
         constexpr auto buildSeq = [](auto&& idx) {
-            constexpr auto Index = std::decay_t<decltype(idx)>::value;
+            constexpr auto Index = decay_t<decltype(idx)>::value;
             return static_cast<DataT>(Start + Index * Stride);
         };
 


### PR DESCRIPTION
- Removes std::scoping on decay_t call for vector util
- Change macro name to prepend ROCWMMA to avoid name clash.
- Remove reference to __hip_internal::size_t that is not defined.