### PR TITLE
Remove unnecessary const keyword to avoid compiler warnings

### DIFF
--- a/library/include/rocwmma/internal/flow_control.hpp
+++ b/library/include/rocwmma/internal/flow_control.hpp
@@ -66,7 +66,7 @@ namespace rocwmma
         template <int32_t priority = 0>
         struct amdgcn_setprio
         {
-            enum : const int16_t
+            enum : int16_t
             {
                 priority16 = priority
             };
@@ -82,7 +82,7 @@ namespace rocwmma
         template <int32_t vmcnt, int32_t lgkmcnt>
         struct amdgcn_s_waitcnt
         {
-            enum : const int16_t
+            enum : int16_t
             {
                 vmcnt16   = (((0xF) & vmcnt) | (((0x30) & vmcnt) << 10)),
                 lgkmcnt16 = (((0xF) & lgkmcnt) << 8),


### PR DESCRIPTION
## Motivation

This unnecessary `const` raises a warning in new clang versions.  Remove it to clean up build output.

## Technical Details

n/a

## Test Plan

Ensure build works.

## Test Result

Build does work.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
