### PR TITLE
Clean up build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,16 +143,6 @@ find_package( hip REQUIRED )
 find_package( hiprtc REQUIRED )
 find_package( OpenMP REQUIRED )
 
-## Check for ROCM-smi
-find_package(rocm_smi PATHS ${ROCM_PATH}/lib/cmake/rocm_smi)
-if (rocm_smi_FOUND)
-  message(STATUS "Found rocm_smi at ${ROCM_SMI_INCLUDE_DIR}")
-else()
-  set(ROCM_SMI_INCLUDE_DIR "${ROCM_PATH}/rocm_smi/include")
-  set(ROCM_SMI_LIB_DIR     "${ROCM_PATH}/rocm_smi/lib")
-  set(ROCM_SMI_LIBRARY   rocm_smi64)
-endif()
-
 add_library(rocwmma INTERFACE)
 target_link_libraries(rocwmma INTERFACE hip::device hip::host OpenMP::OpenMP_CXX ${ROCM_SMI_LIBRARY})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,18 @@ find_package( hip REQUIRED )
 find_package( hiprtc REQUIRED )
 find_package( OpenMP REQUIRED )
 
+if (ROCWMMA_BUILD_BENCHMARK_TESTS)
+    ## Check for ROCM-smi
+    find_package(rocm_smi PATHS ${ROCM_PATH}/lib/cmake/rocm_smi)
+    if (rocm_smi_FOUND)
+      message(STATUS "Found rocm_smi at ${ROCM_SMI_INCLUDE_DIR}")
+    else()
+      set(ROCM_SMI_INCLUDE_DIR "${ROCM_PATH}/rocm_smi/include")
+      set(ROCM_SMI_LIB_DIR     "${ROCM_PATH}/rocm_smi/lib")
+      set(ROCM_SMI_LIBRARY   rocm_smi64)
+    endif()
+endif()
+
 add_library(rocwmma INTERFACE)
 target_link_libraries(rocwmma INTERFACE hip::device hip::host OpenMP::OpenMP_CXX ${ROCM_SMI_LIBRARY})
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The test suite includes validation and benchmarking projects that focus on unit 
 rocWMMA currently supports the following AMD GPU architectures:
 
 * CDNA class GPU featuring matrix core support: gfx908, gfx90a, gfx942, gfx950 as 'gfx9'
-* RDNA class GPU featuring AI acceleration support: gfx1100, gfx1101, gfx1102 as 'gfx11'; gfx1200, gfx1201 as 'gfx12'
+* RDNA class GPU featuring AI acceleration support: gfx1100, gfx1101, gfx1102, gfx1151 as 'gfx11'; gfx1200, gfx1201 as 'gfx12'
 
 Dependencies:
 
@@ -30,11 +30,13 @@ Dependencies:
 * Minimum cmake version support is 3.14.
 * Minimum ROCm-cmake version support is 0.8.0.
 * Minimum rocBLAS version support is rocBLAS 4.0.0 for ROCm 6.0* (or ROCm packages rocblas and rocblas-dev).
-* Minimum HIP runtime version support is 4.3.0 (or ROCm package ROCm hip-runtime-amd).
+* Minimum ROCm SMI version support is 7.6.0** (or ROCm packages rocm-smi-lib and librocm-smi-dev).
+* Minimum HIP runtime version support is 4.3.0 (or ROCm package hip-runtime-amd).
 * Minimum LLVM OpenMP runtime dev package version support is 10.0 (available as ROCm package rocm-llvm-dev).
 
 ```note::
     * = if using rocBLAS for validation.
+    ** = if building benchmark tests (configuring with ROCWMMA_BUILD_BENCHMARK_TESTS=ON).
 
     It is best to use available ROCm packages from the same release where applicable.
 ```
@@ -47,8 +49,8 @@ For more detailed information, please refer to the [rocWMMA installation guide](
 
 |Option|Description|Default value|
 |---|---|---|
-|GPU_TARGETS|Build code for specific GPU target(s)|gfx908;gfx90a;gfx942;gfx950;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201|
-|AMDGPU_TARGETS|(Deprecated) Build code for specific GPU target(s)|gfx908;gfx90a;gfx942;gfx950;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201|
+|GPU_TARGETS|Build code for specific GPU target(s)|gfx908;gfx90a;gfx942;gfx950;gfx1100;gfx1101;gfx1102;gfx1151;gfx1200;gfx1201|
+|AMDGPU_TARGETS|(Deprecated) Build code for specific GPU target(s)|gfx908;gfx90a;gfx942;gfx950;gfx1100;gfx1101;gfx1102;gfx1151;gfx1200;gfx1201|
 |ROCWMMA_BUILD_TESTS|Build Tests|ON|
 |ROCWMMA_BUILD_SAMPLES|Build Samples|ON|
 |ROCWMMA_BUILD_DOCS|Build doxygen documentation from code|OFF|

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -40,7 +40,10 @@ function(add_rocwmma_sample TEST_TARGET TEST_SOURCE)
 
   list(APPEND TEST_SOURCE ${ARGN})
   add_executable(${TEST_TARGET} ${TEST_SOURCE})
-  target_link_libraries(${TEST_TARGET} OpenMP::OpenMP_CXX "-L${HIP_CLANG_ROOT}/lib" "-Wl,-rpath=$ORIGIN/../llvm/lib"  "-fno-rtlib-add-rpath")
+  target_link_libraries(${TEST_TARGET} OpenMP::OpenMP_CXX "-L${HIP_CLANG_ROOT}/lib")
+  if(UNIX)
+    target_link_libraries(${TEST_TARGET} "-Wl,-rpath=$ORIGIN/../llvm/lib"  "-fno-rtlib-add-rpath")
+  endif()
   target_link_libraries(${TEST_TARGET} rocwmma hiprtc::hiprtc)
   target_include_directories(${TEST_TARGET} PRIVATE
                              ${CMAKE_CURRENT_SOURCE_DIR}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -100,7 +100,10 @@ function(add_rocwmma_test TEST_TARGET TEST_SOURCE)
   list(APPEND TEST_SOURCE ${ARGN})
   add_executable(${TEST_TARGET} ${TEST_SOURCE})
   target_link_libraries(${TEST_TARGET} rocwmma gtest)
-  target_link_libraries(${TEST_TARGET} OpenMP::OpenMP_CXX "-L${HIP_CLANG_ROOT}/lib" "-Wl,-rpath=$ORIGIN/../llvm/lib"  "-fno-rtlib-add-rpath")
+  target_link_libraries(${TEST_TARGET} OpenMP::OpenMP_CXX "-L${HIP_CLANG_ROOT}/lib")
+  if(UNIX)
+    target_link_libraries(${TEST_TARGET} "-Wl,-rpath=$ORIGIN/../llvm/lib" "-fno-rtlib-add-rpath")
+  endif()
   target_include_directories(${TEST_TARGET} PRIVATE
                              ${CMAKE_CURRENT_SOURCE_DIR}
                              ${ROCWMMA_TEST_INCLUDE_DIRS})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,6 +31,18 @@ cmake_dependent_option( ROCWMMA_BUILD_BENCHMARK_TESTS "Build benchmarking tests"
 cmake_dependent_option( ROCWMMA_BUILD_EXTENDED_TESTS "Build extended test parameter coverage" OFF "ROCWMMA_BUILD_TESTS" OFF )
 cmake_dependent_option( ROCWMMA_USE_SYSTEM_GOOGLETEST "Use system Google Test library instead of downloading and building it" OFF "ROCWMMA_BUILD_TESTS" OFF )
 
+if (ROCWMMA_BUILD_BENCHMARK_TESTS)
+    ## Check for ROCM-smi
+    find_package(rocm_smi PATHS ${ROCM_PATH}/lib/cmake/rocm_smi)
+    if (rocm_smi_FOUND)
+      message(STATUS "Found rocm_smi at ${ROCM_SMI_INCLUDE_DIR}")
+    else()
+      set(ROCM_SMI_INCLUDE_DIR "${ROCM_PATH}/rocm_smi/include")
+      set(ROCM_SMI_LIB_DIR     "${ROCM_PATH}/rocm_smi/lib")
+      set(ROCM_SMI_LIBRARY   rocm_smi64)
+    endif()
+endif()
+
 add_compile_options(-mcmodel=large)
 if(ROCWMMA_CODE_COVERAGE)
     add_compile_options(-fprofile-instr-generate -fcoverage-mapping)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,18 +31,6 @@ cmake_dependent_option( ROCWMMA_BUILD_BENCHMARK_TESTS "Build benchmarking tests"
 cmake_dependent_option( ROCWMMA_BUILD_EXTENDED_TESTS "Build extended test parameter coverage" OFF "ROCWMMA_BUILD_TESTS" OFF )
 cmake_dependent_option( ROCWMMA_USE_SYSTEM_GOOGLETEST "Use system Google Test library instead of downloading and building it" OFF "ROCWMMA_BUILD_TESTS" OFF )
 
-if (ROCWMMA_BUILD_BENCHMARK_TESTS)
-    ## Check for ROCM-smi
-    find_package(rocm_smi PATHS ${ROCM_PATH}/lib/cmake/rocm_smi)
-    if (rocm_smi_FOUND)
-      message(STATUS "Found rocm_smi at ${ROCM_SMI_INCLUDE_DIR}")
-    else()
-      set(ROCM_SMI_INCLUDE_DIR "${ROCM_PATH}/rocm_smi/include")
-      set(ROCM_SMI_LIB_DIR     "${ROCM_PATH}/rocm_smi/lib")
-      set(ROCM_SMI_LIBRARY   rocm_smi64)
-    endif()
-endif()
-
 add_compile_options(-mcmodel=large)
 if(ROCWMMA_CODE_COVERAGE)
     add_compile_options(-fprofile-instr-generate -fcoverage-mapping)

--- a/test/dlrm/common.hpp
+++ b/test/dlrm/common.hpp
@@ -31,7 +31,6 @@
 #include <cstdlib>
 #include <fcntl.h>
 #include <fstream>
-#include <getopt.h>
 #include <iomanip>
 #include <iostream>
 #include <map>
@@ -42,7 +41,6 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <type_traits>
-#include <unistd.h>
 #include <vector>
 
 #include <hip/hip_fp16.h>

--- a/test/hip_device.hpp
+++ b/test/hip_device.hpp
@@ -29,7 +29,9 @@
 
 #include <hip/hip_runtime.h>
 #include <hip/hip_runtime_api.h>
+#if ROCWMMA_BENCHMARK_TESTS
 #include <rocm_smi/rocm_smi.h>
+#endif // ROCWMMA_BENCHMARK_TESTS
 #include <rocwmma/internal/constants.hpp>
 
 #include "performance.hpp"


### PR DESCRIPTION
## Motivation

`rocm_smi` is only required when building the benchmark tests; only include it when necessary.
Clean up unused headers.
Only add rpath link flags when appropriate.

## Technical Details

Conditionally include the `rocm_smi` header.

## Test Plan

Build with and without `-DROCWMMA_BENCHMARK_TESTS`.

## Test Result

Builds succeeded.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
