### PR TITLE
Add migration guide for rocWMMA 2.0

### DIFF
--- a/docs/api-reference/api-reference-guide.rst
+++ b/docs/api-reference/api-reference-guide.rst
@@ -221,7 +221,7 @@ Supported matrix layouts
 Supported thread block sizes
 ----------------------------
 
-rocWMMA generally supports and tests up to 4 wavefronts per threadblock. The X dimension is expected to be a multiple of the wave size and will be scaled as such.
+rocWMMA generally supports and tests up to 4 wavefronts per thread block. The X dimension is expected to be a multiple of the wave size and will be scaled as such.
 
 .. tabularcolumns::
    |C|C|

--- a/docs/conceptual/migration-guide.rst
+++ b/docs/conceptual/migration-guide.rst
@@ -40,7 +40,7 @@ Previous releases began deprecating cooperative API functions such as those defi
 
 These functions previously required ``WaveCount`` as a template parameter and passed ``waveIndex`` as an argument to the API calls. This information was used to distribute data responsibilities across participating waves, aiming to balance and optimize data transactions within a thread block. Cooperation between wavefronts in a thread block requires the use of a separate cooperative API, along with propagation of wave count and wave index values.
 
-Example:
+Example of deprecated cooperative API:
 
 .. code-block:: c++
 
@@ -68,7 +68,7 @@ Example:
 
 Calculating the warp count and warp index requires extra boilerplate code. It is important to supply the same warp count and warp index values to matching pairs of load, store, and transform APIs. Providing mismatched values to APIs that depend on matching warp count and index poses a risk of incorrect behavior. Embedding the warp count and index into the fragment object helps mitigate the risk.
 
-As a result, fragments are augmented with an additional fragment scheduler template parameter. Fragment schedulers are classes that represent thread block scheduling models. These models provide static values for both the wave count and wave order (wave index). Fragment schedulers are classified as either non-cooperative (the default, where waves act independently) or cooperative (where waves collaborate within a thread block). Their names reflect their ordering scheme.
+As a result, fragments in rocWMMA 2.0 are augmented with an additional fragment scheduler template parameter. Fragment schedulers are classes that represent thread block scheduling models. These models provide static values for both the wave count and wave order (wave index). Fragment schedulers are classified as either non-cooperative (the default, where waves act independently) or cooperative (where waves collaborate within a thread block). Their names reflect their ordering scheme.
 
 Example:
 
@@ -108,7 +108,7 @@ Here is the simplified usage with new cooperative fragment changes:
    // Transfer data from global memory to local memory
    GRBuffA grBuffA;
    load_matrix_sync(grBuffA, gAddrA, lda);
-   store_matrix_sync(ldsAddr, applyDataLayout<DataLayoutLds>(applyTranspose(grBuffA)), ldsld);
+   store_matrix_sync(ldsAddr, apply_data_layout<DataLayoutLds>(apply_transpose(grBuffA)), ldsld);
 
 To summarize, the ``CoopScheduler`` template parameter allows you to express the required cooperative behavior with the fragment class declaration. Boilerplate code for calculating wave count and wave indices is wrapped into the ``CoopScheduler`` class. You can use fragments with the standard rocWMMA API without the need to externally propagate matching wave counts or wave indices, making rocWMMA more compact and expressive than previous versions.
 

--- a/docs/conceptual/migration-guide.rst
+++ b/docs/conceptual/migration-guide.rst
@@ -162,7 +162,7 @@ In previous rocWMMA versions, fragment sizes were required to be a multiple of t
    store_matrix_sync(gResC, accum, ldc, layout_t::mem_row_major);
 
 
-In summary, partial tiles are padded to the minimum MMA block dimensions to accommodate a wider range of fragment sizes. However, this added flexibility comes at a cost: extra registers used for padding may increase kernel register pressure for small tiles and incur extra overhead for checking boundary conditions. Padded fragments are logically restricted to writing in FragMNK dimensions and zeroing boundary conditions.
+In summary, partial tiles are padded to the minimum MMA block dimensions to accommodate a wider range of fragment sizes. However, this added flexibility comes at a cost: extra registers used for padding might increase kernel register pressure for small tiles and incur extra overhead for checking boundary conditions. Padded fragments are logically restricted to writing in FragMNK dimensions and zeroing boundary conditions.
 
 .. note::
 

--- a/docs/conceptual/migration-guide.rst
+++ b/docs/conceptual/migration-guide.rst
@@ -95,7 +95,7 @@ Example:
       ...
    }
 
-Simplified usage with new cooperative fragment changes:
+Here is the simplified usage with new cooperative fragment changes:
 
 .. code-block:: c++
 

--- a/docs/conceptual/migration-guide.rst
+++ b/docs/conceptual/migration-guide.rst
@@ -110,7 +110,7 @@ Here is the simplified usage with new cooperative fragment changes:
    load_matrix_sync(grBuffA, gAddrA, lda);
    store_matrix_sync(ldsAddr, applyDataLayout<DataLayoutLds>(applyTranspose(grBuffA)), ldsld);
 
-To summarize, the ``CoopScheduler`` template parameter allows you to express the required cooperative behavior with the fragment class declaration. Boilerplate code for calculating wave count and wave indices are wrapped into the ``CoopScheduler`` class. You can use fragments with the standard rocWMMA API without the need to externally propagate matching wave counts or wave indices, making rocWMMA more compact and expressive than previous versions.
+To summarize, the ``CoopScheduler`` template parameter allows you to express the required cooperative behavior with the fragment class declaration. Boilerplate code for calculating wave count and wave indices is wrapped into the ``CoopScheduler`` class. You can use fragments with the standard rocWMMA API without the need to externally propagate matching wave counts or wave indices, making rocWMMA more compact and expressive than previous versions.
 
 .. note::
 

--- a/docs/conceptual/migration-guide.rst
+++ b/docs/conceptual/migration-guide.rst
@@ -11,10 +11,6 @@ Migration guide for rocWMMA 2.0
 
 This document outlines the key API changes and new features introduced in rocWMMA 2.0, with examples to help you migrate from earlier versions.
 
---------------------------
-API changes in rocWMMA 2.0
---------------------------
-
 Starting with version 2.0, rocWMMA introduces significant changes to its API, including:
 
 - Removed cooperative API
@@ -42,7 +38,7 @@ Previous releases began deprecating cooperative API functions such as those defi
                                              uint32_t                                                             ldm,
                                              uint32_t                                                             waveIndex);
 
-These functions previously required users to provide ``WaveCount`` as a template parameter and pass ``waveIndex`` as an argument to the API calls. This information was used to distribute data responsibilities across participating waves, aiming to balance and optimize data transactions within a thread block. Cooperation between wavefronts in a threadblock requires the use of a separate cooperative API, along with propagation of wave count and wave index values.
+These functions previously required ``WaveCount`` as a template parameter and pass ``waveIndex`` as an argument to the API calls. This information was used to distribute data responsibilities across participating waves, aiming to balance and optimize data transactions within a thread block. Cooperation between wavefronts in a threadblock requires the use of a separate cooperative API, along with propagation of wave count and wave index values.
 
 Example:
 

--- a/docs/conceptual/migration-guide.rst
+++ b/docs/conceptual/migration-guide.rst
@@ -38,7 +38,7 @@ Previous releases began deprecating cooperative API functions such as those defi
                                              uint32_t                                                             ldm,
                                              uint32_t                                                             waveIndex);
 
-These functions previously required ``WaveCount`` as a template parameter and pass ``waveIndex`` as an argument to the API calls. This information was used to distribute data responsibilities across participating waves, aiming to balance and optimize data transactions within a thread block. Cooperation between wavefronts in a threadblock requires the use of a separate cooperative API, along with propagation of wave count and wave index values.
+These functions previously required ``WaveCount`` as a template parameter and passed ``waveIndex`` as an argument to the API calls. This information was used to distribute data responsibilities across participating waves, aiming to balance and optimize data transactions within a thread block. Cooperation between wavefronts in a threadblock requires the use of a separate cooperative API, along with propagation of wave count and wave index values.
 
 Example:
 

--- a/docs/conceptual/migration-guide.rst
+++ b/docs/conceptual/migration-guide.rst
@@ -13,7 +13,7 @@ This document outlines the key API changes and new features introduced in rocWMM
 
 Starting with version 2.0, rocWMMA introduces significant changes to its API, including:
 
-- Removed cooperative API
+- Removal of the cooperative API
 - Transforms API no longer requires wave count template parameters
 - rocWMMA fragments now have a fragment scheduler template argument
 - rocWMMA fragments now support partial fragment sizes

--- a/docs/conceptual/migration-guide.rst
+++ b/docs/conceptual/migration-guide.rst
@@ -166,8 +166,8 @@ In summary, partial tiles are padded to the minimum MMA block dimensions to acco
 
 .. note::
 
-   Padded fragment internals always use padded sized resources instead of fragment sized resources.
-   However, fragment element-wise accesses, such as uniform FMA, should continue to use fragment.num_elements, assuming that any padded elements will be zero.
+   Padded fragment internals always use padded-sized resources instead of fragment-sized resources.
+   However, fragment element-wise accesses, such as uniform FMA, should continue to use `fragment.num_elements`, assuming that any padded elements will be zero.
 
    Example:
 

--- a/docs/conceptual/migration-guide.rst
+++ b/docs/conceptual/migration-guide.rst
@@ -1,0 +1,184 @@
+.. meta::
+   :description: C++ library for accelerating mixed precision matrix multiply-accumulate operations
+    leveraging specialized GPU matrix cores on AMD's latest discrete GPUs
+   :keywords: rocWMMA, ROCm, library, API, tool
+
+.. _migration-guide:
+
+===============================
+Migration guide for rocWMMA 2.0 
+===============================
+
+This document outlines the key API changes and new features introduced in rocWMMA 2.0, with examples to help you migrate from earlier versions.
+
+--------------------------
+API changes in rocWMMA 2.0
+--------------------------
+
+Starting with version 2.0, rocWMMA introduces significant changes to its API, including:
+
+- Removed cooperative API
+- Transforms API no longer requires wave count template parameters
+- rocWMMA fragments now have a fragment scheduler template argument
+- rocWMMA fragments now support partial fragment sizes
+
+-----------------------
+Cooperative API changes
+-----------------------
+
+Previous releases began deprecating cooperative API functions such as those defined in ``rocwmma/rocwmma_coop.hpp``:
+
+.. code-block:: c++
+
+   template <uint32_t WaveCount, typename MatrixT, uint32_t BlockM, uint32_t BlockN, uint32_t BlockK, typename DataT, typename DataLayoutT>
+   ROCWMMA_DEVICE void load_matrix_coop_sync(fragment<MatrixT, BlockM, BlockN, BlockK, DataT, DataLayoutT>& frag,
+                                             const DataT*                                                   data,
+                                             uint32_t                                                       ldm,
+                                             uint32_t                                                       waveIndex);
+
+   template <uint32_t WaveCount, typename MatrixT, uint32_t BlockM, uint32_t BlockN, uint32_t BlockK, typename DataT, typename DataLayoutT>
+   ROCWMMA_DEVICE void store_matrix_coop_sync(DataT*                                                               data,
+                                             fragment<MatrixT, BlockM, BlockN, BlockK, DataT, DataLayoutT> const& frag,
+                                             uint32_t                                                             ldm,
+                                             uint32_t                                                             waveIndex);
+
+These functions previously required users to provide ``WaveCount`` as a template parameter and pass ``waveIndex`` as an argument to the API calls. This information was used to distribute data responsibilities across participating waves, aiming to balance and optimize data transactions within a thread block. Cooperation between wavefronts in a threadblock requires the use of a separate cooperative API, along with propagation of wave count and wave index values.
+
+Example:
+
+.. code-block:: c++
+
+   // Global read (macro tile)
+   using GRBuffA = fragment<matrix_a, MACRO_TILE_X, ROCWMMA_N, ROCWMMA_K, InputT, DataLayoutA>;
+
+   // Local warp coordinate relative to current threadblock (wg).
+   constexpr auto warpDims        = make_coord2d(WARPS_X, WARPS_Y);
+   auto           localWarpCoord  = make_coord2d(threadIdx.x / WARP_SIZE, threadIdx.y);
+
+   // WorkItems will be split up by minimum IOCount to perform either global read or local write.
+   // These are inputs to cooperative functions.
+   constexpr auto warpCount = get<0>(warpDims) * get<1>(warpDims);
+
+   // Scheduling warp order is analogous to row major priority.
+   // E.g. Wg = (128, 2) = 2x2 warps
+   // (0, 0)   (0, 1)   Share Schedule: w0 = (0, 0), w1 = (0, 1),
+   // (1, 0)   (1, 1)                   w2 = (1, 0), w3 = (1, 1), count = 4
+   const auto warpIndex = get<0>(localWarpCoord) * get<1>(warpDims) + get<1>(localWarpCoord);
+
+   // Transfer data from global memory to local memory
+   GRBuffA grBuffA;
+   load_matrix_coop_sync<warpCount>(grBuffA, gAddrA, lda, warpIndex);
+   store_matrix_coop_sync<warpCount>(ldsAddr, applyDataLayout<DataLayoutLds, warpCount>(applyTranspose(grBuffA)), ldsld, warpIndex);
+
+Calculating the warp count and warp index requires extra boilerplate code. It is important to supply the same warp count and warp index values to matching pairs of load, store and transform APIs. Providing mismatched values to APIs that depend on matching warp count and index poses a risk of incorrect behavior. Embedding the warp count and index into the fragment object helps mitigate the risk.
+
+As a result, fragments are augmented with an additional fragment scheduler template parameter. Fragment schedulers are classes that represent threadblock scheduling models. These models provide static values for both the wave count and wave order (wave index). Fragment schedulers are classified as either non-cooperative (the default, where waves act independently) or cooperative (where waves collaborate within a threadblock). Their names reflect their ordering scheme.
+
+Example:
+
+.. code-block:: c++
+
+   namespace fragment_scheduler
+   {
+      //! @struct default
+      //! @brief The default fragment scheduler; each wave operates independently.
+      using default_schedule = IOScheduler::Default;
+
+      //! @struct coop_row_major_2d
+      //! @brief  A cooperative scheduling strategy where each wave in the 2d threadblock
+      //! will contribute to the fragment operation in row_major grid order.
+      //! All waves are scheduled in row_major order.
+      //! E.g. (TBlockX, TBlockY) => 2x2 waves
+      //! w0 = (0, 0),  w1 = (0, 1),
+      //! w2 = (1, 0),  w3 = (1, 1)
+      //! @tparam TBlockX the size of the thread-block in the X dimension
+      //! @tparam TBlockY the size of the thread-block in the Y dimension
+      template <uint32_t TBlockX, uint32_t TBlockY>
+      using coop_row_major_2d = IOScheduler::RowMajor2d<TBlockX, TBlockY>;
+
+      ...
+   }
+
+Simplified usage with new cooperative fragment changes:
+
+.. code-block:: c++
+
+   // Global read (macro tile)
+   // Distribute segments of macro tile data between waves of the threadblock in
+   // row major order.
+   using CoopScheduler = fragment_scheduler::coop_row_major_2d<TBLOCK_X, TBLOCK_Y>;
+   using GRBuffA = fragment<matrix_a, MACRO_TILE_X, ROCWMMA_N, ROCWMMA_K, InputT, DataLayoutA, CoopScheduler>;
+
+   // Transfer data from global memory to local memory
+   GRBuffA grBuffA;
+   load_matrix_sync(grBuffA, gAddrA, lda);
+   store_matrix_sync(ldsAddr, applyDataLayout<DataLayoutLds>(applyTranspose(grBuffA)), ldsld);
+
+To summarize, the ``CoopScheduler`` template parameter allows you to express the required cooperative behavior with the fragment class declaration. Boilerplate code for calculating wave count and wave indices are wrapped into the ``CoopScheduler`` class. You can use fragments with the standard rocWMMA API without the need to externally propagate matching wave counts or wave indices, making rocWMMA more compact and expressive than previous versions.
+
+.. note::
+
+   Cooperative fragment schedulers require template parameters for ``TBLOCK_X`` and ``TBLOCK_Y`` dimensions. This design enables various optimizations by allowing the schedulers to provide a static wave count at compile time. As a result rocWMMA no longer supports run-time wave count calculations in favor of better performance.
+
+------------------------
+Partial fragment support
+------------------------
+
+In previous rocWMMA versions, fragment sizes were required to be a multiple of the minimum block sizes, as described in the :doc:`programmers-guide`. This was a function of the MMA implementation of hardware acceleration. Thus, rocWMMA serves as a direct hardware enablement to employ block-wise decomposition of matrix-multiply problems. In absence of perfect block-wise decompositions, there is a need to accommodate odd-sized blocks or partials. To increase the utility of rocWMMA to more applications, rocWMMA was extended to include support for partial tile sizes, allowing fragment dimensions (FragMNK) to differ from the minimum block-wise dimensions required for MMA (BlockMNK). rocWMMA now pads FragMNK dimensions to meet the minimal BlockMNK dimensions, ensuring compatibility with MMA hardware.
+
+.. code-block:: c++
+
+   // Fragment types, assuming ROCWMMA_MNK are minimum block sizes.
+   // These fragments will not use any padding.
+   using FragA = fragment<matrix_a, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, InputT, DataLayoutA>;
+   using FragB = fragment<matrix_b, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, InputT, DataLayoutB>;
+   using Accum = fragment<accumulator, ROCWMMA_M, ROCWMMA_N, ROCWMMA_K, AccumT>;
+
+   FragA fragA;
+   FragB fragB;
+   Accum accum;
+   fill_fragment(accum, 0);
+
+   load_matrix_sync(fragA, gAddrA, lda);
+   load_matrix_sync(fragB, gAddrB, ldb);
+   mma_sync(accum, fragA, fragB, accum);
+
+   store_matrix_sync(gResC, accum, ldc, layout_t::mem_row_major);
+
+   // Now also supported
+
+   // Fragment types, which are partial fragments.
+   // These fragments will use padding to minimum block sizes internally.
+   // Note: The dimensions (2, 3, 1) are smaller than BlockMNK, creating partial fragments
+   using FragA = fragment<matrix_a, 2, 3, 1, InputT, DataLayoutA>;
+   using FragB = fragment<matrix_b, 2, 3, 1, InputT, DataLayoutB>;
+   using Accum = fragment<accumulator, 2, 3, 1, AccumT>;
+
+   FragA fragA;
+   FragB fragB;
+   Accum accum;
+   fill_fragment(accum, 0);
+
+   load_matrix_sync(fragA, gAddrA, lda);
+   load_matrix_sync(fragB, gAddrB, ldb);
+   mma_sync(accum, fragA, fragB, accum);
+
+   store_matrix_sync(gResC, accum, ldc, layout_t::mem_row_major);
+
+
+In summary, partial tiles are padded to the minimum MMA block dimensions to accommodate a wider range of fragment sizes. However, this added flexibility comes at a cost: extra registers used for padding may increase kernel register pressure for small tiles and incur extra overhead for checking boundary conditions. Padded fragments are logically restricted to writing in FragMNK dimensions and zeroing boundary conditions.
+
+.. note::
+
+   Padded fragment internals always use padded sized resources instead of fragment sized resources.
+   However, fragment element-wise accesses, such as uniform FMA, should continue to use fragment.num_elements, assuming that any padded elements will be zero.
+
+   Example:
+
+   .. code-block:: c++
+
+      // Fused multiply-add still valid for partials as padded elements are 0
+      for(int i = 0; i < frag.num_elements; i++)
+      {
+         frag.x[i] = frag.x[i] * (alpha + 1);
+      }

--- a/docs/conceptual/migration-guide.rst
+++ b/docs/conceptual/migration-guide.rst
@@ -38,7 +38,7 @@ Previous releases began deprecating cooperative API functions such as those defi
                                              uint32_t                                                             ldm,
                                              uint32_t                                                             waveIndex);
 
-These functions previously required ``WaveCount`` as a template parameter and passed ``waveIndex`` as an argument to the API calls. This information was used to distribute data responsibilities across participating waves, aiming to balance and optimize data transactions within a thread block. Cooperation between wavefronts in a threadblock requires the use of a separate cooperative API, along with propagation of wave count and wave index values.
+These functions previously required ``WaveCount`` as a template parameter and passed ``waveIndex`` as an argument to the API calls. This information was used to distribute data responsibilities across participating waves, aiming to balance and optimize data transactions within a thread block. Cooperation between wavefronts in a thread block requires the use of a separate cooperative API, along with propagation of wave count and wave index values.
 
 Example:
 
@@ -47,7 +47,7 @@ Example:
    // Global read (macro tile)
    using GRBuffA = fragment<matrix_a, MACRO_TILE_X, ROCWMMA_N, ROCWMMA_K, InputT, DataLayoutA>;
 
-   // Local warp coordinate relative to current threadblock (wg).
+   // Local warp coordinate relative to current thread block (wg).
    constexpr auto warpDims        = make_coord2d(WARPS_X, WARPS_Y);
    auto           localWarpCoord  = make_coord2d(threadIdx.x / WARP_SIZE, threadIdx.y);
 
@@ -68,7 +68,7 @@ Example:
 
 Calculating the warp count and warp index requires extra boilerplate code. It is important to supply the same warp count and warp index values to matching pairs of load, store, and transform APIs. Providing mismatched values to APIs that depend on matching warp count and index poses a risk of incorrect behavior. Embedding the warp count and index into the fragment object helps mitigate the risk.
 
-As a result, fragments are augmented with an additional fragment scheduler template parameter. Fragment schedulers are classes that represent threadblock scheduling models. These models provide static values for both the wave count and wave order (wave index). Fragment schedulers are classified as either non-cooperative (the default, where waves act independently) or cooperative (where waves collaborate within a threadblock). Their names reflect their ordering scheme.
+As a result, fragments are augmented with an additional fragment scheduler template parameter. Fragment schedulers are classes that represent thread block scheduling models. These models provide static values for both the wave count and wave order (wave index). Fragment schedulers are classified as either non-cooperative (the default, where waves act independently) or cooperative (where waves collaborate within a thread block). Their names reflect their ordering scheme.
 
 Example:
 
@@ -81,7 +81,7 @@ Example:
       using default_schedule = IOScheduler::Default;
 
       //! @struct coop_row_major_2d
-      //! @brief  A cooperative scheduling strategy where each wave in the 2d threadblock
+      //! @brief  A cooperative scheduling strategy where each wave in the 2d thread block
       //! will contribute to the fragment operation in row_major grid order.
       //! All waves are scheduled in row_major order.
       //! E.g. (TBlockX, TBlockY) => 2x2 waves
@@ -100,7 +100,7 @@ Here is the simplified usage with new cooperative fragment changes:
 .. code-block:: c++
 
    // Global read (macro tile)
-   // Distribute segments of macro tile data between waves of the threadblock in
+   // Distribute segments of macro tile data between waves of the thread block in
    // row major order.
    using CoopScheduler = fragment_scheduler::coop_row_major_2d<TBLOCK_X, TBLOCK_Y>;
    using GRBuffA = fragment<matrix_a, MACRO_TILE_X, ROCWMMA_N, ROCWMMA_K, InputT, DataLayoutA, CoopScheduler>;

--- a/docs/conceptual/migration-guide.rst
+++ b/docs/conceptual/migration-guide.rst
@@ -167,7 +167,7 @@ In summary, partial tiles are padded to the minimum MMA block dimensions to acco
 .. note::
 
    Padded fragment internals always use padded-sized resources instead of fragment-sized resources.
-   However, fragment element-wise accesses, such as uniform FMA, should continue to use `fragment.num_elements`, assuming that any padded elements will be zero.
+   However, fragment element-wise accesses, such as uniform FMA, should continue to use ``fragment.num_elements``, assuming that any padded elements will be zero.
 
    Example:
 

--- a/docs/conceptual/migration-guide.rst
+++ b/docs/conceptual/migration-guide.rst
@@ -114,7 +114,7 @@ To summarize, the ``CoopScheduler`` template parameter allows you to express the
 
 .. note::
 
-   Cooperative fragment schedulers require template parameters for ``TBLOCK_X`` and ``TBLOCK_Y`` dimensions. This design enables various optimizations by allowing the schedulers to provide a static wave count at compile time. As a result rocWMMA no longer supports run-time wave count calculations in favor of better performance.
+   Cooperative fragment schedulers require template parameters for ``TBLOCK_X`` and ``TBLOCK_Y`` dimensions. This design enables various optimizations by allowing the schedulers to provide a static wave count at compile time. As a result, rocWMMA no longer supports run-time wave count calculations in favor of better performance.
 
 ------------------------
 Partial fragment support

--- a/docs/conceptual/migration-guide.rst
+++ b/docs/conceptual/migration-guide.rst
@@ -66,7 +66,7 @@ Example:
    load_matrix_coop_sync<warpCount>(grBuffA, gAddrA, lda, warpIndex);
    store_matrix_coop_sync<warpCount>(ldsAddr, applyDataLayout<DataLayoutLds, warpCount>(applyTranspose(grBuffA)), ldsld, warpIndex);
 
-Calculating the warp count and warp index requires extra boilerplate code. It is important to supply the same warp count and warp index values to matching pairs of load, store and transform APIs. Providing mismatched values to APIs that depend on matching warp count and index poses a risk of incorrect behavior. Embedding the warp count and index into the fragment object helps mitigate the risk.
+Calculating the warp count and warp index requires extra boilerplate code. It is important to supply the same warp count and warp index values to matching pairs of load, store, and transform APIs. Providing mismatched values to APIs that depend on matching warp count and index poses a risk of incorrect behavior. Embedding the warp count and index into the fragment object helps mitigate the risk.
 
 As a result, fragments are augmented with an additional fragment scheduler template parameter. Fragment schedulers are classes that represent threadblock scheduling models. These models provide static values for both the wave count and wave order (wave index). Fragment schedulers are classified as either non-cooperative (the default, where waves act independently) or cooperative (where waves collaborate within a threadblock). Their names reflect their ordering scheme.
 

--- a/docs/conceptual/programmers-guide.rst
+++ b/docs/conceptual/programmers-guide.rst
@@ -46,7 +46,7 @@ external kernel invokations are imposed by the API.
 
 The programming model that is the most useful with the rocWMMA API is wavefront-centric. In a more general
 sense, loading and storing data or mma calls are assumed to involve the entire wavefront (or, warp). In the collaborative API, we can assume that other wavefronts in the
-same threadblock may collaborate moving data from one location to another.
+same thread block may collaborate moving data from one location to another.
 
 The rocWMMA API can eliminate a very large amount of boiler-plate code as it provides tools to decompose matrix multiply-accumulate based problems into
 blocks, or fragments of data that may be efficiently processed by individual wavefronts. Wavefronts will abstract blocks of data into ``fragments``, which are designed to encapsulate meta-data properties about the blocks in different contexts, along with the data itself:
@@ -167,7 +167,7 @@ The ``library`` directory contains the following structure:
 
 The API currently has three API contexts:
 
-  - ``rocwmma.hpp``: The main API for rocWMMA, defining fragment data abstractions, wave-wise storing, loading, matrix multiply-accumulate (mma) and threadblock synchronization. This API's function signatures are portable from nvcuda::wmma.
+  - ``rocwmma.hpp``: The main API for rocWMMA, defining fragment data abstractions, wave-wise storing, loading, matrix multiply-accumulate (mma) and thread block synchronization. This API's function signatures are portable from nvcuda::wmma.
   - ``rocwmma_coop.hpp``: A complimentary API for rocWMMA, defining functionality that allows GPU wavefronts to collaborate in the loading / storing of fragment data. These are unique to rocWMMA.
   - ``rocwmma_transforms.hpp``: A complimentary API for rocWMMA, defining functionality to manipulate fragment data (e.g. transpose and data layout changes). These are unique to rocWMMA.
 
@@ -185,7 +185,7 @@ The API currently has three API contexts:
   - Vector packing and unpacking
   - Matrix multiply-accumulate
   - Cooperative loading and storing
-  - Threadblock synchronization and flow control
+  - Thread block synchronization and flow control
   - Utility code
   - Data layout transformation utilities
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,6 +24,7 @@ The rocWMMA public repository is located at `<https://github.com/ROCm/rocWMMA>`_
   .. grid-item-card:: Conceptual
 
     * :doc:`Programming guide <./conceptual/programmers-guide>`
+    * :doc:`Migration guide <./conceptual/migration-guide>`
 
   .. grid-item-card:: Examples
 

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -16,7 +16,6 @@ subtrees:
   entries:
   - file: conceptual/programmers-guide
     title: Programming guide
-  entries:
   - file: conceptual/migration-guide
     title: Migration guide
 

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -16,6 +16,9 @@ subtrees:
   entries:
   - file: conceptual/programmers-guide
     title: Programming guide
+  entries:
+  - file: conceptual/migration-guide
+    title: Migration guide
 
 - caption: Examples
   entries:


### PR DESCRIPTION
- Add a migration guide to the doc set
- Standardize the terminology by changing 'threadblock' to 'thread block' across topics 