### PR TITLE
Correct test predicates for BLK and VW cooperative kernels

### DIFF
--- a/library/include/rocwmma/rocwmma.hpp
+++ b/library/include/rocwmma/rocwmma.hpp
@@ -220,6 +220,17 @@ namespace rocwmma
             //! WaveCount sizing factor for cooperative fragments
             static constexpr uint32_t WaveCount = scheduler_traits<Scheduler>::WaveCount;
 
+            //! Assert the fragment occupies at least one packed register
+            static_assert(IOTraits::PackedVRegCount >= 1,
+                          "Fragments must occupy at least one packed register");
+
+            //! Assert the fragment is equally splittable among the wave count
+            static_assert(WaveCount >= 1, "WaveCount must be at least 1 for a valid fragment");
+            static_assert(IOTraits::PackedVRegCount >= WaveCount,
+                          "Packed register count must be equal to or greater than WaveCount");
+            static_assert(IOTraits::PackedVRegCount % WaveCount == 0,
+                          "Packed register count must be divisible by WaveCount");
+
         public:
             constexpr static uint32_t Size = IOTraits::UnpackedSize / WaveCount;
 
@@ -229,8 +240,6 @@ namespace rocwmma
             //! Packed data storage view
             using StorageT = VecT<PackedElementT, IOTraits::PackedSize / WaveCount>;
 
-            static_assert(IOTraits::PackedVRegCount >= 1,
-                          "Fragments must occupy at least one packed register");
             static_assert(IOTraits::UnpackedSize % IOTraits::PackedSize == 0,
                           "Unable to pack fragment elements");
         };

--- a/test/gemm/gemm_PGR1_LB2_MP0_MB_CP/device/kernel_predicates.hpp
+++ b/test/gemm/gemm_PGR1_LB2_MP0_MB_CP/device/kernel_predicates.hpp
@@ -80,9 +80,9 @@ namespace rocwmma
         static constexpr uint32_t CoopRegsA_blk = CoopElementsA_blk / WaveSize / MinElementsPerReg;
         static constexpr uint32_t CoopRegsB_blk = CoopElementsB_blk / WaveSize / MinElementsPerReg;
         static constexpr bool     CoopCheckA_blk
-            = (CoopRegsA_blk >= WavesX) && (CoopRegsA_blk % WavesX == 0u);
+            = (CoopRegsA_blk >= WavesY) && (CoopRegsA_blk % WavesY == 0u);
         static constexpr bool CoopCheckB_blk
-            = (CoopRegsB_blk >= WavesY) && (CoopRegsB_blk % WavesY == 0u);
+            = (CoopRegsB_blk >= WavesX) && (CoopRegsB_blk % WavesX == 0u);
         static constexpr bool CoopCheck_blk = CoopCheckA_blk && CoopCheckB_blk;
 
         // In wave-wise cooperation:
@@ -95,9 +95,9 @@ namespace rocwmma
         static constexpr uint32_t CoopRegsA_wv = CoopElementsA_wv / WaveSize / MinElementsPerReg;
         static constexpr uint32_t CoopRegsB_wv = CoopElementsB_wv / WaveSize / MinElementsPerReg;
         static constexpr bool     CoopCheckA_wv
-            = (CoopRegsA_wv >= WavesX) && (CoopRegsA_wv % WavesX == 0u);
+            = (CoopRegsA_wv >= WavesY) && (CoopRegsA_wv % WavesY == 0u);
         static constexpr bool CoopCheckB_wv
-            = (CoopRegsB_wv >= WavesY) && (CoopRegsB_wv % WavesY == 0u);
+            = (CoopRegsB_wv >= WavesX) && (CoopRegsB_wv % WavesX == 0u);
         static constexpr bool CoopCheck_wv = CoopCheckA_wv && CoopCheckB_wv;
 
         // In wg-wise cooperation:


### PR DESCRIPTION
- Previous calculations for waves in the same row / col were backwards.
- Add some better messaging in rocwmma fragment class to clarify the issue and catch it sooner.