### PR TITLE
[Docs] Fix various Doxygen related warning

### DIFF
--- a/docs/api-reference/api-reference-guide.rst
+++ b/docs/api-reference/api-reference-guide.rst
@@ -324,7 +324,7 @@ coop_col_slice_2d
 single
 ^^^^^^^^^
 
-.. doxygenstruct:: rocwmma::fragment_scheduler::single
+.. doxygenstruct:: rocwmma::fragment_scheduler::Single
 
 
 fragment
@@ -348,13 +348,13 @@ rocWMMA API functions
 
 .. doxygenfunction:: rocwmma::fill_fragment
 
-.. doxygenfunction:: rocwmma::load_matrix_sync(fragment<MatrixT, BlockM, BlockN, BlockK, DataT, DataLayoutT>& frag, const DataT* data, uint32_t ldm)
+.. doxygenfunction:: rocwmma::load_matrix_sync(FragT &frag, const DataT* data, uint32_t ldm)
 
-.. doxygenfunction:: rocwmma::load_matrix_sync(fragment<MatrixT, BlockM, BlockN, BlockK, DataT>& frag, const DataT* data, uint32_t ldm, layout_t layout)
+.. doxygenfunction:: rocwmma::load_matrix_sync(FragT &frag, const DataT* data, uint32_t ldm, layout_t layout)
 
-.. doxygenfunction:: rocwmma::store_matrix_sync(DataT* data, fragment<MatrixT, BlockM, BlockN, BlockK, DataT, DataLayoutT> const& frag, uint32_t ldm)
+.. doxygenfunction:: rocwmma::store_matrix_sync(DataT* data, FragT const& frag, uint32_t ldm)
 
-.. doxygenfunction:: rocwmma::store_matrix_sync(DataT* data, fragment<MatrixT, BlockM, BlockN, BlockK, DataT> const& frag, uint32_t ldm, layout_t layout)
+.. doxygenfunction:: rocwmma::store_matrix_sync(DataT* data, FragT const& frag, uint32_t ldm, layout_t layout)
 
 .. doxygenfunction:: rocwmma::mma_sync
 

--- a/docs/api-reference/api-reference-guide.rst
+++ b/docs/api-reference/api-reference-guide.rst
@@ -294,37 +294,37 @@ col_major
 default_schedule
 ^^^^^^^^^
 
-.. doxygenstruct:: rocwmma::fragment_scheduler::default_schedule
+.. doxygentypedef:: rocwmma::fragment_scheduler::default_schedule
 
 
 coop_row_major_2d
 ^^^^^^^^^
 
-.. doxygenstruct:: rocwmma::fragment_scheduler::coop_row_major_2d
+.. doxygentypedef:: rocwmma::fragment_scheduler::coop_row_major_2d
 
 
 coop_col_major_2d
 ^^^^^^^^^
 
-.. doxygenstruct:: rocwmma::fragment_scheduler::coop_col_major_2d
+.. doxygentypedef:: rocwmma::fragment_scheduler::coop_col_major_2d
 
 
 coop_row_slice_2d
 ^^^^^^^^^
 
-.. doxygenstruct:: rocwmma::fragment_scheduler::coop_row_slice_2d
+.. doxygentypedef:: rocwmma::fragment_scheduler::coop_row_slice_2d
 
 
 coop_col_slice_2d
 ^^^^^^^^^
 
-.. doxygenstruct:: rocwmma::fragment_scheduler::coop_col_slice_2d
+.. doxygentypedef:: rocwmma::fragment_scheduler::coop_col_slice_2d
 
 
 single
 ^^^^^^^^^
 
-.. doxygenstruct:: rocwmma::fragment_scheduler::Single
+.. doxygentypedef:: rocwmma::fragment_scheduler::single
 
 
 fragment

--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -2167,7 +2167,9 @@ PREDEFINED             = "__device__= " \
                          "ROCWMMA_DEVICE= " \
                          "__align__(n)= " \
                          "decltype(auto)= T" \
-                         "ROCWMMA_HOST_DEVICE= "
+                         "ROCWMMA_HOST_DEVICE= " \
+                         "ROCWMMA_DEVICE= " \
+                         "ROCWMMA_INLINE= " \
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/library/include/rocwmma/rocwmma.hpp
+++ b/library/include/rocwmma/rocwmma.hpp
@@ -112,11 +112,11 @@ namespace rocwmma
 
     namespace fragment_scheduler
     {
-        //! @struct default
+        //! @typedef default_schedule
         //! @brief The default fragment scheduler; each wave operates independently.
         using default_schedule = IOScheduler::Default;
 
-        //! @struct coop_row_major_2d
+        //! @typedef coop_row_major_2d
         //! @brief  A cooperative scheduling strategy where each wave in the 2d threadblock
         //! will contribute to the fragment operation in row_major grid order.
         //! All waves are scheduled in row_major order.
@@ -128,7 +128,7 @@ namespace rocwmma
         template <uint32_t TBlockX, uint32_t TBlockY>
         using coop_row_major_2d = IOScheduler::RowMajor2d<TBlockX, TBlockY>;
 
-        //! @struct coop_col_major_2d
+        //! @typedef coop_col_major_2d
         //! @brief  A cooperative scheduling strategy where each wave in the 2d threadblock
         //! will contribute to the fragment operation in col_major grid order.
         //! All waves are scheduled in row_major order.
@@ -140,7 +140,7 @@ namespace rocwmma
         template <uint32_t TBlockX, uint32_t TBlockY>
         using coop_col_major_2d = IOScheduler::ColMajor2d<TBlockX, TBlockY>;
 
-        //! @struct coop_row_slice_2d
+        //! @typedef coop_row_slice_2d
         //! @brief  A cooperative scheduling strategy where each row of waves
         //! in the 2d threadblock will contribute to the fragment operation.
         //! Waves are partitioned into rows. Only waves in the same row
@@ -153,7 +153,7 @@ namespace rocwmma
         template <uint32_t TBlockX, uint32_t TBlockY>
         using coop_row_slice_2d = IOScheduler::RowSlice2d<TBlockX, TBlockY>;
 
-        //! @struct coop_col_slice_2d
+        //! @typedef coop_col_slice_2d
         //! @brief  A cooperative scheduling strategy where each col of waves
         //! in the 2d threadblock will contribute to the fragment operation.
         //! Waves are partitioned into cols. Only waves in the same col
@@ -167,7 +167,7 @@ namespace rocwmma
         template <uint32_t TBlockX, uint32_t TBlockY>
         using coop_col_slice_2d = IOScheduler::ColSlice2d<TBlockX, TBlockY>;
 
-        //! @struct single
+        //! @typedef single
         //! @brief  A cooperative scheduling strategy where only one wave in
         //! the thread block will participate.
         //! @tparam TBlockX the size of the thread-block in the X dimension


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

Doxygen failed to extract content due to incorrect setting. Causing warning boxes on live documentation:

<img width="1239" height="1737" alt="image" src="https://github.com/user-attachments/assets/637fcdb3-3596-4697-bd1f-e71c29d503bf" />


## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

Issue 1: Incorrect type definition
`default_schedule`, `coop_row_major_2d`, `coop_col_major_2d`, `coop_row_slice_2d`, `coop_col_slice_2d` and `single` are define by `using` keyword, which is considered as a `typedef`. In the api-reference.rst, they are declared as struct which causes doxygen misinterpretation

Issue 2: Missing Predefined Macro in Doxyfile
`ROCWMMA_DEVICE` and `ROCWMMA_INLINE` exist in function signature but are not defined in Doxygile, causing error during parsing step.

Issue 3: Incorrect function signature
https://github.com/ROCm/rocWMMA/commit/0139d9d4232593cadc9d2b602d51aec882ff438b replaced `fragment<MatrixT, BlockM, BlockN, BlockK, DataT>` with `FragT` but didn't synchronize the signature definition in api-reference.rst.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
