### PR TITLE
Fix bug in i8 gemm sample and remove compilation warning

### DIFF
--- a/samples/perf_i8gemm.cpp
+++ b/samples/perf_i8gemm.cpp
@@ -422,7 +422,7 @@ ROCWMMA_KERNEL void __launch_bounds__(256) gemm_rocwmma_d(uint32_t       m,
 
     // Initialize accumulation frags
     MmaFragAcc mmaFragAcc;
-    fill_fragment(mmaFragAcc, 0.0f);
+    fill_fragment(mmaFragAcc, 0);
 
     // Synchronize states
     synchronize_workgroup();

--- a/samples/simple_dlrm.cpp
+++ b/samples/simple_dlrm.cpp
@@ -113,7 +113,7 @@ __host__ void dlrmDotBwdCPU(float16_t* input,
         }
 
         // Remake tril
-        float16_t temp[m * m];
+        std::vector<float16_t> temp(m*m);
         uint32_t  tempIdx = t * trilSize + k;
         for(int i = 0; i < m; i++)
         {


### PR DESCRIPTION
## Motivation

1. Fix a small bug in perf_i8gemm.cpp that caused build error in http://math-ci.amd.com/job/main/job/precheckin/job/rocWMMA/job/develop/481/pipeline-overview/?selected-node=1069
2. Remove a compilation warning

## Technical Details

## Test Plan
run normal tests

## Test Result
all tests passed.

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
