### PR TITLE
Add missing hipEventDestroy calls in tests to solve mem leak

### DIFF
--- a/test/common.hpp
+++ b/test/common.hpp
@@ -664,6 +664,8 @@ namespace rocwmma
         CHECK_HIP_ERROR(
             hipMemcpy(&maxRelativeError, d_relativeError, sizeof(double), hipMemcpyDeviceToHost));
 
+        CHECK_HIP_ERROR(hipEventDestroy(syncEvent));
+
         // Free allocated device memory
         CHECK_HIP_ERROR(hipFree(d_relativeError));
 
@@ -744,6 +746,8 @@ namespace rocwmma
 
         CHECK_HIP_ERROR(
             hipMemcpy(&maxRelativeError, d_relativeError, sizeof(double), hipMemcpyDeviceToHost));
+
+        CHECK_HIP_ERROR(hipEventDestroy(syncEvent));
 
         // Free allocated device memory
         CHECK_HIP_ERROR(hipFree(d_relativeError));


### PR DESCRIPTION
## Motivation

Valgrind memory check has reported leaks when run with rocWMMA, and these changes fix the leaks. All the found memory leaks were in test code only, so there are no impacts in the library or for anyone properly using the library APIs.

## Technical Details

The `compareEqualLaunchKernel`, used across all the tests, creates a sync event, but the event wasn't been destroyed after its usage. This PR adds the missing call to the destroy API.

## Test Plan

- A small subset of the tests selected across all the test files, previously reporting memory leaks, were re-executed with valgrind.

## Test Result

- No *definitely lost* and *indirect lost* blocks have been reported for the subset of tests executed with valgrind.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
