### PR TITLE
Fix rocwmma-samples\tests are not installed due to missing packages on RHEL 10 by removing absolute path in rpath

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -40,7 +40,7 @@ function(add_rocwmma_sample TEST_TARGET TEST_SOURCE)
 
   list(APPEND TEST_SOURCE ${ARGN})
   add_executable(${TEST_TARGET} ${TEST_SOURCE})
-  target_link_libraries(${TEST_TARGET} OpenMP::OpenMP_CXX "-L${HIP_CLANG_ROOT}/lib" "-Wl,-rpath=${HIP_CLANG_ROOT}/lib")
+  target_link_libraries(${TEST_TARGET} OpenMP::OpenMP_CXX "-L${HIP_CLANG_ROOT}/lib" "-Wl,-rpath=$ORIGIN/../llvm/lib"  "-fno-rtlib-add-rpath")
   target_link_libraries(${TEST_TARGET} rocwmma hiprtc::hiprtc)
   target_include_directories(${TEST_TARGET} PRIVATE
                              ${CMAKE_CURRENT_SOURCE_DIR}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -88,7 +88,7 @@ function(add_rocwmma_test TEST_TARGET TEST_SOURCE)
   list(APPEND TEST_SOURCE ${ARGN})
   add_executable(${TEST_TARGET} ${TEST_SOURCE})
   target_link_libraries(${TEST_TARGET} rocwmma gtest)
-  target_link_libraries(${TEST_TARGET} OpenMP::OpenMP_CXX "-L${HIP_CLANG_ROOT}/lib" "-Wl,-rpath=${HIP_CLANG_ROOT}/lib")
+  target_link_libraries(${TEST_TARGET} OpenMP::OpenMP_CXX "-L${HIP_CLANG_ROOT}/lib" "-Wl,-rpath=$ORIGIN/../llvm/lib"  "-fno-rtlib-add-rpath")
   target_include_directories(${TEST_TARGET} PRIVATE
                              ${CMAKE_CURRENT_SOURCE_DIR}
                              ${ROCWMMA_TEST_INCLUDE_DIRS})


### PR DESCRIPTION
## Motivation

In OS RHEL 10, it refuse to package the rocwmma sample and tests binary files that have absolute rpath. 

## Technical Details

Set rpath to be relative path in CMakeLists.txt.

## Test Plan

Run cpack and install  rocwmma-samples\tests packages at different OS including RHEL 10. Run ctests and sample binary files under different OS including RHEL 10.

## Test Result

It can successfully install rocwmma-samples\tests under  RHEL 10 after the fixing.

