### PR TITLE
Ensure transform functions in samples are only available on the device

### DIFF
--- a/samples/perf_dgemm.cpp
+++ b/samples/perf_dgemm.cpp
@@ -258,12 +258,13 @@ using LWFragA = apply_data_layout_t<GRFragA, DataLayoutLds>;
 using LWFragB = apply_data_layout_t<apply_transpose_t<GRFragB>, DataLayoutLds>;
 
 // Transform helpers
-constexpr auto transformGRFragAToLWFragA
-    = [](GRFragA const& grFragA) { return apply_data_layout<DataLayoutLds>(grFragA); };
+ROCWMMA_DEVICE auto transformGRFragAToLWFragA(GRFragA const& grFragA) {
+    return apply_data_layout<DataLayoutLds>(grFragA);
+}
 
-constexpr auto transformGRFragBToLWFragB = [](GRFragB const& grFragB) {
+ROCWMMA_DEVICE auto transformGRFragBToLWFragB(GRFragB const& grFragB) {
     return apply_data_layout<DataLayoutLds>(apply_transpose(grFragB));
-};
+}
 
 // Local read (mfma frags)
 // - Must match Lds data layout.
@@ -272,12 +273,13 @@ using LRFragA = apply_data_layout_t<MmaFragA, DataLayoutLds>;
 using LRFragB = apply_data_layout_t<apply_transpose_t<MmaFragB>, DataLayoutLds>;
 
 // Transform helpers
-constexpr auto transformLRFragAToMmaFragA
-    = [](LRFragA const& lrFragA) { return apply_data_layout<DataLayoutA>(lrFragA); };
+ROCWMMA_DEVICE auto transformLRFragAToMmaFragA(LRFragA const& lrFragA) {
+    return apply_data_layout<DataLayoutA>(lrFragA);
+}
 
-constexpr auto transformLRFragBToMmaFragB = [](LRFragB const& lrFragB) {
+ROCWMMA_DEVICE auto transformLRFragBToMmaFragB(LRFragB const& lrFragB) {
     return apply_data_layout<DataLayoutB>(apply_transpose(lrFragB));
-};
+}
 
 ROCWMMA_KERNEL void __launch_bounds__(256) gemm_rocwmma_d(uint32_t       m,
                                                           uint32_t       n,

--- a/samples/perf_hgemm.cpp
+++ b/samples/perf_hgemm.cpp
@@ -307,12 +307,13 @@ using LWFragA = apply_data_layout_t<GRFragA, DataLayoutLds>;
 using LWFragB = apply_data_layout_t<apply_transpose_t<GRFragB>, DataLayoutLds>;
 
 // Transform helpers
-constexpr auto transformGRFragAToLWFragA
-    = [](GRFragA const& grFragA) { return apply_data_layout<DataLayoutLds>(grFragA); };
+ROCWMMA_DEVICE auto transformGRFragAToLWFragA(GRFragA const& grFragA) {
+    return apply_data_layout<DataLayoutLds>(grFragA);
+}
 
-constexpr auto transformGRFragBToLWFragB = [](GRFragB const& grFragB) {
+ROCWMMA_DEVICE auto transformGRFragBToLWFragB(GRFragB const& grFragB) {
     return apply_data_layout<DataLayoutLds>(apply_transpose(grFragB));
-};
+}
 
 // Local read (mfma frags)
 // - Must match Lds data layout.
@@ -321,12 +322,13 @@ using LRFragA = apply_data_layout_t<MmaFragA, DataLayoutLds>;
 using LRFragB = apply_data_layout_t<apply_transpose_t<MmaFragB>, DataLayoutLds>;
 
 // Transform helpers
-constexpr auto transformLRFragAToMmaFragA
-    = [](LRFragA const& lrFragA) { return apply_data_layout<DataLayoutA>(lrFragA); };
+ROCWMMA_DEVICE auto transformLRFragAToMmaFragA(LRFragA const& lrFragA) {
+    return apply_data_layout<DataLayoutA>(lrFragA);
+}
 
-constexpr auto transformLRFragBToMmaFragB = [](LRFragB const& lrFragB) {
+ROCWMMA_DEVICE auto transformLRFragBToMmaFragB(LRFragB const& lrFragB) {
     return apply_data_layout<DataLayoutB>(apply_transpose(lrFragB));
-};
+}
 
 ROCWMMA_KERNEL void __launch_bounds__(256) gemm_rocwmma_d(uint32_t       m,
                                                           uint32_t       n,

--- a/samples/perf_i8gemm.cpp
+++ b/samples/perf_i8gemm.cpp
@@ -307,12 +307,13 @@ using LWFragA = apply_data_layout_t<GRFragA, DataLayoutLds>;
 using LWFragB = apply_data_layout_t<apply_transpose_t<GRFragB>, DataLayoutLds>;
 
 // Transform helpers
-constexpr auto transformGRFragAToLWFragA
-    = [](GRFragA const& grFragA) { return apply_data_layout<DataLayoutLds>(grFragA); };
+ROCWMMA_DEVICE auto transformGRFragAToLWFragA(GRFragA const& grFragA) {
+    return apply_data_layout<DataLayoutLds>(grFragA);
+}
 
-constexpr auto transformGRFragBToLWFragB = [](GRFragB const& grFragB) {
+ROCWMMA_DEVICE auto transformGRFragBToLWFragB(GRFragB const& grFragB) {
     return apply_data_layout<DataLayoutLds>(apply_transpose(grFragB));
-};
+}
 
 // Local read (mfma frags)
 // - Must match Lds data layout.
@@ -321,12 +322,13 @@ using LRFragA = apply_data_layout_t<MmaFragA, DataLayoutLds>;
 using LRFragB = apply_data_layout_t<apply_transpose_t<MmaFragB>, DataLayoutLds>;
 
 // Transform helpers
-constexpr auto transformLRFragAToMmaFragA
-    = [](LRFragA const& lrFragA) { return apply_data_layout<DataLayoutA>(lrFragA); };
+ROCWMMA_DEVICE auto transformLRFragAToMmaFragA(LRFragA const& lrFragA) {
+    return apply_data_layout<DataLayoutA>(lrFragA);
+}
 
-constexpr auto transformLRFragBToMmaFragB = [](LRFragB const& lrFragB) {
+ROCWMMA_DEVICE auto transformLRFragBToMmaFragB(LRFragB const& lrFragB) {
     return apply_data_layout<DataLayoutB>(apply_transpose(lrFragB));
-};
+}
 
 ROCWMMA_KERNEL void __launch_bounds__(256) gemm_rocwmma_d(uint32_t       m,
                                                           uint32_t       n,

--- a/samples/perf_sgemm.cpp
+++ b/samples/perf_sgemm.cpp
@@ -258,12 +258,13 @@ using LWFragA = apply_data_layout_t<GRFragA, DataLayoutLds>;
 using LWFragB = apply_data_layout_t<apply_transpose_t<GRFragB>, DataLayoutLds>;
 
 // Transform helpers
-constexpr auto transformGRFragAToLWFragA
-    = [](GRFragA const& grFragA) { return apply_data_layout<DataLayoutLds>(grFragA); };
+ROCWMMA_DEVICE auto transformGRFragAToLWFragA(GRFragA const& grFragA) {
+    return apply_data_layout<DataLayoutLds>(grFragA);
+}
 
-constexpr auto transformGRFragBToLWFragB = [](GRFragB const& grFragB) {
+ROCWMMA_DEVICE auto transformGRFragBToLWFragB(GRFragB const& grFragB) {
     return apply_data_layout<DataLayoutLds>(apply_transpose(grFragB));
-};
+}
 
 // Local read (mfma frags)
 // - Must match Lds data layout.
@@ -272,12 +273,13 @@ using LRFragA = apply_data_layout_t<MmaFragA, DataLayoutLds>;
 using LRFragB = apply_data_layout_t<apply_transpose_t<MmaFragB>, DataLayoutLds>;
 
 // Transform helpers
-constexpr auto transformLRFragAToMmaFragA
-    = [](LRFragA const& lrFragA) { return apply_data_layout<DataLayoutA>(lrFragA); };
+ROCWMMA_DEVICE auto transformLRFragAToMmaFragA(LRFragA const& lrFragA) {
+    return apply_data_layout<DataLayoutA>(lrFragA);
+}
 
-constexpr auto transformLRFragBToMmaFragB = [](LRFragB const& lrFragB) {
+ROCWMMA_DEVICE auto transformLRFragBToMmaFragB(LRFragB const& lrFragB) {
     return apply_data_layout<DataLayoutB>(apply_transpose(lrFragB));
-};
+}
 
 ROCWMMA_KERNEL void __launch_bounds__(256) sgemm_rocwmma_d(uint32_t       m,
                                                            uint32_t       n,


### PR DESCRIPTION
## Motivation

Allowing these transform functions on the host can cause compile issues.  Ensure they are only available in the device compile.

## Technical Details

Add ROCWMMA_DEVICE scoping to ensure the transform functions cannot be accessed in host code.

## Test Plan

Built and ran the samples.

## Test Result

Samples ran as usual.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
